### PR TITLE
Option to switch to DVI mode for DVI only displays

### DIFF
--- a/FrensHelpers.cpp
+++ b/FrensHelpers.cpp
@@ -1265,7 +1265,7 @@ namespace Frens
         // 空サンプル詰めとく
         dvi_->getAudioRingBuffer().advanceWritePointer(255);
 #else
-        hstx_init();
+        hstx_init(settings.flags.useExtAudio);
 #if 0
         // For now use an MCP4822 DAC for audio output
         // https://ww1.microchip.com/downloads/aemDocuments/documents/OTH/ProductDocuments/DataSheets/20002249B.pdf

--- a/FrensHelpers.cpp
+++ b/FrensHelpers.cpp
@@ -192,6 +192,7 @@ namespace Frens
         hstx_waitForVSync();
 #endif
     }
+#if 0
     /// @brief Poor way to pace frames to 60fps
     /// @param init
     void PaceFrames60fps(bool init)
@@ -221,7 +222,7 @@ namespace Frens
         next_frame_time = delayed_by_us(next_frame_time, 16666); // 1/60s = 16666us
 #endif
     }
-
+#endif
     //
     //
     // test if string ends with suffix

--- a/drivers/pico_hdmi/hstx.c
+++ b/drivers/pico_hdmi/hstx.c
@@ -152,11 +152,11 @@ void __not_in_flash_func(hstx_push_audio_sample)(const int left, const int right
     }
 }
 
