### PR TITLE
Updated nespad to closer represent the actual NES scheme

### DIFF
--- a/nespad.cpp
+++ b/nespad.cpp
@@ -1,23 +1,24 @@
 #include "hardware/pio.h"
 
 #define nespad_wrap_target 0
-#define nespad_wrap 6
+#define nespad_wrap 7
 
 static const uint16_t nespad_program_instructions[] = {
             //     .wrap_target
     0xd020, //  0: irq    wait 0          side 1     
-    0xfa01, //  1: set    pins, 1         side 1 [10]
+    0xf101, //  1: set    pins, 1         side 1 [1] 
     0xf027, //  2: set    x, 7            side 1     
     0xf000, //  3: set    pins, 0         side 1     
-    0xf800, //  4: set    pins, 0         side 1 [8] 
-    0x4201, //  5: in     pins, 1         side 0 [2] 
-    0x1044, //  6: jmp    x--, 4          side 1     
+    0xf400, //  4: set    pins, 0         side 1 [4] 
+    0xe100, //  5: set    pins, 0         side 0 [1] 
+    0x5301, //  6: in     pins, 1         side 1 [3] 
+    0x1044, //  7: jmp    x--, 4          side 1     
             //     .wrap
 };
 
 static const struct pio_program nespad_program = {
     .instructions = nespad_program_instructions,
-    .length = 7,
+    .length = 8,
     .origin = -1,
 };
 

--- a/nespad.pio
+++ b/nespad.pio
@@ -10,12 +10,13 @@
 
 .wrap_target
   irq wait 0      side 1      ; Set IRQ and wait for CPU to clear it
-  set pins, 1     side 1 [10] ; Latch high, 12 uS total
+  set pins, 1     side 1 [1]  ; Latch high, 3 uS total
   set x, 7        side 1      ; Set bit counter
   set pins, 0     side 1      ; Latch low
 bitloop:
-  set pins, 0     side 1 [8] 
-  in pins, 1      side 0 [2]  ; Read bit on falling clock or latch, wait 3 uS
+  set pins, 0     side 1 [4] 
+  set pins, 0     side 0 [1]
+  in  pins, 1     side 1 [3]  ; Read bit after falling clock or latch, wait 2 uS
   jmp x-- bitloop side 1      ; Clock high, repeat for 8 bits
 ; Autopush will write byte to FIFO at this point
 .wrap


### PR DESCRIPTION
Reading input moved from falling edge to 1cycle after falling edge -> fixed incompatibility with 3rd party controllers

Latch - Clock Scheme of a PAL NES in Everdrive Menu
![image](https://github.com/user-attachments/assets/a978eb12-8920-423b-8390-84e9652cdf82)


Latch - Clock Scheme of Pico-infoNES in Menu
![image](https://github.com/user-attachments/assets/977b916a-98ba-4108-bff5-cc3c66498a94)

