### PR TITLE
Enable fast scrolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release notes
 
+
+## 01/01/2025
+
+- Enabe fastscrolling in the menu, by holding up/down/left/right for 500 milliseconds, repeat delay is 40 milliseconds.
+- bld.sh mow uses the amount of cores available on the system to speed up the build process.
+- Temporary Rollback NesPad code for the WaveShare RP2040-PiZero only. Other configurations are not affected.
+- Update time functions to return milliseconds and use uint64_t to return microseconds.
+
 ## 22/12/2024
 
 - The menu now uses the entire screen resolution of 320x240 pixels. This makes a 40x30 char screen with 8x8 font possible instead of 32x29. This also fixes the menu not displaying correctly on Risc-v builds because of a not implemented assembly rendering routine in Risc-v.

--- a/FrensHelpers.cpp
+++ b/FrensHelpers.cpp
@@ -70,10 +70,16 @@ namespace Frens
         return (strcmp(string + pos, width) == 0);
     }
 
-    uint32_t time_us()
+    uint64_t time_us()
     {
         absolute_time_t t = get_absolute_time();
         return to_us_since_boot(t);
+    }
+
+    uint32_t time_ms()
+    {
+        absolute_time_t t = get_absolute_time();
+        return to_ms_since_boot(t);
     }
 
 #define INITIAL_CAPACITY 10

--- a/FrensHelpers.h
+++ b/FrensHelpers.h
@@ -57,7 +57,8 @@ namespace Frens
     void blinkLed(bool on);
     void resetWifi();
     void printbin16(int16_t v);
-    uint32_t time_us();
+    uint64_t time_us();
+    uint32_t time_ms();
    
 } // namespace Frens
 

--- a/bld.sh
+++ b/bld.sh
@@ -204,7 +204,7 @@ if [ -z "$TOOLCHAIN_PATH" ] ; then
 else
 	cmake -DCMAKE_BUILD_TYPE=$BUILD -DPICO_BOARD=$PICO_BOARD -DHW_CONFIG=$HWCONFIG -DPICO_PLATFORM=$PICO_PLATFORM -DPICO_TOOLCHAIN_PATH=$TOOLCHAIN_PATH ..
 fi
-make -j 4
+make -j "`nproc`"
 cd ..
 echo ""
 if [ -f build/${APP}.uf2 ] ; then

--- a/menu.cpp
+++ b/menu.cpp
@@ -129,7 +129,7 @@ void RomSelect_PadState(DWORD *pdwPad1, bool ignorepushed = false)
 #endif
     delta = currentTime - previousTime;
     previousTime = currentTime;
-    if ( v & UP || v & DOWN || v & LEFT || v & RIGHT ) {
+    if (v & (UP | DOWN | LEFT | RIGHT)) {
         longpressTreshold += delta;
     } else {
         longpressTreshold = 0;

--- a/menu.cpp
+++ b/menu.cpp
@@ -206,7 +206,7 @@ void RomSelect_PadState(DWORD *pdwPad1, bool ignorepushed = false)
     {
         if ( ! pushed) {
             if ( longpressTreshold > LONG_PRESS_TRESHOLD) {
-                longpressTreshold -= REPEAT_DELAY;
+                longpressTreshold = LONG_PRESS_TRESHOLD - REPEAT_DELAY;
             } 
         }
         *pdwPad1 = v;

--- a/nespad.cpp
+++ b/nespad.cpp
@@ -5,14 +5,24 @@
 
 static const uint16_t nespad_program_instructions[] = {
             //     .wrap_target
+#if HW_CONFIG != 4
     0xd020, //  0: irq    wait 0          side 1     
     0xfa01, //  1: set    pins, 1         side 1 [10]
     0xf027, //  2: set    x, 7            side 1     
     0xf000, //  3: set    pins, 0         side 1     
     0xf800, //  4: set    pins, 0         side 1 [8] 
     0x4201, //  5: in     pins, 1         side 0 [2] 
-    0x1044, //  6: jmp    x--, 4          side 1     
-            //     .wrap
+    0x1044, //  6: jmp    x--, 4          side 1             
+#else
+    0xc020, //  0: irq    wait 0          side 0
+    0xea01, //  1: set    pins, 1         side 0 [10]
+    0xe027, //  2: set    x, 7            side 0
+    0xe000, //  3: set    pins, 0         side 0
+    0x4401, //  4: in     pins, 1         side 0 [4]
+    0xf500, //  5: set    pins, 0         side 1 [5]
+    0x0044, //  6: jmp    x--, 4          side 0
+#endif
+   //     .wrap
 };
 
 static const struct pio_program nespad_program = {


### PR DESCRIPTION
- Enabe fastscrolling in the menu, by holding up/down/left/right for 500 milliseconds, repeat delay is 40 milliseconds.
- bld.sh mow uses the amount of cores available on the system to speed up the build process.
- Temporary Rollback NesPad code for the WaveShare RP2040-PiZero only. Other configurations are not affected.
- Update time functions to return milliseconds and use uint64_t to return microseconds.