-void hstx_init(void)
+void hstx_init(bool dviOnly)
 {
+    video_output_set_dvi_mode(dviOnly);
     hstx_di_queue_init();
-    video_output_set_vsync_callback(hstx_vsync_callbackfunc);
-    //video_output_set_dvi_mode(true);
+    video_output_set_vsync_callback(hstx_vsync_callbackfunc);   
     video_output_init(640, 480);
     pico_hdmi_set_audio_sample_rate(44100);
     video_output_set_scanline_callback(scanline_callbackfunc);

--- a/drivers/pico_hdmi/hstx.h
+++ b/drivers/pico_hdmi/hstx.h
@@ -20,7 +20,7 @@ void hstx_waitForVSync(void);
 uint8_t *hstx_getframebuffer(void);
 void hstx_setScanLines(int enable);
 uint16_t *hstx_getlineFromFramebuffer(int scanline);
-void hstx_init(void);
+void hstx_init(bool dviOnly);
 void video_output_core1_run(void);
 void hstx_push_audio_sample(const int left, const int right);
 #ifdef __cplusplus

--- a/menu.cpp
+++ b/menu.cpp
@@ -308,7 +308,7 @@ void RomSelect_PadState(DWORD *pdwPad1, bool ignorepushed = false)
            
             v = p1 =pushed = 0; // Clear all inputs to prevent accidental menu navigation after resetting to DVI mode           
             if (!settings.flags.useExtAudio) {
-                 printf("SELECT + A long press detected, defaulting to DVI\n");
+                 printf("SELECT + A detected, defaulting to DVI\n");
                 settings.flags.useExtAudio = 1; // Force DVI 
                 FrensSettings::savesettings();
                 exitMenu = true; // Signal to exit menu after saving settings

--- a/menu.cpp
+++ b/menu.cpp
@@ -89,7 +89,7 @@ static char buttonLabel1[2]; // e.g., "A", "B", "X", "O"
 static char buttonLabel2[2]; // e.g., "A", "B", "
 static char line[41];
 static char valueBuf[16]; // separate buffer for numeric values
-
+static bool exitMenu = false;
 static WORD *WorkLineRom = nullptr;
 
 #if PICO_RP2350
@@ -300,7 +300,24 @@ void RomSelect_PadState(DWORD *pdwPad1, bool ignorepushed = false)
         pushed = v;
     }
     // SELECT no longer changes colors directly; it opens the options menu in the main loop.
-
+    if ( p1 & SELECT )
+    {
+#if HSTX
+       //printf("SELECT pressed, opening options menu\n");
+       if (pushed & A){
+           
+            v = p1 =pushed = 0; // Clear all inputs to prevent accidental menu navigation after resetting to DVI mode           
+            if (!settings.flags.useExtAudio) {
+                 printf("SELECT + A long press detected, defaulting to DVI\n");
+                settings.flags.useExtAudio = 1; // Force DVI 
+                FrensSettings::savesettings();
+                exitMenu = true; // Signal to exit menu after saving settings
+            }
+        
+           
+       }
+#endif
+    }
     if (pushed || longpressTreshold > LONG_PRESS_TRESHOLD)
     {
         if (!pushed)
@@ -1685,7 +1702,7 @@ bool showSaveStateMenu(int (*savestatefunc)(const char *path), int (*loadstatefu
         bool autosaveEnabled = (Frens::fileExists(tmppath));
         printf("Auto save configured: %s\n", autosaveEnabled ? "Yes" : "No");
         int selected = 0;
-        bool exitMenu = false;
+        exitMenu = false;
         bool saved = false;
         DWORD pad = 0;
         int idleStart = -1;
@@ -2176,7 +2193,7 @@ int showSettingsMenu(bool calledFromGame)
     const int defaultRowScreen = cancelRowScreen + 1;
     const int helpRowScreen = defaultRowScreen + 2; // extra spacer before help line
     int selectedRowLocal = rowStartOptions;         // first selectable option row
-    bool exitMenu = false;
+    exitMenu = false;
     bool applySettings = false; // true when SAVE, false when CANCEL
     // lambda to redraw the entire menu
     auto redraw = [&]()

--- a/menu.cpp
+++ b/menu.cpp
@@ -2968,7 +2968,7 @@ void menu(const char *title, char *errorMessage, bool isFatal, bool showSplash, 
 #else
     hstx_setScanLines(false);
 #endif
-    abSwapped = 1; // Swap A and B buttons, so menu is consistent accrross different emilators
+    abSwapped = 1; // Swap A and B buttons, so menu is consistent across different emulators
    // Frens::PaceFrames60fps(true);
     Frens::waitForVSync();
     //

--- a/menu.cpp
+++ b/menu.cpp
@@ -72,7 +72,6 @@ const __UINT16_TYPE__ NesMenuPalette[64] = {
 
 int NesMenuPaletteItems = sizeof(NesMenuPalette) / sizeof(NesMenuPalette[0]);
 static char connectedGamePadName[sizeof(io::GamePadState::GamePadName)];
-static bool useFrameBuffer = false;
 #define SCREENBUFCELLS SCREEN_ROWS *SCREEN_COLS
 charCell *screenBuffer;
 
@@ -90,6 +89,7 @@ static char buttonLabel2[2]; // e.g., "A", "B", "
 static char line[41];
 static char valueBuf[16]; // separate buffer for numeric values
 static bool exitMenu = false;
+static bool settingsActive = false;
 static WORD *WorkLineRom = nullptr;
 
 #if PICO_RP2350
@@ -355,29 +355,15 @@ void RomSelect_DrawLine(int line, int selectedRow, int pixelsToSkip = 0)
         uint c = screenBuffer[charIndex].charvalue;
         if (row == selectedRow)
         {
-            if (useFrameBuffer)
-            {
-                fgcolor = screenBuffer[charIndex].bgcolor;
-                bgcolor = screenBuffer[charIndex].fgcolor;
-            }
-            else
-            {
-                fgcolor = NesMenuPalette[screenBuffer[charIndex].bgcolor];
-                bgcolor = NesMenuPalette[screenBuffer[charIndex].fgcolor];
-            }
+
+            fgcolor = settingsActive ? NesMenuPalette[CWHITE] : NesMenuPalette[settings.bgcolor];
+            bgcolor = settingsActive ? NesMenuPalette[CBLACK] : NesMenuPalette[settings.fgcolor];
         }
         else
         {
-            if (useFrameBuffer)
-            {
-                fgcolor = screenBuffer[charIndex].fgcolor;
-                bgcolor = screenBuffer[charIndex].bgcolor;
-            }
-            else
-            {
-                fgcolor = NesMenuPalette[screenBuffer[charIndex].fgcolor];
-                bgcolor = NesMenuPalette[screenBuffer[charIndex].bgcolor];
-            }
+
+            fgcolor = NesMenuPalette[screenBuffer[charIndex].fgcolor];
+            bgcolor = NesMenuPalette[screenBuffer[charIndex].bgcolor];
         }
 
         int rowInChar = line % FONT_CHAR_HEIGHT;
@@ -667,6 +653,24 @@ void ClearScreen(int color)
     }
 }
 
+inline void showhdmilabel()
+{
+    short fgcolor = settingsActive ? CBLACK : settings.fgcolor;
+    short bgcolor = settingsActive ? CWHITE : settings.bgcolor;
+#if HSTX
+    if (video_output_get_dvi_mode())
+    {
+        putText(SCREEN_COLS - 4, 0, "DVI", fgcolor, bgcolor);
+    }
+    else
+    {
+        putText(SCREEN_COLS - 5, 0, "HDMI", fgcolor, bgcolor);
+    }
+#else
+    putText(SCREEN_COLS - 5, 0, "HDMI", fgcolor, bgcolor);
+#endif
+}
+
 char *menutitle = nullptr;
 
 void displayRoms(Frens::RomLister &romlister, int startIndex)
@@ -679,6 +683,7 @@ void displayRoms(Frens::RomLister &romlister, int startIndex)
     snprintf(s, sizeof(s), "- %s -", menutitle);
     putText(SCREEN_COLS / 2 - strlen(s) / 2, 0, s, settings.fgcolor, settings.bgcolor);
     snprintf(buffer, sizeof(buffer), "%uMHZ", clock_get_hz(clk_sys) / 1000000);
+    showhdmilabel();
     putText(1, 0, buffer, settings.fgcolor, settings.bgcolor);
     strcpy(s, "Choose a rom to play:");
     putText(SCREEN_COLS / 2 - strlen(s) / 2, 1, s, settings.fgcolor, settings.bgcolor);
@@ -2078,7 +2083,7 @@ int showSettingsMenu(bool calledFromGame)
     int rval = 0;
     int margintop = 0;
     int marginbottom = 0;
-
+    settingsActive = true;
     // Allocate screen buffer if called from game
     if (calledFromGame)
     {
@@ -2202,7 +2207,7 @@ int showSettingsMenu(bool calledFromGame)
         ClearScreen(CWHITE); // Always white background
 
         int row = 0;
-
+        showhdmilabel();
         // Centered Title
         constexpr int titleLen = 13; // "-- Settings --"
         int titleCol = (SCREEN_COLS - titleLen) / 2;
@@ -2921,6 +2926,7 @@ int showSettingsMenu(bool calledFromGame)
 #if USE_I2S_AUDIO == PICO_AUDIO_I2S_DRIVER_TLV320
     wavplayer::reset(); // stop menu music
 #endif
+    settingsActive = false; 
     return rval;
 }
 void setclockInFlashAndReboot(uint32_t freq, vreg_voltage voltage)

--- a/menu.cpp
+++ b/menu.cpp
@@ -2067,7 +2067,8 @@ bool showSaveStateMenu(int (*savestatefunc)(const char *path), int (*loadstatefu
 #else
     hstx_setScanLines(settings.flags.scanlineOn);
 #endif
-    Frens::PaceFrames60fps(true);
+    //Frens::PaceFrames60fps(true);
+    Frens::waitForVSync();
     printf("Exiting save state menu.\n");
     Frens::f_free(screenBuffer);
     return saveStateLoadedOK;
@@ -2921,7 +2922,8 @@ int showSettingsMenu(bool calledFromGame)
         // Speaker can be muted/unmuted from settings menu
         EXT_AUDIO_MUTE_INTERNAL_SPEAKER(settings.flags.fruitJamEnableInternalSpeaker == 0);
         EXT_AUDIO_SETVOLUME(settings.fruitjamVolumeLevel);
-        Frens::PaceFrames60fps(true);
+        //Frens::PaceFrames60fps(true);
+         Frens::waitForVSync();
     }
 #if USE_I2S_AUDIO == PICO_AUDIO_I2S_DRIVER_TLV320
     wavplayer::reset(); // stop menu music
@@ -2967,7 +2969,8 @@ void menu(const char *title, char *errorMessage, bool isFatal, bool showSplash, 
     hstx_setScanLines(false);
 #endif
     abSwapped = 1; // Swap A and B buttons, so menu is consistent accrross different emilators
-    Frens::PaceFrames60fps(true);
+   // Frens::PaceFrames60fps(true);
+    Frens::waitForVSync();
     //
     menutitle = (char *)title;
     int totalFrames = -1;
@@ -3533,5 +3536,6 @@ void menu(const char *title, char *errorMessage, bool isFatal, bool showSplash, 
         // Never return
     }
     Frens::restoreScanlines();
-    Frens::PaceFrames60fps(true); // reset frame pacing
+    //Frens::PaceFrames60fps(true); // reset frame pacing
+    Frens::waitForVSync();
 }

--- a/settings.cpp
+++ b/settings.cpp
@@ -142,6 +142,11 @@ namespace FrensSettings
             printf("Error opening %s: %d\n", getSettingsFileName(), fr);
         }
         printsettings();
+#if HSTX
+        printf("Setting HDMI DVI mode to %d\n", settings.flags.useExtAudio);
+        video_output_set_dvi_mode(settings.flags.useExtAudio);
+        printf("done\n");
+#endif
     }
 
     void loadsettings()

--- a/settings.cpp
+++ b/settings.cpp
@@ -99,7 +99,7 @@ namespace FrensSettings
         settings.horzontalScrollIndex = 0;
         settings.fgcolor = DEFAULT_FGCOLOR;
         settings.bgcolor = DEFAULT_BGCOLOR;
-        settings.flags.useExtAudio = (HW_CONFIG == 13); // external audio switches to DVI mode, default on Murmulator M2.
+        settings.flags.useExtAudio = (HW_CONFIG == 13); // when 1: enable DVI mode (disables HDMI audio/data islands, assumes external audio hardware); default on Murmulator M2 (HW_CONFIG == 13).
         settings.flags.enableVUMeter = ENABLE_VU_METER ? 1 : 0; // default to ENABLE_VU_METER
         settings.flags.borderMode = THEMEDBORDER;
         settings.flags.dmgLCDPalette = 0; // default DMG LCD Palette, DMG Green

--- a/settings.cpp
+++ b/settings.cpp
@@ -99,7 +99,7 @@ namespace FrensSettings
         settings.horzontalScrollIndex = 0;
         settings.fgcolor = DEFAULT_FGCOLOR;
         settings.bgcolor = DEFAULT_BGCOLOR;
-        settings.flags.useExtAudio = 0; // default to use DVIAudio
+        settings.flags.useExtAudio = (HW_CONFIG == 13); // external audio switches to DVI mode, default on Murmulator M2.
         settings.flags.enableVUMeter = ENABLE_VU_METER ? 1 : 0; // default to ENABLE_VU_METER
         settings.flags.borderMode = THEMEDBORDER;
         settings.flags.dmgLCDPalette = 0; // default DMG LCD Palette, DMG Green

--- a/settings.h
+++ b/settings.h
@@ -6,7 +6,7 @@
 
 
 extern struct settings settings;
-#define SETTINGS_VERSION 104
+#define SETTINGS_VERSION 105
 
 struct settings
 {

--- a/settings.h
+++ b/settings.h
@@ -6,7 +6,7 @@
 
 
 extern struct settings settings;
-#define SETTINGS_VERSION 105
+#define SETTINGS_VERSION 107
 
 struct settings
 {


### PR DESCRIPTION
This pull request introduces several enhancements and refactors to the menu system and video output initialization, focusing on improving HDMI/DVI mode handling, menu visual feedback, and frame pacing. The most significant changes are grouped below:

### HDMI/DVI Mode Handling

* Changed `hstx_init` to accept a `dviOnly` parameter, allowing explicit control of DVI mode at initialization, and updated all relevant function signatures and calls (`hstx.c`, `hstx.h`, `FrensHelpers.cpp`). [[1]](diffhunk://#diff-d241c2856e91356fd96a3df1ad47e0ec41b6eae3d9c1beb76e7f1d99802c4e52L155-L159) [[2]](diffhunk://#diff-a070c381149ef588201f3d06d8b6b93c2cd5fb8227dd315a14e657905ca4313cL23-R23) [[3]](diffhunk://#diff-47e62d520f7eae50d3519dbc612bbebcb49fef07fc4079a79b177921ac064db8L1268-R1269)
* Updated settings logic to default `useExtAudio` to DVI mode for specific hardware (`HW_CONFIG == 13`), and ensured HDMI/DVI mode is set according to settings after loading (`settings.cpp`). [[1]](diffhunk://#diff-014d386d7f6ac8bbe4a0dc992031ea561c9e8929605a90078bdc2c3407e9017fL102-R102) [[2]](diffhunk://#diff-014d386d7f6ac8bbe4a0dc992031ea561c9e8929605a90078bdc2c3407e9017fR145-R149)
* Added menu logic to allow users to switch to DVI mode via a SELECT+A, with settings persistence and menu exit (`menu.cpp`).

### Menu Visual Feedback

* Introduced `showhdmilabel` function to display "HDMI" or "DVI" in the menu header based on the current mode, and integrated it into main menu and settings menu rendering (`menu.cpp`). [[1]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79R656-R673) [[2]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79R686) [[3]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L2188-R2211)
* Added `settingsActive` flag to visually differentiate menu selections when settings are active, affecting menu color rendering (`menu.cpp`). [[1]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L92-R92) [[2]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L341-L364) [[3]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L2064-R2087) [[4]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L2902-R2931)

### Frame Pacing Refactor

* Replaced calls to `PaceFrames60fps` with `waitForVSync` for improved frame pacing and synchronization in menu and settings transitions (`menu.cpp`). [[1]](diffhunk://#diff-47e62d520f7eae50d3519dbc612bbebcb49fef07fc4079a79b177921ac064db8R195) [[2]](diffhunk://#diff-47e62d520f7eae50d3519dbc612bbebcb49fef07fc4079a79b177921ac064db8L224-R225) [[3]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L2048-R2071) [[4]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L2947-R2973) [[5]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L3513-R3540) [[6]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L2902-R2931)

### Settings and State Management

* Unified `exitMenu` and `settingsActive` flags across menu and settings state management for consistent behavior and easier maintenance (`menu.cpp`). [[1]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L92-R92) [[2]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L1688-R1710) [[3]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L2179-R2202)

### Miscellaneous

* Updated `SETTINGS_VERSION` to 107. This will reset settings to default.

