### PR TITLE
Changes for upcoming retroJam update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,54 @@
 # Release notes
 
+## 25/4/2025
+
+- **New `pico_hdmi` HSTX driver** by [@fliperama86](https://github.com/fliperama86/pico_hdmi) replaces the in-tree HSTX driver used previously.
+  - Several RP2350 board configurations switched from the PicoDVI driver to HSTX: HW_CONFIG 2 (Breadboard / PCB Pico/Pico 2) and HW_CONFIG 5 (Adafruit Metro RP2350). Adafruit Fruit Jam and Murmulator M2 also use the new driver.
+  - `pico_hdmi` is embedded as a Git submodule; include path fixed in `CMakeLists.txt`.
+  - `HSTX` definition now guarded by `PICO_RP2350` to keep RP2040 builds clean.
+
+- **HDMI audio over HSTX**.
+  - HSTX output now embeds audio in the HDMI stream (previously HSTX was video-only on this codebase).
+  - Pre-encoded silence packets are emitted when no game audio is playing, keeping the audio clock alive.
+  - Sample-rate setup moved into `hstx.c`; `hstx_init()` gained a `dviOnly` parameter so the same driver can be configured for full HDMI or DVI-only signaling.
+  - WAV player audio path refactored to handle both DVI (no embedded audio) and HSTX (embedded audio) configurations.
+  - `di_ring_buffer` offloaded to PSRAM where available to free SRAM.
+
+- **DVI / HDMI display-mode setting** added to the settings menu (`SETTINGS_VERSION` bumped to 107).
+  - On boards that support both, users can pick full HDMI (with embedded audio) or DVI-only (video only). Some monitors prefer the DVI signaling.
+  - `SELECT + A` shortcut switches to DVI-only at runtime for quick troubleshooting.
+  - New `ENABLEDVI` build flag (in `FrensHelpers.h` / `BoardConfigs.cmake`) controls whether the toggle is exposed per hardware configuration.
+  - Display-mode initialisation fixed when external audio is enabled at boot.
+
+- **HSTX picture-loss watchdog** (`video_output.c`).
+  - Two cooperating watchdogs detect a wedged DMA chain: a stuck-frame check (no new frame for ~500 ms) and an over-rate check (>75 fps measured in a 1 Hz sliding window — observed ~158 Hz drift in DVI mode).
+  - Recovery calls `hstx_resync()` to rebuild the DMA chain in place — no reboot needed.
+  - A soft HSTX CSR-toggle recovery was tested and removed; only a full resync reliably clears the wedge.
+  - Manual resync is also triggered when the settings menu is opened.
+  - Extensive diagnostics available behind `HSTX_DEBUG`: frame/IRQ rates, `clk_sys`/`clk_hstx` values, HSTX CSR, ping/pong DMA control words, PLL state, and frequency-counter readings.
+  - DMA resync now correctly clears and restores the channel enable bits during abort.
+
+- **Frame pacing / VSync rework**.
+  - New `hstx_paceFrame()` implements slack-aware frame pacing for steady 60 fps output.
+  - `hstx_waitForVSync()` switched from polling to a frame-counter–driven wait.
+  - Menu code refactored to use VSync-based pacing for smoother scrolling; pacing state is reset on menu exit so the emulator returns to normal timing.
+
+- **Headphone jack detection** (Adafruit Fruit Jam):
+  - New `Frens::pollHeadPhoneJack()` returns a connection-status enum.
+  - Polling is gated by `EXT_AUDIO_IS_ENABLED` so it only runs on boards that actually have a jack.
+  - Removed the Fruit Jam internal-speaker mute setting and the Button 1 mute shortcut — superseded by automatic detection.
+
+- **Settings / in-game menu additions**:
+  - **Reset game** option in the settings menu, restarts the running game without a reboot.
+  - **BOOTSEL mode** option in the settings menu, for flashing firmware without unplugging the device.
+  - HDMI/DVI label rendering logic refactored to reflect the active display mode.
+
+- **Other**:
+  - Directory and file sorting in the menu switched from `std::sort` to `std::stable_sort` for predictable ordering of equal keys.
+  - UART output enabled in `BoardConfigs.cmake` for the RP2040/RP2350-Zero PCB builds.
+  - Added a clarifying comment for `FLASHPARAM_MAX_FREQ_KHZ` referencing the conditions under which higher flash frequencies can produce screen artifacts.
+  - Fixed a typo in the Adafruit Metro RP2350 board configuration.
+
 ## 16/10/2025
 
 - Added support for [Retro-Bit Genesis/Megadrive 8 button Arcade Pad with USB](https://www.retro-bit.com/controllers/genesis/#usb).

--- a/FrensHelpers.cpp
+++ b/FrensHelpers.cpp
@@ -1736,12 +1736,14 @@ namespace Frens
 
     void pollHeadPhoneJack()
     {
+#if EXT_AUDIO_IS_ENABLED
         auto hpToggle = EXT_AUDIO_POLL_HEADPHONE();
         if (hpToggle != HP_TOGGLE_NONE)
         {
             extSpeakerEnabled = (hpToggle == HP_TOGGLE_CONNECT) ? true : false;
             // printf("Headphone toggle detected. Headphones %s\n", extSpeakerEnabled ? "unplugged, using speakers" : "plugged in, using headphones");
         }
+#endif
     }
 
     bool isHeadPhoneJackConnected()

--- a/FrensHelpers.cpp
+++ b/FrensHelpers.cpp
@@ -208,6 +208,8 @@ namespace Frens
             }
         }
 #else
+        hstx_paceFrame(init);
+#if 0
         static absolute_time_t next_frame_time = {0};
         if (init)
         {
@@ -221,6 +223,8 @@ namespace Frens
         // Pace to 60fps
         sleep_until(next_frame_time);
         next_frame_time = delayed_by_us(next_frame_time, 16666); // 1/60s = 16666us
+
+#endif
 #endif
     }
 #endif

--- a/FrensHelpers.cpp
+++ b/FrensHelpers.cpp
@@ -208,14 +208,14 @@ namespace Frens
             }
         }
 #else
-        static int resync_count = 0;
+        //static int resync_count = 0;
         hstx_paceFrame(init);
-        int current_resync_count = get_video_output_resync_count();
-        if (current_resync_count != resync_count)
-        {
-            printf("Video output resync count: %d\n", current_resync_count);
-            resync_count = current_resync_count;
-        }
+        // int current_resync_count = get_video_output_resync_count();
+        // if (current_resync_count != resync_count)
+        // {
+        //     printf("Video output resync count: %d\n", current_resync_count);
+        //     resync_count = current_resync_count;
+        // }
 #if 0
         static absolute_time_t next_frame_time = {0};
         if (init)

--- a/FrensHelpers.cpp
+++ b/FrensHelpers.cpp
@@ -208,7 +208,14 @@ namespace Frens
             }
         }
 #else
+        static int resync_count = 0;
         hstx_paceFrame(init);
+        int current_resync_count = get_video_output_resync_count();
+        if (current_resync_count != resync_count)
+        {
+            printf("Video output resync count: %d\n", current_resync_count);
+            resync_count = current_resync_count;
+        }
 #if 0
         static absolute_time_t next_frame_time = {0};
         if (init)

--- a/FrensHelpers.cpp
+++ b/FrensHelpers.cpp
@@ -58,6 +58,7 @@ namespace Frens
     static bool fatfsUsesPioSpi = false;
     static DWORD totalSpace = 0;
     static DWORD freeSpace = 0;
+    static bool extSpeakerEnabled = false;
 #if !HSTX && FRAMEBUFFERISPOSSIBLE
     // uint8_t *framebuffer1; // [320 * 240];
     // uint8_t *framebuffer2; // [320 * 240];
@@ -1733,6 +1734,20 @@ namespace Frens
         return (f_stat(filepath, &fno) == FR_OK);
     }
 
+    void pollHeadPhoneJack()
+    {
+        auto hpToggle = EXT_AUDIO_POLL_HEADPHONE();
+        if (hpToggle != HP_TOGGLE_NONE)
+        {
+            extSpeakerEnabled = (hpToggle == HP_TOGGLE_CONNECT) ? true : false;
+            // printf("Headphone toggle detected. Headphones %s\n", extSpeakerEnabled ? "unplugged, using speakers" : "plugged in, using headphones");
+        }
+    }
+
+    bool isHeadPhoneJackConnected()
+    {
+        return extSpeakerEnabled;
+    }
 }
 // C-compatible wrappers
 extern "C"

--- a/FrensHelpers.h
+++ b/FrensHelpers.h
@@ -152,6 +152,9 @@ namespace Frens
     uint32_t getCrcOfLoadedRom();
     bool fileExists(const char *filename);
     float read_onboard_temperature(const char unit);
+
+     void pollHeadPhoneJack();
+     bool isHeadPhoneJackConnected();
    
 } // namespace Frens
 

--- a/FrensHelpers.h
+++ b/FrensHelpers.h
@@ -69,6 +69,9 @@ enum class ScreenMode
 #define RETROJAM 0
 #endif
 
+#ifndef ENABLEDVI
+#define ENABLEDVI 0 
+#endif
 extern uintptr_t ROM_FILE_ADDR ; //0x10090000
 extern int maxRomSize;
 extern char ErrorMessage[];

--- a/RomLister.cpp
+++ b/RomLister.cpp
@@ -185,13 +185,13 @@ namespace Frens
 		// Sort: directories first (case-insensitive), then files (case-insensitive)
 		if (numberOfEntries > 1)
 		{
-			std::sort(entries, entries + numberOfEntries, [](const RomEntry &a, const RomEntry &b) {
-				if (a.IsDirectory != b.IsDirectory)
-				{
-					return a.IsDirectory && !b.IsDirectory; // directories come before files
-				}
-				return strcasecmp(a.Path, b.Path) < 0; // case-insensitive alphabetical
-			});
+			   std::stable_sort(entries, entries + numberOfEntries, [](const RomEntry &a, const RomEntry &b) {
+				   if (a.IsDirectory != b.IsDirectory)
+				   {
+					   return a.IsDirectory && !b.IsDirectory; // directories come before files
+				   }
+				   return strcasecmp(a.Path, b.Path) < 0; // case-insensitive alphabetical
+			   });
 		}
 		printf("Sort done (std::sort)\n");
 	}

--- a/drivers/pico_audio_i2s/audio_i2s.c
+++ b/drivers/pico_audio_i2s/audio_i2s.c
@@ -260,7 +260,7 @@ static void hp_int1_callback(uint gpio, uint32_t events)
 /// and the non-sticky flag register (Page 0 / Reg 0x2E) D4 to determine
 /// whether a headset is currently inserted.
 /// Also reads the headset type from Page 0 / Reg 0x43 D6-D5.
-static void tlv320_handle_headphone_event()
+static enum headphone_toggle_t tlv320_handle_headphone_event()
 {
 	setPage(0);
 	// Read sticky flags to acknowledge/clear the interrupt
@@ -279,13 +279,14 @@ static void tlv320_handle_headphone_event()
 
 	if (hp_inserted)
 	{
-		speakerMute();
+		speakerMute();		
 	}
 	else
 	{
 		speakerUnmute();
 	}
 	speakerIsMuted = hp_inserted;
+	return hp_inserted ? HP_TOGGLE_CONNECT : HP_TOGGLE_DISCONNECT;
 }
 
 // Set up the IRQ handler to mute/unmute the speaker
@@ -670,13 +671,16 @@ static void tlv320_init()
 /// Call this periodically from the main loop to process headphone
 /// insertion/removal events detected via DAC INT1.
 /// When no INT1 interrupt is pending, this function returns immediately.
-void audio_i2s_poll_headphone_status()
+enum headphone_toggle_t audio_i2s_poll_headphone_status()
 {
 	if (_driver == PICO_AUDIO_I2S_DRIVER_TLV320 && hp_irq_pending)
 	{
 		hp_irq_pending = false;
-		tlv320_handle_headphone_event();
+		return tlv320_handle_headphone_event();
+	} else {
+		return HP_TOGGLE_NONE;
 	}
+	
 }
 
 /**

--- a/drivers/pico_audio_i2s/audio_i2s.h
+++ b/drivers/pico_audio_i2s/audio_i2s.h
@@ -75,17 +75,24 @@ typedef struct {
     PIO pio;     // PIO instance (e.g., pio0 or pio1)
     int dma_chan; // DMA channel for audio transfer
 } audio_i2s_hw_t;
-
+enum headphone_toggle_t {
+    HP_TOGGLE_NONE = 0,
+    HP_TOGGLE_CONNECT = 1,
+    HP_TOGGLE_DISCONNECT = 2
+};
 audio_i2s_hw_t *audio_i2s_setup(int driver, int freqHZ, int dmachan);
 void audio_i2s_update_pio_frequency(uint32_t sample_freq);
 void audio_i2s_out_32(uint32_t sample32);
 void audio_i2s_enqueue_sample(uint32_t sample32);
-void audio_i2s_poll_headphone_status();
+enum headphone_toggle_t audio_i2s_poll_headphone_status();
 int audio_i2s_get_freebuffer_size();
 void audio_i2s_disable() ;
 bool audio_i2s_dacError();
 void audio_i2s_muteInternalSpeaker(bool mute);
 void audio_i2s_setVolume(int8_t level);
+
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/drivers/pico_hdmi/backup/CMakeLists.txt
+++ b/drivers/pico_hdmi/backup/CMakeLists.txt
@@ -1,0 +1,22 @@
+
+  if (NOT TARGET pico_hdmi)
+    add_library(pico_hdmi INTERFACE)
+    if (PICO_RP2350)
+        target_sources(pico_hdmi INTERFACE
+                    ${CMAKE_CURRENT_LIST_DIR}/video_output.c
+                    ${CMAKE_CURRENT_LIST_DIR}/hstx_packet.c
+                    ${CMAKE_CURRENT_LIST_DIR}/hstx_data_island_queue.c
+                    ${CMAKE_CURRENT_LIST_DIR}/hstx.c
+            )
+        target_include_directories(pico_hdmi INTERFACE
+                    ${CMAKE_CURRENT_LIST_DIR}
+            )
+        target_link_libraries(pico_hdmi INTERFACE pico_stdlib hardware_spi hardware_i2c hardware_pwm hardware_adc hardware_pio hardware_dma)
+    else()
+          target_include_directories(pico_hdmi INTERFACE
+                    ${CMAKE_CURRENT_LIST_DIR}
+            )
+       target_compile_definitions(pico_hdmi INTERFACE PICO_HDMI_DUMMY=1 PICO_HDMI_DISABLED=1)
+        # If you add stub headers later, expose them here:
+    endif()
+endif()

--- a/drivers/pico_hdmi/backup/hstx.c
+++ b/drivers/pico_hdmi/backup/hstx.c
@@ -1,0 +1,191 @@
+#if PICO_RP2350
+#include "hstx.h"
+#include "pico/multicore.h" 
+#include "stdio.h"
+// Custom changes
+volatile bool HSTX_vblank = false;
+static uint8_t FRAMEBUFFER[(MODE_H_ACTIVE_PIXELS / 2) * (MODE_V_ACTIVE_LINES / 2) * 2];
+// uint16_t ALIGNED HDMIlines[2][MODE_H_ACTIVE_PIXELS] = {0};
+static uint8_t *WriteBuf = FRAMEBUFFER;
+static uint8_t *DisplayBuf = FRAMEBUFFER;
+static uint8_t *LayerBuf = FRAMEBUFFER;
+static uint16_t *tilefcols;
+static uint16_t *tilebcols;
+static volatile int enableScanLines = 0; // Enable scanlines
+static volatile int scanlineMode = 0;
+#define HRes (MODE_H_ACTIVE_PIXELS / 2) // 320
+#define VRes (MODE_V_ACTIVE_LINES / 2)  // 240
+void hstx_waitForVSync(void)
+{
+    // Wait until the frame counter advances, indicating a new vsync edge.
+    // video_frame_count is incremented exactly once per frame in the DMA ISR
+    // on core1 (video_output.c), so this guarantees one-frame synchronization
+    // without the race conditions of a bool flag approach.
+    uint32_t current = video_frame_count;
+    while (video_frame_count == current)
+    {
+        tight_loop_contents();
+    }
+}
+
+void hstx_paceFrame(bool init)
+{
+    // Slack-aware 60fps pacing. Waits for the next vsync only if we haven't
+    // already passed our target frame. If the caller overran a frame, resync
+    // to the current counter instead of stalling another ~16.6ms, which would
+    // otherwise harmonic-lock the loop to 30fps.
+    static uint32_t target_frame = 0;
+    if (init)
+    {
+        target_frame = video_frame_count;
+    }
+    target_frame++;
+    uint32_t current = video_frame_count;
+    if ((int32_t)(current - target_frame) < 0)
+    {
+        while (video_frame_count != target_frame)
+        {
+            tight_loop_contents();
+        }
+    }
+    else
+    {
+        target_frame = current;
+    }
+}
+uint8_t *hstx_getframebuffer(void)
+{
+    // Return the pointer to the framebuffer
+    return WriteBuf;
+}
+
+void hstx_setScanLines(int enable)
+{
+    // Set the scanlines effect flag
+    enableScanLines = enable ? 1 : 0;
+}
+
+uint16_t *__not_in_flash_func(hstx_getlineFromFramebuffer)(int scanline)
+{
+    return (uint16_t *)(WriteBuf + (scanline * HRes * 2));
+}
+void __not_in_flash_func(hstx_vsync_callbackfunc)(void)
+{
+   HSTX_vblank = true;
+}
+void __not_in_flash_func(scanline_callbackfunc)(uint32_t v_scanline, uint32_t active_line, uint32_t *buff)
+{
+    uint16_t *p = (uint16_t *)buff;
+    int last_line = 2, load_line, line_to_load, Line_dup;
+    load_line = v_scanline - (MODE_V_TOTAL_LINES - MODE_V_ACTIVE_LINES);
+    Line_dup = load_line >> 1;
+    if (load_line >= 0 && load_line < MODE_V_ACTIVE_LINES)
+    {
+        HSTX_vblank = false;
+        __dmb();
+
+        for (int i = 0; i < MODE_H_ACTIVE_PIXELS / 2; i++)
+        {
+            uint8_t *d = &DisplayBuf[(Line_dup)*MODE_H_ACTIVE_PIXELS + i * 2];
+            int c = *d++;
+            c |= ((*d++) << 8);
+#if 1
+            // Apply CRT scanline effect for RGB555: darken every other line
+            if (load_line & 1 && enableScanLines)
+            { // Odd lines = scanlines
+                int r = (c >> 10) & 0x1F;
+                int g = (c >> 5) & 0x1F;
+                int b = c & 0x1F;
+                r = r >> 1;
+                g = g >> 1;
+                b = b >> 1;
+                c = (r << 10) | (g << 5) | b;
+            }
+            // tried vertical and pixel-grid scanlines
+            // but this is probably too much for the RP2350:
+#else
+            // Horizontal scanlines: darken every other line
+            if (scanlineMode == 1 && (load_line & 1))
+            {
+                int r = (c >> 10) & 0x1F;
+                int g = (c >> 5) & 0x1F;
+                int b = c & 0x1F;
+                r = r >> 1;
+                g = g >> 1;
+                b = b >> 1;
+                c = (r << 10) | (g << 5) | b;
+            }
+            // Vertical scanlines: darken every other pixel column
+            else if (scanlineMode == 2 && (i & 1))
+            {
+                int r = (c >> 10) & 0x1F;
+                int g = (c >> 5) & 0x1F;
+                int b = c & 0x1F;
+                r = r >> 1;
+                g = g >> 1;
+                b = b >> 1;
+                c = (r << 10) | (g << 5) | b;
+            }
+            // Pixel-grid: darken every other line and every other pixel column
+            else if (scanlineMode == 3 && ((load_line & 1) || (i & 1)))
+            {
+                int r = (c >> 10) & 0x1F;
+                int g = (c >> 5) & 0x1F;
+                int b = c & 0x1F;
+                r = r >> 1;
+                g = g >> 1;
+                b = b >> 1;
+                c = (r << 10) | (g << 5) | b;
+            }
+
+#endif
+            *p++ = c;
+            *p++ = c;
+        }
+    }
+}
+
+extern volatile uint32_t video_frame_count;
+uint32_t hstx_getframecounter(void)
+{
+    return video_frame_count;
+}
+
+void __not_in_flash_func(hstx_push_audio_sample)(const int left, const int right)
+{
+    static int g_hdmi_audio_frame_counter = 0;
+    static audio_sample_t acc_buf[4];
+    static int acc_count = 0;
+    static  uint32_t video_frame_count = 0;
+    acc_buf[acc_count].left = left;
+    acc_buf[acc_count].right = right;
+    acc_count++;
+    if (acc_count == 4)
+    {
+        if (hstx_di_queue_get_level() >= HSTX_AUDIO_DI_HIGH_WATERMARK)
+        {
+            acc_count = 0;
+            return;
+        }
+        hstx_packet_t packet;
+        g_hdmi_audio_frame_counter = hstx_packet_set_audio_samples(&packet, acc_buf, 4, g_hdmi_audio_frame_counter);
+
+        hstx_data_island_t island;
+        hstx_encode_data_island(&island, &packet, false, true);
+        (void)hstx_di_queue_push(&island);
+        acc_count = 0;
+    }
+}
+
+void hstx_init(bool dviOnly)
+{
+    video_output_set_dvi_mode(dviOnly);
+    hstx_di_queue_init();
+    video_output_set_vsync_callback(hstx_vsync_callbackfunc);   
+    video_output_init(640, 480);
+    pico_hdmi_set_audio_sample_rate(44100);
+    video_output_set_scanline_callback(scanline_callbackfunc);
+    multicore_launch_core1(video_output_core1_run);
+    printf("Pico HDMI initialized.\n");
+}
+#endif

--- a/drivers/pico_hdmi/backup/hstx.h
+++ b/drivers/pico_hdmi/backup/hstx.h
@@ -1,0 +1,30 @@
+#pragma once
+#if PICO_RP2350
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include "video_output.h"
+#include "hstx_packet.h"
+#include "hstx_data_island_queue.h"
+extern volatile bool HSTX_vblank;
+// Calculate HSTX output bit from GPIO number (GPIO12-19 => bit 0-7)
+#define HSTX_BIT_FROM_GPIO(gpio) ((gpio) - 12)
+#ifndef HSTX_AUDIO_DI_HIGH_WATERMARK
+#define HSTX_AUDIO_DI_HIGH_WATERMARK 200  // ~16–18 ms at 4 samples/packet
+#endif
+uint32_t hstx_getframecounter(void);
+void hstx_waitForVSync(void);
+void hstx_paceFrame(bool init);
+uint8_t *hstx_getframebuffer(void);
+void hstx_setScanLines(int enable);
+uint16_t *hstx_getlineFromFramebuffer(int scanline);
+void hstx_init(bool dviOnly);
+void video_output_core1_run(void);
+void hstx_push_audio_sample(const int left, const int right);
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/drivers/pico_hdmi/backup/hstx_data_island_queue.c
+++ b/drivers/pico_hdmi/backup/hstx_data_island_queue.c
@@ -1,0 +1,92 @@
+#include "hstx_data_island_queue.h"
+
+#include "video_output.h"
+#include "hstx_packet.h"
+
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include "pico.h"
+
+#define DI_RING_BUFFER_SIZE 256
+static hstx_data_island_t *di_ring_buffer = NULL; // [DI_RING_BUFFER_SIZE];
+static volatile uint32_t di_ring_head = 0;
+static volatile uint32_t di_ring_tail = 0;
+
+// Single pre-encoded silent audio packet (fixed B-frame flags).
+static hstx_data_island_t silence_packet;
+
+// Audio timing state (default 48kHz)
+static uint32_t audio_sample_accum = 0; // Fixed-point accumulator
+#define DEFAULT_SAMPLES_PER_FRAME (48000 / 60)
+static uint32_t samples_per_line_fp = (DEFAULT_SAMPLES_PER_FRAME << 16) / MODE_V_TOTAL_LINES;
+
+// Limit accumulator to avoid overflow if we run dry.
+// Clamping to 1 packet (plus a tiny margin is implicit) ensures we don't burst.
+#define MAX_AUDIO_ACCUM (4 << 16)
+extern void * frens_f_malloc(size_t size);
+void hstx_di_queue_init(void)
+{
+    di_ring_head = 0;
+    di_ring_tail = 0;
+    audio_sample_accum = 0;
+    // Allocate memory for the ring buffer
+    if (di_ring_buffer == NULL) {
+        printf("Allocating memory for HSTX DI ring buffer: %d bytes\n", DI_RING_BUFFER_SIZE * sizeof(hstx_data_island_t));  
+        di_ring_buffer = (hstx_data_island_t *)frens_f_malloc(DI_RING_BUFFER_SIZE * sizeof(hstx_data_island_t));
+    }
+    // Build a single silent audio packet with fixed B-frame flags.
+    di_ring_buffer = (hstx_data_island_t *)malloc(DI_RING_BUFFER_SIZE * sizeof(hstx_data_island_t));
+    // Build a single silent audio packet with fixed B-frame flags.
+    hstx_packet_t packet;
+    audio_sample_t samples[4] = {0};
+    (void)hstx_packet_set_audio_samples(&packet, samples, 4, 0);
+    hstx_encode_data_island(&silence_packet, &packet, false, true);
+}
+
+void hstx_di_queue_set_sample_rate(uint32_t sample_rate)
+{
+    uint32_t samples_per_frame = sample_rate / 60;
+    samples_per_line_fp = (samples_per_frame << 16) / MODE_V_TOTAL_LINES;
+}
+
+bool hstx_di_queue_push(const hstx_data_island_t *island)
+{
+    uint32_t next_head = (di_ring_head + 1) % DI_RING_BUFFER_SIZE;
+    if (next_head == di_ring_tail)
+        return false;
+
+    di_ring_buffer[di_ring_head] = *island;
+    di_ring_head = next_head;
+    return true;
+}
+
+uint32_t hstx_di_queue_get_level(void)
+{
+    uint32_t head = di_ring_head;
+    uint32_t tail = di_ring_tail;
+    if (head >= tail)
+        return head - tail;
+    return DI_RING_BUFFER_SIZE + head - tail;
+}
+
+void __not_in_flash_func(hstx_di_queue_tick)(void)
+{
+    audio_sample_accum += samples_per_line_fp;
+}
+
+const uint32_t *__not_in_flash_func(hstx_di_queue_get_audio_packet)(void)
+{
+    // Check if it's time to send a 4-sample audio packet (every ~2.6 lines)
+    if (audio_sample_accum >= (4 << 16)) {
+        audio_sample_accum -= (4 << 16);
+        if (di_ring_tail != di_ring_head) {
+            const uint32_t *words = di_ring_buffer[di_ring_tail].words;
+            di_ring_tail = (di_ring_tail + 1) % DI_RING_BUFFER_SIZE;
+            return words;
+        }
+        // Queue is empty: return a pre-encoded silent packet to keep HDMI audio active.
+        return silence_packet.words;
+    }
+    return NULL;
+}

--- a/drivers/pico_hdmi/backup/hstx_data_island_queue.h
+++ b/drivers/pico_hdmi/backup/hstx_data_island_queue.h
@@ -1,0 +1,44 @@
+#ifndef HSTX_DATA_ISLAND_QUEUE_H
+#define HSTX_DATA_ISLAND_QUEUE_H
+
+#include "hstx_packet.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/**
+ * Initialize the Data Island queue and scheduler.
+ */
+void hstx_di_queue_init(void);
+
+/**
+ * Set the audio sample rate for packet timing.
+ * @param sample_rate Audio sample rate in Hz (e.g. 44100, 48000)
+ */
+void hstx_di_queue_set_sample_rate(uint32_t sample_rate);
+
+/**
+ * Push a pre-encoded Data Island into the queue.
+ * Returns true if successful, false if the queue is full.
+ */
+bool hstx_di_queue_push(const hstx_data_island_t *island);
+
+/**
+ * Get the current number of items in the queue.
+ */
+uint32_t hstx_di_queue_get_level(void);
+
+/**
+ * Advance the Data Island scheduler by one scanline.
+ * Must be called exactly once per scanline in the DMA ISR.
+ */
+void hstx_di_queue_tick(void);
+
+/**
+ * Get the next audio Data Island packet if the scheduler determines it's time.
+ *
+ * @return Pointer to 36-word HSTX data island, or NULL if no packet is due.
+ */
+const uint32_t *hstx_di_queue_get_audio_packet(void);
+
+#endif // HSTX_DATA_ISLAND_QUEUE_H

--- a/drivers/pico_hdmi/backup/hstx_data_island_queue_silencepacketarray.c
+++ b/drivers/pico_hdmi/backup/hstx_data_island_queue_silencepacketarray.c
@@ -1,0 +1,91 @@
+#include "hstx_data_island_queue.h"
+
+#include "video_output.h"
+#include "hstx_packet.h"
+
+#include <string.h>
+
+#include "pico.h"
+
+#define DI_RING_BUFFER_SIZE 256
+static hstx_data_island_t di_ring_buffer[DI_RING_BUFFER_SIZE];
+static volatile uint32_t di_ring_head = 0;
+static volatile uint32_t di_ring_tail = 0;
+
+#define SILENCE_PACKET_COUNT 48
+static hstx_data_island_t silence_packets[SILENCE_PACKET_COUNT];
+static uint8_t silence_packet_index = 0;
+
+// Audio timing state (default 48kHz)
+static uint32_t audio_sample_accum = 0; // Fixed-point accumulator
+#define DEFAULT_SAMPLES_PER_FRAME (48000 / 60)
+static uint32_t samples_per_line_fp = (DEFAULT_SAMPLES_PER_FRAME << 16) / MODE_V_TOTAL_LINES;
+
+// Limit accumulator to avoid overflow if we run dry.
+// Clamping to 1 packet (plus a tiny margin is implicit) ensures we don't burst.
+#define MAX_AUDIO_ACCUM (4 << 16)
+
+void hstx_di_queue_init(void)
+{
+    di_ring_head = 0;
+    di_ring_tail = 0;
+    audio_sample_accum = 0;
+     // Build a rotating set of silent audio packets with correct B-frame flags.
+    hstx_packet_t packet;
+    audio_sample_t samples[4] = {0};
+    int frame_counter = 0;
+    for (int i = 0; i < SILENCE_PACKET_COUNT; ++i) {
+        frame_counter = hstx_packet_set_audio_samples(&packet, samples, 4, frame_counter);
+        hstx_encode_data_island(&silence_packets[i], &packet, false, true);
+    }
+    silence_packet_index = 0;
+}
+
+void hstx_di_queue_set_sample_rate(uint32_t sample_rate)
+{
+    uint32_t samples_per_frame = sample_rate / 60;
+    samples_per_line_fp = (samples_per_frame << 16) / MODE_V_TOTAL_LINES;
+}
+
+bool hstx_di_queue_push(const hstx_data_island_t *island)
+{
+    uint32_t next_head = (di_ring_head + 1) % DI_RING_BUFFER_SIZE;
+    if (next_head == di_ring_tail)
+        return false;
+
+    di_ring_buffer[di_ring_head] = *island;
+    di_ring_head = next_head;
+    return true;
+}
+
+uint32_t hstx_di_queue_get_level(void)
+{
+    uint32_t head = di_ring_head;
+    uint32_t tail = di_ring_tail;
+    if (head >= tail)
+        return head - tail;
+    return DI_RING_BUFFER_SIZE + head - tail;
+}
+
+void __not_in_flash_func(hstx_di_queue_tick)(void)
+{
+    audio_sample_accum += samples_per_line_fp;
+}
+
+const uint32_t *__not_in_flash_func(hstx_di_queue_get_audio_packet)(void)
+{
+    // Check if it's time to send a 4-sample audio packet (every ~2.6 lines)
+    if (audio_sample_accum >= (4 << 16)) {
+        audio_sample_accum -= (4 << 16);
+        if (di_ring_tail != di_ring_head) {
+            const uint32_t *words = di_ring_buffer[di_ring_tail].words;
+            di_ring_tail = (di_ring_tail + 1) % DI_RING_BUFFER_SIZE;
+            return words;
+        }
+        // Queue is empty: return a pre-encoded silent packet to keep HDMI audio active.
+        const uint32_t *words = silence_packets[silence_packet_index].words;
+        silence_packet_index = (silence_packet_index + 1) % SILENCE_PACKET_COUNT;
+        return words;
+    }
+    return NULL;
+}

--- a/drivers/pico_hdmi/backup/hstx_packet.c
+++ b/drivers/pico_hdmi/backup/hstx_packet.c
@@ -1,0 +1,334 @@
+#include "hstx_packet.h"
+
+#include <string.h>
+
+// ============================================================================
+// TERC4 Symbol Table (4-bit to 10-bit encoding)
+// ============================================================================
+
+static const uint16_t ter_c4[16] = {
+    0b1010011100, // 0
+    0b1001100011, // 1
+    0b1011100100, // 2
+    0b1011100010, // 3
+    0b0101110001, // 4
+    0b0100011110, // 5
+    0b0110001110, // 6
+    0b0100111100, // 7
+    0b1011001100, // 8
+    0b0100111001, // 9
+    0b0110011100, // 10
+    0b1011000110, // 11
+    0b1010001110, // 12
+    0b1001110001, // 13
+    0b0101100011, // 14
+    0b1011000011, // 15
+};
+
+#define GUARD_BAND_SYMBOL 0x133u // 0b0100110011
+
+// ============================================================================
+// BCH Encoding
+// ============================================================================
+
+static const uint8_t bch_table[256] = {
+    0x00, 0xd9, 0xb5, 0x6c, 0x6d, 0xb4, 0xd8, 0x01, 0xda, 0x03, 0x6f, 0xb6, 0xb7, 0x6e, 0x02, 0xdb, 0xb3, 0x6a, 0x06,
+    0xdf, 0xde, 0x07, 0x6b, 0xb2, 0x69, 0xb0, 0xdc, 0x05, 0x04, 0xdd, 0xb1, 0x68, 0x61, 0xb8, 0xd4, 0x0d, 0x0c, 0xd5,
+    0xb9, 0x60, 0xbb, 0x62, 0x0e, 0xd7, 0xd6, 0x0f, 0x63, 0xba, 0xd2, 0x0b, 0x67, 0xbe, 0xbf, 0x66, 0x0a, 0xd3, 0x08,
+    0xd1, 0xbd, 0x64, 0x65, 0xbc, 0xd0, 0x09, 0xc2, 0x1b, 0x77, 0xae, 0xaf, 0x76, 0x1a, 0xc3, 0x18, 0xc1, 0xad, 0x74,
+    0x75, 0xac, 0xc0, 0x19, 0x71, 0xa8, 0xc4, 0x1d, 0x1c, 0xc5, 0xa9, 0x70, 0xab, 0x72, 0x1e, 0xc7, 0xc6, 0x1f, 0x73,
+    0xaa, 0xa3, 0x7a, 0x16, 0xcf, 0xce, 0x17, 0x7b, 0xa2, 0x79, 0xa0, 0xcc, 0x15, 0x14, 0xcd, 0xa1, 0x78, 0x10, 0xc9,
+    0xa5, 0x7c, 0x7d, 0xa4, 0xc8, 0x11, 0xca, 0x13, 0x7f, 0xa6, 0xa7, 0x7e, 0x12, 0xcb, 0x83, 0x5a, 0x36, 0xef, 0xee,
+    0x37, 0x5b, 0x82, 0x59, 0x80, 0xec, 0x35, 0x34, 0xed, 0x81, 0x58, 0x30, 0xe9, 0x85, 0x5c, 0x5d, 0x84, 0xe8, 0x31,
+    0xea, 0x33, 0x5f, 0x86, 0x87, 0x5e, 0x32, 0xeb, 0xe2, 0x3b, 0x57, 0x8e, 0x8f, 0x56, 0x3a, 0xe3, 0x38, 0xe1, 0x8d,
+    0x54, 0x55, 0x8c, 0xe0, 0x39, 0x51, 0x88, 0xe4, 0x3d, 0x3c, 0xe5, 0x89, 0x50, 0x8b, 0x52, 0x3e, 0xe7, 0xe6, 0x3f,
+    0x53, 0x8a, 0x41, 0x98, 0xf4, 0x2d, 0x2c, 0xf5, 0x99, 0x40, 0x9b, 0x42, 0x2e, 0xf7, 0xf6, 0x2f, 0x43, 0x9a, 0xf2,
+    0x2b, 0x47, 0x9e, 0x9f, 0x46, 0x2a, 0xf3, 0x28, 0xf1, 0x9d, 0x44, 0x45, 0x9c, 0xf0, 0x29, 0x20, 0xf9, 0x95, 0x4c,
+    0x4d, 0x94, 0xf8, 0x21, 0xfa, 0x23, 0x4f, 0x96, 0x97, 0x4e, 0x22, 0xfb, 0x93, 0x4a, 0x26, 0xff, 0xfe, 0x27, 0x4b,
+    0x92, 0x49, 0x90, 0xfc, 0x25, 0x24, 0xfd, 0x91, 0x48,
+};
+
+static const uint8_t parity_table[32] = {0x96, 0x69, 0x69, 0x96, 0x69, 0x96, 0x96, 0x69, 0x69, 0x96, 0x96,
+                                         0x69, 0x96, 0x69, 0x69, 0x96, 0x69, 0x96, 0x96, 0x69, 0x96, 0x69,
+                                         0x69, 0x96, 0x96, 0x69, 0x69, 0x96, 0x69, 0x96, 0x96, 0x69};
+
+static inline bool compute_parity(uint8_t v)
+{
+    return (parity_table[v / 8] >> (v % 8)) & 1;
+}
+
+static inline bool compute_parity3(uint8_t a, uint8_t b, uint8_t c)
+{
+    return compute_parity(a) ^ compute_parity(b) ^ compute_parity(c);
+}
+
+static uint8_t encode_bch_3(const uint8_t *p)
+{
+    uint8_t v = bch_table[p[0]];
+    v = bch_table[p[1] ^ v];
+    v = bch_table[p[2] ^ v];
+    return v;
+}
+
+static uint8_t encode_bch_7(const uint8_t *p)
+{
+    uint8_t v = bch_table[p[0]];
+    v = bch_table[p[1] ^ v];
+    v = bch_table[p[2] ^ v];
+    v = bch_table[p[3] ^ v];
+    v = bch_table[p[4] ^ v];
+    v = bch_table[p[5] ^ v];
+    v = bch_table[p[6] ^ v];
+    return v;
+}
+
+static void compute_header_parity(hstx_packet_t *p)
+{
+    p->header[3] = encode_bch_3(p->header);
+}
+
+static void compute_subpacket_parity(hstx_packet_t *p, int idx)
+{
+    p->subpacket[idx][7] = encode_bch_7(p->subpacket[idx]);
+}
+
+static void compute_all_parity(hstx_packet_t *p)
+{
+    compute_header_parity(p);
+    for (int i = 0; i < 4; i++) {
+        compute_subpacket_parity(p, i);
+    }
+}
+
+static void compute_infoframe_checksum(hstx_packet_t *p)
+{
+    int sum = 0;
+    for (int i = 0; i < 3; i++) {
+        sum += p->header[i];
+    }
+    int len = p->header[2] + 1;
+    for (int j = 0; j < 4 && len > 0; j++) {
+        for (int i = 0; i < 7 && len > 0; i++, len--) {
+            sum += p->subpacket[j][i];
+        }
+    }
+    p->subpacket[0][0] = (uint8_t)(-sum);
+}
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+void hstx_packet_init(hstx_packet_t *packet)
+{
+    memset(packet, 0, sizeof(hstx_packet_t));
+}
+
+void hstx_packet_set_null(hstx_packet_t *packet)
+{
+    hstx_packet_init(packet);
+    compute_all_parity(packet);
+}
+
+void hstx_packet_set_acr(hstx_packet_t *packet, uint32_t n, uint32_t cts)
+{
+    hstx_packet_init(packet);
+    packet->header[0] = 0x01;
+    packet->header[1] = 0x00;
+    packet->header[2] = 0x00;
+    compute_header_parity(packet);
+
+    packet->subpacket[0][0] = 0;
+    packet->subpacket[0][1] = (cts >> 16) & 0x0F;
+    packet->subpacket[0][2] = (cts >> 8) & 0xFF;
+    packet->subpacket[0][3] = cts & 0xFF;
+    packet->subpacket[0][4] = (n >> 16) & 0x0F;
+    packet->subpacket[0][5] = (n >> 8) & 0xFF;
+    packet->subpacket[0][6] = n & 0xFF;
+    compute_subpacket_parity(packet, 0);
+
+    memcpy(packet->subpacket[1], packet->subpacket[0], 8);
+    memcpy(packet->subpacket[2], packet->subpacket[0], 8);
+    memcpy(packet->subpacket[3], packet->subpacket[0], 8);
+}
+
+void hstx_packet_set_audio_infoframe(hstx_packet_t *packet, uint32_t sample_rate, uint8_t channels,
+                                     uint8_t bits_per_sample)
+{
+    hstx_packet_init(packet);
+    packet->header[0] = 0x84;
+    packet->header[1] = 0x01;
+    packet->header[2] = 0x0A;
+
+    uint8_t cc = (channels - 1) & 0x07;
+    uint8_t ct = 0x01;
+    uint8_t ss =
+        (bits_per_sample == 16) ? 0x01 : (bits_per_sample == 20 ? 0x02 : (bits_per_sample == 24 ? 0x03 : 0x00));
+    uint8_t sf = (sample_rate == 32000) ? 0x01 : (sample_rate == 44100 ? 0x02 : (sample_rate == 48000 ? 0x03 : 0x00));
+
+    packet->subpacket[0][1] = cc | (ct << 4);
+    packet->subpacket[0][2] = ss | (sf << 2);
+    packet->subpacket[0][3] = 0x00;
+    packet->subpacket[0][4] = 0x00;
+    packet->subpacket[0][5] = 0x00;
+
+    compute_infoframe_checksum(packet);
+    compute_all_parity(packet);
+}
+
+void hstx_packet_set_avi_infoframe(hstx_packet_t *packet, uint8_t vic, uint8_t pixel_repetition)
+{
+    hstx_packet_init(packet);
+    packet->header[0] = 0x82;
+    packet->header[1] = 0x02;
+    packet->header[2] = 0x0D;
+
+    packet->subpacket[0][1] = 0x00;
+    packet->subpacket[0][2] = 0x08;
+    packet->subpacket[0][3] = 0x00;
+    packet->subpacket[0][4] = vic;
+    packet->subpacket[0][5] = pixel_repetition & 0x0F;
+
+    compute_infoframe_checksum(packet);
+    compute_all_parity(packet);
+}
+
+int hstx_packet_set_audio_samples(hstx_packet_t *packet, const audio_sample_t *samples, int num_samples,
+                                  int frame_count)
+{
+    hstx_packet_init(packet);
+    if (num_samples < 1)
+        num_samples = 1;
+    if (num_samples > 4)
+        num_samples = 4;
+
+    uint8_t sample_present = (1 << num_samples) - 1;
+    uint8_t b_flags = 0;
+
+    int temp_frame_count = frame_count;
+    for (int i = 0; i < num_samples; i++) {
+        if (temp_frame_count == 0)
+            b_flags |= (1 << i);
+        temp_frame_count = (temp_frame_count + 1) % 192;
+    }
+
+    packet->header[0] = 0x02;
+    packet->header[1] = sample_present;
+    packet->header[2] = b_flags << 4;
+    compute_header_parity(packet);
+
+    for (int i = 0; i < num_samples; i++) {
+        uint8_t *d = packet->subpacket[i];
+        int16_t left = samples[i].left;
+        int16_t right = samples[i].right;
+
+        d[0] = 0x00;
+        d[1] = left & 0xFF;
+        d[2] = (left >> 8) & 0xFF;
+        d[3] = 0x00;
+        d[4] = right & 0xFF;
+        d[5] = (right >> 8) & 0xFF;
+
+        bool p_left = compute_parity3(d[1], d[2], 0);
+        bool p_right = compute_parity3(d[4], d[5], 0);
+
+        d[6] = (p_left << 3) | (p_right << 7);
+        compute_subpacket_parity(packet, i);
+    }
+
+    return temp_frame_count;
+}
+
+static inline uint32_t make_hstx_word(uint16_t lane0, uint16_t lane1, uint16_t lane2)
+{
+    return (lane0 & 0x3FF) | ((lane1 & 0x3FF) << 10) | ((lane2 & 0x3FF) << 20);
+}
+
+static void encode_header_to_lane0(const hstx_packet_t *packet, uint16_t *lane0, int hv, bool first_packet)
+{
+    int hv1 = hv | 0x08;
+    if (!first_packet)
+        hv = hv1;
+
+    int idx = 0;
+    for (int i = 0; i < 4; i++) {
+        uint8_t h = packet->header[i];
+        lane0[idx++] = ter_c4[((h << 2) & 4) | hv];
+        hv = hv1;
+        lane0[idx++] = ter_c4[((h << 1) & 4) | hv];
+        lane0[idx++] = ter_c4[(h & 4) | hv];
+        lane0[idx++] = ter_c4[((h >> 1) & 4) | hv];
+        lane0[idx++] = ter_c4[((h >> 2) & 4) | hv];
+        lane0[idx++] = ter_c4[((h >> 3) & 4) | hv];
+        lane0[idx++] = ter_c4[((h >> 4) & 4) | hv];
+        lane0[idx++] = ter_c4[((h >> 5) & 4) | hv];
+    }
+}
+
+static void encode_subpackets_to_lanes(const hstx_packet_t *packet, uint16_t *lane1, uint16_t *lane2)
+{
+    for (int i = 0; i < 8; i++) {
+        uint32_t v = (packet->subpacket[0][i] << 0) | (packet->subpacket[1][i] << 8) | (packet->subpacket[2][i] << 16) |
+                     (packet->subpacket[3][i] << 24);
+        uint32_t t = (v ^ (v >> 7)) & 0x00aa00aa;
+        v = v ^ t ^ (t << 7);
+        t = (v ^ (v >> 14)) & 0x0000cccc;
+        v = v ^ t ^ (t << 14);
+
+        lane1[(i * 4) + 0] = ter_c4[(v >> 0) & 0xF];
+        lane1[(i * 4) + 1] = ter_c4[(v >> 16) & 0xF];
+        lane1[(i * 4) + 2] = ter_c4[(v >> 4) & 0xF];
+        lane1[(i * 4) + 3] = ter_c4[(v >> 20) & 0xF];
+
+        lane2[(i * 4) + 0] = ter_c4[(v >> 8) & 0xF];
+        lane2[(i * 4) + 1] = ter_c4[(v >> 24) & 0xF];
+        lane2[(i * 4) + 2] = ter_c4[(v >> 12) & 0xF];
+        lane2[(i * 4) + 3] = ter_c4[(v >> 28) & 0xF];
+    }
+}
+
+void hstx_encode_data_island(hstx_data_island_t *out, const hstx_packet_t *packet, bool vsync_active, bool hsync_active)
+{
+    // REVERTED: vsync_active/hsync_active indicate pulse region, not signal level
+    // For 640x480 (negative polarity), pulse region means signal=0
+    int hv = (vsync_active ? 0 : 2) | (hsync_active ? 0 : 1);
+    uint16_t lane0[32];
+    uint16_t lane1[32];
+    uint16_t lane2[32];
+
+    encode_header_to_lane0(packet, lane0, hv, true);
+    encode_subpackets_to_lanes(packet, lane1, lane2);
+
+    uint16_t gb_lane0 = ter_c4[0xC | hv];
+    uint32_t guard_word = make_hstx_word(gb_lane0, GUARD_BAND_SYMBOL, GUARD_BAND_SYMBOL);
+
+    out->words[0] = guard_word;
+    out->words[1] = guard_word;
+    for (int i = 0; i < 32; i++)
+        out->words[i + 2] = make_hstx_word(lane0[i], lane1[i], lane2[i]);
+    out->words[34] = guard_word;
+    out->words[35] = guard_word;
+}
+
+static hstx_data_island_t null_islands[4];
+static bool null_islands_initialized = false;
+
+static void init_null_islands(void)
+{
+    if (null_islands_initialized)
+        return;
+    hstx_packet_t null_packet;
+    hstx_packet_set_null(&null_packet);
+    for (int vsync = 0; vsync < 2; vsync++) {
+        for (int hsync = 0; hsync < 2; hsync++) {
+            hstx_encode_data_island(&null_islands[(vsync * 2) + hsync], &null_packet, vsync, hsync);
+        }
+    }
+    null_islands_initialized = true;
+}
+
+const uint32_t *hstx_get_null_data_island(bool vsync, bool hsync)
+{
+    init_null_islands();
+    return null_islands[(vsync ? 2 : 0) | (hsync ? 1 : 0)].words;
+}

--- a/drivers/pico_hdmi/backup/hstx_packet.h
+++ b/drivers/pico_hdmi/backup/hstx_packet.h
@@ -1,0 +1,53 @@
+#ifndef HSTX_PACKET_H
+#define HSTX_PACKET_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+// Data Island timing constants
+#define W_GUARDBAND 2                                             // Guard band: 2 pixel clocks
+#define W_PREAMBLE 8                                              // Preamble: 8 pixel clocks
+#define W_DATA_PACKET 32                                          // Packet data: 32 pixel clocks
+#define W_DATA_ISLAND (W_GUARDBAND + W_DATA_PACKET + W_GUARDBAND) // Total: 36
+
+// HSTX outputs 1 symbol per word
+#define HSTX_DATA_ISLAND_WORDS W_DATA_ISLAND // 36 words for HSTX
+
+// Packet structure (same as DVI/HSTX spec)
+typedef struct {
+    uint8_t header[4];       // 3 bytes header + 1 byte BCH parity
+    uint8_t subpacket[4][8]; // 4 subpackets, each 7 bytes + 1 byte BCH parity
+} hstx_packet_t;
+
+// Pre-encoded data island for HSTX (36 words)
+typedef struct {
+    uint32_t words[HSTX_DATA_ISLAND_WORDS];
+} hstx_data_island_t;
+
+// Audio sample structure
+typedef struct {
+    int16_t left;
+    int16_t right;
+} audio_sample_t;
+
+// ============================================================================
+// Packet creation functions
+// ============================================================================
+
+void hstx_packet_init(hstx_packet_t *packet);
+void hstx_packet_set_acr(hstx_packet_t *packet, uint32_t n, uint32_t cts);
+void hstx_packet_set_audio_infoframe(hstx_packet_t *packet, uint32_t sample_rate, uint8_t channels,
+                                     uint8_t bits_per_sample);
+void hstx_packet_set_avi_infoframe(hstx_packet_t *packet, uint8_t vic, uint8_t pixel_repetition);
+int hstx_packet_set_audio_samples(hstx_packet_t *packet, const audio_sample_t *samples, int num_samples,
+                                  int frame_count);
+void hstx_packet_set_null(hstx_packet_t *packet);
+
+// ============================================================================
+// TERC4 encoding for HSTX
+// ============================================================================
+
+void hstx_encode_data_island(hstx_data_island_t *out, const hstx_packet_t *packet, bool vsync, bool hsync);
+const uint32_t *hstx_get_null_data_island(bool vsync, bool hsync);
+
+#endif // HSTX_PACKET_H

--- a/drivers/pico_hdmi/backup/hstx_pins.h
+++ b/drivers/pico_hdmi/backup/hstx_pins.h
@@ -1,0 +1,19 @@
+/**
+ * pico_hdmi Pin Configuration
+ *
+ * Default HSTX output pin mapping for the pico_hdmi library.
+ */
+
+#ifndef HSTX_PINS_H
+#define HSTX_PINS_H
+
+// =============================================================================
+// DVI/HSTX Output Pins (GPIO 12-19)
+// =============================================================================
+// These are the default pins for the RP2350's HSTX peripheral.
+#define PIN_HSTX_CLK 12 // Clock pair base (12=CLK-, 13=CLK+)
+#define PIN_HSTX_D0 14  // Data 0 pair base (14=D0-, 15=D0+)
+#define PIN_HSTX_D1 16  // Data 1 pair base (16=D1-, 17=D1+)
+#define PIN_HSTX_D2 18  // Data 2 pair base (18=D2-, 19=D2+)
+
+#endif // HSTX_PINS_H

--- a/drivers/pico_hdmi/backup/video_output.c
+++ b/drivers/pico_hdmi/backup/video_output.c
@@ -1,0 +1,622 @@
+#include "video_output.h"
+
+#include "hstx_data_island_queue.h"
+#include "hstx_packet.h"
+#include "hstx_pins.h"
+#include "pico/stdlib.h"
+
+#include "hardware/clocks.h"
+#include "hardware/dma.h"
+#include "hardware/gpio.h"
+#include "hardware/irq.h"
+#include "hardware/structs/bus_ctrl.h"
+#include "hardware/structs/clocks.h"
+#include "hardware/structs/hstx_ctrl.h"
+#include "hardware/structs/hstx_fifo.h"
+
+#include <math.h>
+#include <string.h>
+#include "hstx.h"
+
+// ============================================================================
+// DVI/HSTX Constants
+// ============================================================================
+
+#define TMDS_CTRL_00 0x354u // vsync=0 hsync=0
+#define TMDS_CTRL_01 0x0abu // vsync=0 hsync=1
+#define TMDS_CTRL_10 0x154u // vsync=1 hsync=0
+#define TMDS_CTRL_11 0x2abu // vsync=1 hsync=1
+
+// Sync symbols: Lane 0 carries sync, Lanes 1&2 are always CTRL_00
+#define SYNC_V0_H0 (TMDS_CTRL_00 | (TMDS_CTRL_00 << 10) | (TMDS_CTRL_00 << 20))
+#define SYNC_V0_H1 (TMDS_CTRL_01 | (TMDS_CTRL_00 << 10) | (TMDS_CTRL_00 << 20))
+#define SYNC_V1_H0 (TMDS_CTRL_10 | (TMDS_CTRL_00 << 10) | (TMDS_CTRL_00 << 20))
+#define SYNC_V1_H1 (TMDS_CTRL_11 | (TMDS_CTRL_00 << 10) | (TMDS_CTRL_00 << 20))
+
+// Data Island preamble: Lane 0 = sync, Lanes 1&2 = CTRL_01 pattern
+// Per HDMI 1.3a Table 5-2: CTL0=1, CTL1=0, CTL2=1, CTL3=0
+#define PREAMBLE_V0_H0 (TMDS_CTRL_00 | (TMDS_CTRL_01 << 10) | (TMDS_CTRL_01 << 20))
+#define PREAMBLE_V1_H0 (TMDS_CTRL_10 | (TMDS_CTRL_01 << 10) | (TMDS_CTRL_01 << 20))
+
+// Video preamble: Lane 0 = sync, Lane 1 = CTRL_01, Lane 2 = CTRL_00
+// Per HDMI 1.3a Table 5-2: CTL0=1, CTL1=0, CTL2=0, CTL3=0
+#define VIDEO_PREAMBLE_V0_H1 (TMDS_CTRL_01 | (TMDS_CTRL_01 << 10) | (TMDS_CTRL_00 << 20))
+#define VIDEO_PREAMBLE_V1_H1 (TMDS_CTRL_11 | (TMDS_CTRL_01 << 10) | (TMDS_CTRL_00 << 20))
+
+// Video guard band: Per HDMI 1.3a Table 5-5
+// CH0 = 0b1011001100 (0x2CC), CH1 = 0b0100110011 (0x133), CH2 = 0b1011001100 (0x2CC)
+#define VIDEO_GUARD_BAND (0x2CCu | (0x133u << 10) | (0x2CCu << 20))
+
+#define HSTX_CMD_RAW (0x0u << 12)
+#define HSTX_CMD_RAW_REPEAT (0x1u << 12)
+#define HSTX_CMD_TMDS (0x2u << 12)
+#define HSTX_CMD_TMDS_REPEAT (0x3u << 12)
+#define HSTX_CMD_NOP (0xfu << 12)
+
+#define SYNC_AFTER_DI (MODE_H_SYNC_WIDTH - W_PREAMBLE - W_DATA_ISLAND)
+
+// Video preamble and guard band widths (HDMI 1.3a Section 5.2.2)
+#define W_VIDEO_PREAMBLE 8
+#define W_VIDEO_GUARD_BAND 2
+
+// ============================================================================
+// Audio/Video State
+// ============================================================================
+
+uint16_t frame_width = 0;
+uint16_t frame_height = 0;
+volatile uint32_t video_frame_count = 0;
+
+// DVI mode: when true, disables all HDMI Data Islands (pure DVI output, no audio)
+// Some monitors have trouble syncing with HDMI Data Islands
+static bool dvi_mode = false; // Default to HDMI mode (full features with audio)
+
+static uint16_t line_buffer[MODE_H_ACTIVE_PIXELS] __attribute__((aligned(4)));
+static uint32_t v_scanline = 2;
+static bool vactive_cmdlist_posted = false;
+static bool dma_pong = false;
+
+static video_output_task_fn background_task = NULL;
+static video_output_scanline_cb_t scanline_callback = NULL;
+static video_output_vsync_cb_t vsync_callback = NULL;
+
+#define DMACH_PING 0
+#define DMACH_PONG 1
+
+// ============================================================================
+// Command Lists
+// ============================================================================
+
+// Pure DVI command lists (no Data Islands)
+static uint32_t vblank_line_vsync_off[] = {HSTX_CMD_RAW_REPEAT | MODE_H_FRONT_PORCH,
+                                           SYNC_V1_H1,
+                                           HSTX_CMD_NOP,
+                                           HSTX_CMD_RAW_REPEAT | MODE_H_SYNC_WIDTH,
+                                           SYNC_V1_H0,
+                                           HSTX_CMD_NOP,
+                                           HSTX_CMD_RAW_REPEAT | (MODE_H_BACK_PORCH + MODE_H_ACTIVE_PIXELS),
+                                           SYNC_V1_H1,
+                                           HSTX_CMD_NOP};
+
+static uint32_t vblank_line_vsync_on[] = {HSTX_CMD_RAW_REPEAT | MODE_H_FRONT_PORCH,
+                                          SYNC_V0_H1,
+                                          HSTX_CMD_NOP,
+                                          HSTX_CMD_RAW_REPEAT | MODE_H_SYNC_WIDTH,
+                                          SYNC_V0_H0,
+                                          HSTX_CMD_NOP,
+                                          HSTX_CMD_RAW_REPEAT | (MODE_H_BACK_PORCH + MODE_H_ACTIVE_PIXELS),
+                                          SYNC_V0_H1,
+                                          HSTX_CMD_NOP};
+
+// Active video line for DVI mode (no Data Island, just sync + pixels)
+static uint32_t vactive_line_dvi[] = {
+    HSTX_CMD_RAW_REPEAT | MODE_H_FRONT_PORCH, SYNC_V1_H1, HSTX_CMD_NOP,
+    HSTX_CMD_RAW_REPEAT | MODE_H_SYNC_WIDTH,  SYNC_V1_H0, HSTX_CMD_NOP,
+    HSTX_CMD_RAW_REPEAT | MODE_H_BACK_PORCH,  SYNC_V1_H1, HSTX_CMD_TMDS | MODE_H_ACTIVE_PIXELS};
+
+static uint32_t vactive_di_ping[128], vactive_di_pong[128], vactive_di_null[128];
+static uint32_t vactive_di_len, vactive_di_null_len;
+
+static uint32_t vblank_di_ping[128], vblank_di_pong[128], vblank_di_null[128];
+static uint32_t vblank_di_len, vblank_di_null_len;
+
+static uint32_t vblank_acr_vsync_on[64], vblank_acr_vsync_on_len;
+static uint32_t vblank_acr_vsync_off[64], vblank_acr_vsync_off_len;
+static uint32_t vblank_infoframe_vsync_on[64], vblank_infoframe_vsync_on_len;
+static uint32_t vblank_infoframe_vsync_off[64], vblank_infoframe_vsync_off_len;
+static uint32_t vblank_avi_infoframe[64], vblank_avi_infoframe_len;
+
+// ============================================================================
+// HSTX Resync - Reset output to sync with input VSYNC
+// ============================================================================
+
+static void __not_in_flash_func(hstx_resync)(void)
+{
+    // 1. Abort DMA chains
+    dma_channel_abort(DMACH_PING);
+    dma_channel_abort(DMACH_PONG);
+
+    // 2. Disable HSTX (resets shift register, clock generator, and flushes FIFO)
+    hstx_ctrl_hw->csr &= ~HSTX_CTRL_CSR_EN_BITS;
+
+    // Small delay to ensure HSTX fully stops
+    __asm volatile("nop\nnop\nnop\nnop");
+
+    // 3. Reset state to start of frame
+    v_scanline = 0;
+    vactive_cmdlist_posted = false;
+    dma_pong = false;
+
+    // 4. Clear any pending DMA interrupts
+    dma_hw->ints0 = (1U << DMACH_PING) | (1U << DMACH_PONG);
+
+    // 5. Configure DMA PING to start from beginning of frame (Line 0)
+    dma_channel_hw_t *ch_ping = &dma_hw->ch[DMACH_PING];
+    ch_ping->read_addr = (uintptr_t)vblank_line_vsync_off;
+    ch_ping->transfer_count = count_of(vblank_line_vsync_off);
+
+    // 6. Configure DMA PONG for the NEXT line (Line 1)
+    // This ensures that when PING finishes and chains to PONG, PONG is ready.
+    dma_channel_hw_t *ch_pong = &dma_hw->ch[DMACH_PONG];
+    ch_pong->read_addr = (uintptr_t)vblank_line_vsync_off; // Line 1 is also blank
+    ch_pong->transfer_count = count_of(vblank_line_vsync_off);
+
+    // 7. Re-enable HSTX then start DMA
+    hstx_ctrl_hw->csr |= HSTX_CTRL_CSR_EN_BITS;
+    dma_channel_start(DMACH_PING);
+}
+
+// ============================================================================
+// Internal Helpers
+// ============================================================================
+
+static uint32_t build_line_with_di(uint32_t *buf, const uint32_t *di_words, bool vsync, bool active)
+{
+    uint32_t *p = buf;
+    uint32_t sync_h0 = vsync ? SYNC_V0_H0 : SYNC_V1_H0;
+    uint32_t sync_h1 = vsync ? SYNC_V0_H1 : SYNC_V1_H1;
+    uint32_t preamble = vsync ? PREAMBLE_V0_H0 : PREAMBLE_V1_H0;
+
+    *p++ = HSTX_CMD_RAW_REPEAT | MODE_H_FRONT_PORCH;
+    *p++ = sync_h1;
+    *p++ = HSTX_CMD_NOP;
+
+    *p++ = HSTX_CMD_RAW_REPEAT | W_PREAMBLE;
+    *p++ = preamble;
+    *p++ = HSTX_CMD_NOP;
+
+    *p++ = HSTX_CMD_RAW | W_DATA_ISLAND;
+    for (int i = 0; i < W_DATA_ISLAND; i++)
+        *p++ = di_words[i];
+    *p++ = HSTX_CMD_NOP;
+
+    *p++ = HSTX_CMD_RAW_REPEAT | SYNC_AFTER_DI;
+    *p++ = sync_h0;
+    *p++ = HSTX_CMD_NOP;
+
+    if (active) {
+        // HDMI 1.3a Section 5.2.2: Video Data Period requires preamble and guard band
+        uint32_t video_preamble = vsync ? VIDEO_PREAMBLE_V0_H1 : VIDEO_PREAMBLE_V1_H1;
+
+        // Control period (back porch minus preamble and guard band)
+        *p++ = HSTX_CMD_RAW_REPEAT | (MODE_H_BACK_PORCH - W_VIDEO_PREAMBLE - W_VIDEO_GUARD_BAND);
+        *p++ = sync_h1;
+        *p++ = HSTX_CMD_NOP;
+
+        // Video Preamble (8 pixels)
+        *p++ = HSTX_CMD_RAW_REPEAT | W_VIDEO_PREAMBLE;
+        *p++ = video_preamble;
+        *p++ = HSTX_CMD_NOP;
+
+        // Video Guard Band (2 pixels)
+        *p++ = HSTX_CMD_RAW_REPEAT | W_VIDEO_GUARD_BAND;
+        *p++ = VIDEO_GUARD_BAND;
+
+        // Active video pixels
+        *p++ = HSTX_CMD_TMDS | MODE_H_ACTIVE_PIXELS;
+    } else {
+        *p++ = HSTX_CMD_RAW_REPEAT | (MODE_H_BACK_PORCH + MODE_H_ACTIVE_PIXELS);
+        *p++ = sync_h1;
+        *p++ = HSTX_CMD_NOP;
+    }
+    return (uint32_t)(p - buf);
+}
+
+typedef struct {
+    bool vsync_active;
+    bool front_porch;
+    bool back_porch;
+    bool active_video;
+    bool send_acr;
+    uint32_t active_line;
+} scanline_state_t;
+
+static inline void __not_in_flash_func(get_scanline_state)(uint32_t v_scanline, scanline_state_t *state)
+{
+    state->vsync_active = (v_scanline >= MODE_V_FRONT_PORCH && v_scanline < (MODE_V_FRONT_PORCH + MODE_V_SYNC_WIDTH));
+    state->front_porch = (v_scanline < MODE_V_FRONT_PORCH);
+    state->back_porch = (v_scanline >= MODE_V_FRONT_PORCH + MODE_V_SYNC_WIDTH &&
+                         v_scanline < MODE_V_FRONT_PORCH + MODE_V_SYNC_WIDTH + MODE_V_BACK_PORCH);
+    state->active_video = (!state->vsync_active && !state->front_porch && !state->back_porch);
+
+    state->send_acr = (v_scanline >= (MODE_V_FRONT_PORCH + MODE_V_SYNC_WIDTH) &&
+                       v_scanline < (MODE_V_TOTAL_LINES - MODE_V_ACTIVE_LINES) && (v_scanline % 4 == 0));
+
+    if (state->active_video) {
+        state->active_line = v_scanline - (MODE_V_TOTAL_LINES - MODE_V_ACTIVE_LINES);
+    } else {
+        state->active_line = 0;
+    }
+}
+
+static inline void __not_in_flash_func(video_output_handle_vsync)(dma_channel_hw_t *ch, uint32_t v_scanline)
+{
+    if (dvi_mode) {
+        // Pure DVI: simple vsync line without Data Islands
+        ch->read_addr = (uintptr_t)vblank_line_vsync_on;
+        ch->transfer_count = count_of(vblank_line_vsync_on);
+        if (v_scanline == MODE_V_FRONT_PORCH) {
+            video_frame_count++;
+            if (vsync_callback)
+                vsync_callback();
+        } 
+    } else {
+        if (v_scanline == MODE_V_FRONT_PORCH) {
+            ch->read_addr = (uintptr_t)vblank_acr_vsync_on;
+            ch->transfer_count = vblank_acr_vsync_on_len;
+            video_frame_count++;
+            if (vsync_callback)
+                vsync_callback();
+        } else {
+            ch->read_addr = (uintptr_t)vblank_infoframe_vsync_on;
+            ch->transfer_count = vblank_infoframe_vsync_on_len;
+        }
+    }
+}
+
+static inline void __not_in_flash_func(video_output_handle_active_start)(dma_channel_hw_t *ch, uint32_t v_scanline, uint32_t active_line, bool dma_pong)
+{
+    uint32_t *dst32 = (uint32_t *)line_buffer;
+
+    if (scanline_callback) {
+        scanline_callback(v_scanline, active_line, dst32);
+    } else {
+        // If no callback, just output black pixels
+        for (uint32_t i = 0; i < MODE_H_ACTIVE_PIXELS / 2; i++) {
+            dst32[i] = 0;
+        }
+    }
+
+    if (dvi_mode) {
+        // Pure DVI: simple active line without Data Islands
+        ch->read_addr = (uintptr_t)vactive_line_dvi;
+        ch->transfer_count = count_of(vactive_line_dvi);
+    } else {
+        uint32_t *buf = dma_pong ? vactive_di_ping : vactive_di_pong;
+        const uint32_t *di_words = hstx_di_queue_get_audio_packet();
+        if (di_words) {
+            vactive_di_len = build_line_with_di(buf, di_words, false, true);
+            ch->read_addr = (uintptr_t)buf;
+            ch->transfer_count = vactive_di_len;
+        } else {
+            ch->read_addr = (uintptr_t)vactive_di_null;
+            ch->transfer_count = vactive_di_null_len;
+        }
+    }
+}
+
+static inline void __not_in_flash_func(video_output_handle_blanking)(dma_channel_hw_t *ch, uint32_t v_scanline, bool send_acr, bool dma_pong)
+{
+    if (dvi_mode) {
+        // Pure DVI: simple blanking line without Data Islands
+        (void)send_acr;
+        (void)dma_pong;
+        (void)v_scanline;
+        ch->read_addr = (uintptr_t)vblank_line_vsync_off;
+        ch->transfer_count = count_of(vblank_line_vsync_off);
+    } else {
+        if (send_acr) {
+            ch->read_addr = (uintptr_t)vblank_acr_vsync_off;
+            ch->transfer_count = vblank_acr_vsync_off_len;
+        } else if (v_scanline == 0) {
+            ch->read_addr = (uintptr_t)vblank_avi_infoframe;
+            ch->transfer_count = vblank_avi_infoframe_len;
+        } else {
+            const uint32_t *di_words = hstx_di_queue_get_audio_packet();
+            if (di_words) {
+                uint32_t *buf = dma_pong ? vblank_di_ping : vblank_di_pong;
+                vblank_di_len = build_line_with_di(buf, di_words, false, false);
+                ch->read_addr = (uintptr_t)buf;
+                ch->transfer_count = vblank_di_len;
+            } else {
+                ch->read_addr = (uintptr_t)vblank_di_null;
+                ch->transfer_count = vblank_di_null_len;
+            }
+        }
+    }
+}
+
+static inline void __not_in_flash_func(video_output_handle_active_data)(dma_channel_hw_t *ch)
+{
+    ch->read_addr = (uintptr_t)line_buffer;
+    ch->transfer_count = (MODE_H_ACTIVE_PIXELS * sizeof(uint16_t)) / sizeof(uint32_t);
+}
+
+// ============================================================================
+// DMA IRQ Handler
+// ============================================================================
+
+void __not_in_flash_func(dma_irq_handler)(void)
+{
+    uint32_t ch_num = dma_pong ? DMACH_PONG : DMACH_PING;
+    dma_channel_hw_t *ch = &dma_hw->ch[ch_num];
+    dma_hw->intr = 1U << ch_num;
+    dma_pong = !dma_pong;
+
+    // Advance audio/data-island scheduler exactly once per scanline (HDMI mode only)
+    if (!dvi_mode && !vactive_cmdlist_posted) {
+        hstx_di_queue_tick();
+    }
+
+    scanline_state_t state;
+    get_scanline_state(v_scanline, &state);
+
+    if (state.vsync_active) {
+        video_output_handle_vsync(ch, v_scanline);
+    } else if (state.active_video && !vactive_cmdlist_posted) {
+        video_output_handle_active_start(ch, v_scanline, state.active_line, dma_pong);
+        vactive_cmdlist_posted = true;
+    } else if (state.active_video && vactive_cmdlist_posted) {
+        video_output_handle_active_data(ch);
+        vactive_cmdlist_posted = false;
+    } else {
+        video_output_handle_blanking(ch, v_scanline, state.send_acr, dma_pong);
+    }
+    if (!vactive_cmdlist_posted)
+        v_scanline = (v_scanline + 1) % MODE_V_TOTAL_LINES;
+}
+
+// ============================================================================
+// Public Interface
+// ============================================================================
+
+// ACR N/CTS lookup for 25.2 MHz pixel clock (HDMI spec Table 7-1/7-2)
+static void get_acr_params(uint32_t sample_rate, uint32_t *n, uint32_t *cts)
+{
+    switch (sample_rate) {
+        case 32000:
+            *n = 4096;
+            *cts = 25200;
+            break;
+        case 44100:
+            *n = 6272;
+            *cts = 28000;
+            break;
+        case 48000:
+            *n = 6144;
+            *cts = 25200;
+            break;
+        case 88200:
+            *n = 12544;
+            *cts = 28000;
+            break;
+        case 96000:
+            *n = 12288;
+            *cts = 25200;
+            break;
+        case 176400:
+            *n = 25088;
+            *cts = 28000;
+            break;
+        case 192000:
+            *n = 24576;
+            *cts = 25200;
+            break;
+        default:
+            *n = 6144;
+            *cts = 25200;
+            break; // fallback to 48kHz
+    }
+}
+
+static void configure_audio_packets(uint32_t sample_rate)
+{
+    hstx_di_queue_set_sample_rate(sample_rate);
+
+    hstx_packet_t packet;
+    hstx_data_island_t island;
+
+    uint32_t acr_n;
+    uint32_t acr_cts;
+    get_acr_params(sample_rate, &acr_n, &acr_cts);
+    hstx_packet_set_acr(&packet, acr_n, acr_cts);
+    hstx_encode_data_island(&island, &packet, true, true);
+    vblank_acr_vsync_on_len = build_line_with_di(vblank_acr_vsync_on, island.words, true, false);
+    hstx_encode_data_island(&island, &packet, false, true);
+    vblank_acr_vsync_off_len = build_line_with_di(vblank_acr_vsync_off, island.words, false, false);
+
+    hstx_packet_set_audio_infoframe(&packet, sample_rate, 2, 16);
+    hstx_encode_data_island(&island, &packet, true, true);
+    vblank_infoframe_vsync_on_len = build_line_with_di(vblank_infoframe_vsync_on, island.words, true, false);
+    hstx_encode_data_island(&island, &packet, false, true);
+    vblank_infoframe_vsync_off_len = build_line_with_di(vblank_infoframe_vsync_off, island.words, false, false);
+}
+
+void video_output_init(uint16_t width, uint16_t height)
+{
+    frame_width = width;
+    frame_height = height;
+
+    // Configure clk_hstx for the current video mode
+    // After set_sys_clock_khz(), clk_hstx needs to be reconfigured
+#ifndef NOHSTXCLOCK
+    uint32_t sys_freq = clock_get_hz(clk_sys);
+
+    clock_configure_int_divider(clk_hstx,
+                                0, // No glitchless mux
+                                CLOCKS_CLK_HSTX_CTRL_AUXSRC_VALUE_CLK_SYS, sys_freq, MODE_HSTX_CLK_DIV);
+#endif
+    // Claim DMA channels for HSTX (channels 0 and 1)
+    dma_channel_claim(DMACH_PING);
+    dma_channel_claim(DMACH_PONG);
+
+    // Initialize HDMI audio packets (default 48kHz)
+    configure_audio_packets(48000);
+
+    hstx_packet_t packet;
+    hstx_data_island_t island;
+
+#ifdef VIDEO_MODE_320x240
+    // PR=3 (4x repetition) for 1280x240 representing 320x240
+    hstx_packet_set_avi_infoframe(&packet, 1, 3);
+#else
+    hstx_packet_set_avi_infoframe(&packet, 1, 0);
+#endif
+    hstx_encode_data_island(&island, &packet, false, true);
+    vblank_avi_infoframe_len = build_line_with_di(vblank_avi_infoframe, island.words, false, false);
+
+    vblank_di_null_len = build_line_with_di(vblank_di_null, hstx_get_null_data_island(false, true), false, false);
+    vactive_di_null_len = build_line_with_di(vactive_di_null, hstx_get_null_data_island(false, true), false, true);
+
+    vblank_di_len = build_line_with_di(vblank_di_ping, hstx_get_null_data_island(false, true), false, false);
+    memcpy(vblank_di_pong, vblank_di_ping, sizeof(vblank_di_ping));
+}
+
+void video_output_set_background_task(video_output_task_fn task)
+{
+    background_task = task;
+}
+
+bool video_output_get_dvi_mode(void)
+{
+    return dvi_mode;
+}
+
+void video_output_set_dvi_mode(bool enabled)
+{
+    dvi_mode = enabled;
+}
+
+void video_output_set_scanline_callback(video_output_scanline_cb_t cb)
+{
+    scanline_callback = cb;
+}
+
+void video_output_set_vsync_callback(video_output_vsync_cb_t cb)
+{
+    vsync_callback = cb;
+}
+
+void video_output_core1_run(void)
+{
+#if 0
+    // HSTX Hardware Setup
+    hstx_ctrl_hw->expand_tmds = 4 << HSTX_CTRL_EXPAND_TMDS_L2_NBITS_LSB | 8 << HSTX_CTRL_EXPAND_TMDS_L2_ROT_LSB |
+                                5 << HSTX_CTRL_EXPAND_TMDS_L1_NBITS_LSB | 3 << HSTX_CTRL_EXPAND_TMDS_L1_ROT_LSB |
+                                4 << HSTX_CTRL_EXPAND_TMDS_L0_NBITS_LSB | 13 << HSTX_CTRL_EXPAND_TMDS_L0_ROT_LSB;
+
+    hstx_ctrl_hw->expand_shift =
+        2 << HSTX_CTRL_EXPAND_SHIFT_ENC_N_SHIFTS_LSB | 16 << HSTX_CTRL_EXPAND_SHIFT_ENC_SHIFT_LSB |
+        1 << HSTX_CTRL_EXPAND_SHIFT_RAW_N_SHIFTS_LSB | 0 << HSTX_CTRL_EXPAND_SHIFT_RAW_SHIFT_LSB;
+#else
+     // Configure HSTX's TMDS encoder for RGB555
+    hstx_ctrl_hw->expand_tmds =
+        29 << HSTX_CTRL_EXPAND_TMDS_L0_ROT_LSB |
+        4 << HSTX_CTRL_EXPAND_TMDS_L0_NBITS_LSB |
+        2 << HSTX_CTRL_EXPAND_TMDS_L1_ROT_LSB |
+        4 << HSTX_CTRL_EXPAND_TMDS_L1_NBITS_LSB |
+        7 << HSTX_CTRL_EXPAND_TMDS_L2_ROT_LSB |
+        4 << HSTX_CTRL_EXPAND_TMDS_L2_NBITS_LSB;
+    // Pixels (TMDS) come in 4 8-bit chunks. Control symbols (RAW) are an
+    // entire 32-bit word.
+    hstx_ctrl_hw->expand_shift =
+        2 << HSTX_CTRL_EXPAND_SHIFT_ENC_N_SHIFTS_LSB |
+        16 << HSTX_CTRL_EXPAND_SHIFT_ENC_SHIFT_LSB |
+        1 << HSTX_CTRL_EXPAND_SHIFT_RAW_N_SHIFTS_LSB |
+        0 << HSTX_CTRL_EXPAND_SHIFT_RAW_SHIFT_LSB;
+
+#endif
+    hstx_ctrl_hw->csr = 0;
+    hstx_ctrl_hw->csr = HSTX_CTRL_CSR_EXPAND_EN_BITS | (uint32_t)MODE_HSTX_CSR_CLKDIV << HSTX_CTRL_CSR_CLKDIV_LSB |
+                        5U << HSTX_CTRL_CSR_N_SHIFTS_LSB | 2U << HSTX_CTRL_CSR_SHIFT_LSB | HSTX_CTRL_CSR_EN_BITS;
+
+    int clk_bit_p = HSTX_BIT_FROM_GPIO(GPIOHSTXCK);
+    int clk_bit_n = GPIOHSTXINVERTED ? (clk_bit_p - 1) : (clk_bit_p + 1);
+    hstx_ctrl_hw->bit[clk_bit_p] = HSTX_CTRL_BIT0_CLK_BITS;
+    hstx_ctrl_hw->bit[clk_bit_n] = HSTX_CTRL_BIT0_CLK_BITS | HSTX_CTRL_BIT0_INV_BITS;
+    // hstx_ctrl_hw->bit[0] = HSTX_CTRL_BIT0_CLK_BITS | HSTX_CTRL_BIT0_INV_BITS;
+    // hstx_ctrl_hw->bit[1] = HSTX_CTRL_BIT0_CLK_BITS;
+    for (uint lane = 0; lane < 3; ++lane) {
+          // For each TMDS lane, assign it to the correct GPIO pair based on the desired pinout:
+
+        // lane_to_output_bit Array:
+        // The lane_to_output_bit array specifies which HSTX output bits are used for each TMDS lane, based on the GPIOHSTXDx defines:
+
+        // Index 0: TMDS lane D0 (data lane 0) → GPIOHSTXD0 (D0+), (GPIOHSTXD0 + GPIOHSTXINVERTED ? -1 : +1) (D0-)
+        // Index 1: TMDS lane D1 (data lane 1) → GPIOHSTXD1 (D1+), (GPIOHSTXD1 + GPIOHSTXINVERTED ? -1 : +1) (D1-)
+        // Index 2: TMDS lane D2 (data lane 2) → GPIOHSTXD2 (D2+), (GPIOHSTXD2 + GPIOHSTXINVERTED ? -1 : +1) (D2-)
+
+        // Example default mapping for Adafruit Metro RP2350:
+        // D0+ = GPIOHSTXD0 (default: GPIO18), D0- = GPIOHSTXD0 + 1 (default: GPIO19)
+        // D1+ = GPIOHSTXD1 (default: GPIO16), D1- = GPIOHSTXD1 + 1 (default: GPIO17)
+        // D2+ = GPIOHSTXD2 (default: GPIO12), D2- = GPIOHSTXD2 + 1 (default: GPIO13)
+        // If GPIOHSTXINVERTED is set, D- is D+ - 1 instead of D+ + 1
+        // See https://learn.adafruit.com/adafruit-metro-rp2350/pinouts#hstx-connector-3193107
+        static const int lane_to_output_bit[3] = {
+            HSTX_BIT_FROM_GPIO(GPIOHSTXD0),
+            HSTX_BIT_FROM_GPIO(GPIOHSTXD1),
+            HSTX_BIT_FROM_GPIO(GPIOHSTXD2)};
+        int bit = lane_to_output_bit[lane];
+        int bit_dn = GPIOHSTXINVERTED ? (bit - 1) : (bit + 1);
+        // Output even bits during first half of each HSTX cycle, and odd bits
+        // during second half. The shifter advances by two bits each cycle.
+        uint32_t lane_data_sel_bits =
+            (lane * 10) << HSTX_CTRL_BIT0_SEL_P_LSB |
+            (lane * 10 + 1) << HSTX_CTRL_BIT0_SEL_N_LSB;
+        // The two halves of each pair get identical data, but one pin is inverted.
+        hstx_ctrl_hw->bit[bit] = lane_data_sel_bits;
+        hstx_ctrl_hw->bit[bit_dn] = lane_data_sel_bits | HSTX_CTRL_BIT0_INV_BITS;
+    }
+
+    // Set GPIO 12-19 to HSTX function (function 0 on RP2350)
+    for (int i = 12; i <= 19; ++i)
+        gpio_set_function(i, 0);
+
+    // DMA Setup
+    dma_channel_config c = dma_channel_get_default_config(DMACH_PING);
+    channel_config_set_chain_to(&c, DMACH_PONG);
+    channel_config_set_dreq(&c, DREQ_HSTX);
+    dma_channel_configure(DMACH_PING, &c, &hstx_fifo_hw->fifo, vblank_line_vsync_off, count_of(vblank_line_vsync_off),
+                          false);
+
+    c = dma_channel_get_default_config(DMACH_PONG);
+    channel_config_set_chain_to(&c, DMACH_PING);
+    channel_config_set_dreq(&c, DREQ_HSTX);
+    dma_channel_configure(DMACH_PONG, &c, &hstx_fifo_hw->fifo, vblank_line_vsync_off, count_of(vblank_line_vsync_off),
+                          false);
+
+    dma_hw->ints0 = (1U << DMACH_PING) | (1U << DMACH_PONG);
+    dma_hw->inte0 = (1U << DMACH_PING) | (1U << DMACH_PONG);
+    irq_set_exclusive_handler(DMA_IRQ_0, dma_irq_handler);
+    irq_set_priority(DMA_IRQ_0, 0);
+    irq_set_enabled(DMA_IRQ_0, true);
+
+    bus_ctrl_hw->priority = BUSCTRL_BUS_PRIORITY_DMA_W_BITS | BUSCTRL_BUS_PRIORITY_DMA_R_BITS;
+    dma_channel_start(DMACH_PING);
+
+    while (1) {
+        if (background_task) {
+            background_task();
+        }
+        tight_loop_contents();
+    }
+}
+
+void pico_hdmi_set_audio_sample_rate(uint32_t sample_rate)
+{
+    configure_audio_packets(sample_rate);
+}
+
+
+
+

--- a/drivers/pico_hdmi/backup/video_output.h
+++ b/drivers/pico_hdmi/backup/video_output.h
@@ -1,0 +1,139 @@
+#ifndef VIDEO_OUTPUT_H
+#define VIDEO_OUTPUT_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+// ============================================================================
+// Video Output Configuration
+// ============================================================================
+
+// Video mode selection (define VIDEO_MODE_320x240 before including this header)
+#ifdef VIDEO_MODE_320x240
+
+// 1280x240 @ 60Hz - True 240p (Quad Clock Rate)
+// Pixel Clock: 25.2 MHz (15kHz scan rate)
+// H_TOTAL = 1600 pixels, V_TOTAL = 262 lines
+// Active: 1280 (320x4), Front: 32 (8x4), Sync: 192 (48x4), Back: 96 (24x4)
+#define MODE_H_FRONT_PORCH 32
+#define MODE_H_SYNC_WIDTH 192
+#define MODE_H_BACK_PORCH 96
+#define MODE_H_ACTIVE_PIXELS 1280
+
+#define MODE_V_FRONT_PORCH 4
+#define MODE_V_SYNC_WIDTH 4
+#define MODE_V_BACK_PORCH 14
+#define MODE_V_ACTIVE_LINES 240
+
+// HSTX clock divider: clk_sys / 1 = 126 MHz -> 25.2 MHz pixel clock (with CSR_CLKDIV=5)
+#define MODE_HSTX_CLK_DIV 1
+#define MODE_HSTX_CSR_CLKDIV 5
+
+#else
+
+// 640x480 @ 60Hz (VIC 1) - Default mode
+// Pixel clock: 25.2 MHz
+#define MODE_H_FRONT_PORCH 16
+#define MODE_H_SYNC_WIDTH 96
+#define MODE_H_BACK_PORCH 48
+#define MODE_H_ACTIVE_PIXELS 640
+
+#define MODE_V_FRONT_PORCH 10
+#define MODE_V_SYNC_WIDTH 2
+#define MODE_V_BACK_PORCH 33
+#define MODE_V_ACTIVE_LINES 480
+
+// HSTX clock divider: 1 (no division)
+#define MODE_HSTX_CLK_DIV 1
+#define MODE_HSTX_CSR_CLKDIV 5
+
+#endif
+
+#define MODE_H_TOTAL_PIXELS (MODE_H_FRONT_PORCH + MODE_H_SYNC_WIDTH + MODE_H_BACK_PORCH + MODE_H_ACTIVE_PIXELS)
+#define MODE_V_TOTAL_LINES (MODE_V_FRONT_PORCH + MODE_V_SYNC_WIDTH + MODE_V_BACK_PORCH + MODE_V_ACTIVE_LINES)
+
+// Frame dimensions (set via video_output_init)
+extern uint16_t frame_width;
+extern uint16_t frame_height;
+
+// ============================================================================
+// Global State
+// ============================================================================
+
+extern volatile uint32_t video_frame_count;
+
+// ============================================================================
+// Public Interface
+// ============================================================================
+
+typedef void (*video_output_task_fn)(void);
+typedef void (*video_output_vsync_cb_t)(void);
+
+/**
+ * Scanline Callback:
+ * Called by the video output system when it needs pixel data for a scanline.
+ *
+ * @param v_scanline The current vertical scanline (0 to MODE_V_TOTAL_LINES - 1)
+ * @param active_line The current active video line (0 to MODE_V_ACTIVE_LINES - 1),
+ *                    only valid if active_video is true.
+ * @param line_buffer Buffer to fill with MODE_H_ACTIVE_PIXELS RGB565 pixels (packed as uint32_t pairs).
+ *                    The buffer MUST be filled with (MODE_H_ACTIVE_PIXELS / 2) uint32_t words.
+ *                    - 640x480 mode: 640 pixels = 320 uint32_t words
+ *                    - 320x240 mode: 1280 pixels = 640 uint32_t words (4x pixel repetition)
+ */
+typedef void (*video_output_scanline_cb_t)(uint32_t v_scanline, uint32_t active_line, uint32_t *line_buffer);
+
+/**
+ * Initialize HSTX and DMA for video output.
+ * @param width Framebuffer width in pixels (e.g., 320)
+ * @param height Framebuffer height in pixels (e.g., 240)
+ */
+void video_output_init(uint16_t width, uint16_t height);
+
+/**
+ * Register the scanline callback.
+ */
+void video_output_set_scanline_callback(video_output_scanline_cb_t cb);
+
+/**
+ * Register a VSYNC callback, called once per frame at the start of vertical sync.
+ */
+void video_output_set_vsync_callback(video_output_vsync_cb_t cb);
+
+/**
+ * Register a background task to run in the Core 1 loop.
+ * This is typically used for audio processing.
+ */
+void video_output_set_background_task(video_output_task_fn task);
+
+/**
+ * Get DVI mode status.
+ * @return true if DVI mode (no HDMI audio), false if HDMI mode
+ */
+bool video_output_get_dvi_mode(void);
+
+/**
+ * Set DVI mode.
+ * When enabled, disables all HDMI Data Islands (no audio output).
+ * Some monitors have trouble syncing with HDMI Data Islands.
+ * Default: false (HDMI mode with audio).
+ * @param enabled true for DVI mode, false for HDMI mode with audio
+ */
+void video_output_set_dvi_mode(bool enabled);
+
+/**
+ * Core 1 entry point for video output.
+ * This function does not return.
+ */
+void video_output_core1_run(void);
+
+/**
+ * Reconfigure HDMI audio for a different sample rate.
+ * Updates ACR, Audio InfoFrame, and packet timing.
+ * Can be called after video_output_init() to override the default 48kHz.
+ * @param sample_rate Audio sample rate in Hz (e.g. 32000, 44100, 48000)
+ */
+void pico_hdmi_set_audio_sample_rate(uint32_t sample_rate);
+
+
+#endif // VIDEO_OUTPUT_H

--- a/drivers/pico_hdmi/hstx.c
+++ b/drivers/pico_hdmi/hstx.c
@@ -4,7 +4,7 @@
 #include "stdio.h"
 // Custom changes
 volatile bool HSTX_vblank = false;
-static uint8_t FRAMEBUFFER[(MODE_H_ACTIVE_PIXELS / 2) * (MODE_V_ACTIVE_LINES / 2) * 2];
+static uint8_t FRAMEBUFFER[(MODE_H_ACTIVE_PIXELS / 2) * (MODE_V_ACTIVE_LINES / 2) * 2] __attribute__((aligned(4)));
 // uint16_t ALIGNED HDMIlines[2][MODE_H_ACTIVE_PIXELS] = {0};
 static uint8_t *WriteBuf = FRAMEBUFFER;
 static uint8_t *DisplayBuf = FRAMEBUFFER;
@@ -75,72 +75,45 @@ void __not_in_flash_func(hstx_vsync_callbackfunc)(void)
 }
 void __not_in_flash_func(scanline_callbackfunc)(uint32_t v_scanline, uint32_t active_line, uint32_t *buff)
 {
-    uint16_t *p = (uint16_t *)buff;
-    int last_line = 2, load_line, line_to_load, Line_dup;
-    load_line = v_scanline - (MODE_V_TOTAL_LINES - MODE_V_ACTIVE_LINES);
-    Line_dup = load_line >> 1;
-    if (load_line >= 0 && load_line < MODE_V_ACTIVE_LINES)
-    {
-        HSTX_vblank = false;
-        __dmb();
+    int load_line = v_scanline - (MODE_V_TOTAL_LINES - MODE_V_ACTIVE_LINES);
+    if (load_line < 0 || load_line >= MODE_V_ACTIVE_LINES)
+        return;
 
-        for (int i = 0; i < MODE_H_ACTIVE_PIXELS / 2; i++)
-        {
-            uint8_t *d = &DisplayBuf[(Line_dup)*MODE_H_ACTIVE_PIXELS + i * 2];
-            int c = *d++;
-            c |= ((*d++) << 8);
-#if 1
-            // Apply CRT scanline effect for RGB555: darken every other line
-            if (load_line & 1 && enableScanLines)
-            { // Odd lines = scanlines
-                int r = (c >> 10) & 0x1F;
-                int g = (c >> 5) & 0x1F;
-                int b = c & 0x1F;
-                r = r >> 1;
-                g = g >> 1;
-                b = b >> 1;
-                c = (r << 10) | (g << 5) | b;
-            }
-            // tried vertical and pixel-grid scanlines
-            // but this is probably too much for the RP2350:
-#else
-            // Horizontal scanlines: darken every other line
-            if (scanlineMode == 1 && (load_line & 1))
-            {
-                int r = (c >> 10) & 0x1F;
-                int g = (c >> 5) & 0x1F;
-                int b = c & 0x1F;
-                r = r >> 1;
-                g = g >> 1;
-                b = b >> 1;
-                c = (r << 10) | (g << 5) | b;
-            }
-            // Vertical scanlines: darken every other pixel column
-            else if (scanlineMode == 2 && (i & 1))
-            {
-                int r = (c >> 10) & 0x1F;
-                int g = (c >> 5) & 0x1F;
-                int b = c & 0x1F;
-                r = r >> 1;
-                g = g >> 1;
-                b = b >> 1;
-                c = (r << 10) | (g << 5) | b;
-            }
-            // Pixel-grid: darken every other line and every other pixel column
-            else if (scanlineMode == 3 && ((load_line & 1) || (i & 1)))
-            {
-                int r = (c >> 10) & 0x1F;
-                int g = (c >> 5) & 0x1F;
-                int b = c & 0x1F;
-                r = r >> 1;
-                g = g >> 1;
-                b = b >> 1;
-                c = (r << 10) | (g << 5) | b;
-            }
+    HSTX_vblank = false;
+    __dmb();
 
-#endif
-            *p++ = c;
-            *p++ = c;
+    // Source row (320 pixels RGB555 = 640 bytes = 160 uint32_t) with vertical
+    // line doubling (two output scanlines share one framebuffer row).
+    int Line_dup = load_line >> 1;
+    const uint32_t *src = (const uint32_t *)&DisplayBuf[Line_dup * MODE_H_ACTIVE_PIXELS];
+    uint32_t *dst = buff;
+    const uint32_t iters = MODE_H_ACTIVE_PIXELS / 4; // 2 src pixels in, 4 dst pixels out
+
+    // Darken-both-halves mask for a 32-bit word holding two RGB555 pixels.
+    // Per 5-bit component, divide-by-two is (c & 0x1E) >> 1, i.e. mask off
+    // the LSB and shift. Applied to both pixels in parallel with one AND+shift.
+    //   r: bits 10..14   mask 0x7800 -> 0x7800 with LSB cleared = 0x7800
+    //   g: bits  5.. 9   mask 0x03E0 -> LSB cleared             = 0x03C0
+    //   b: bits  0.. 4   mask 0x001F -> LSB cleared             = 0x001E
+    // Combined per pixel = 0x7BDE; packed twice = 0x7BDE7BDE.
+    // (Faster than a 32-entry lookup table: no memory access, single cycle.)
+    const uint32_t DARKEN_MASK = 0x7BDE7BDEu;
+
+    if ((load_line & 1) && enableScanLines) {
+        for (uint32_t i = 0; i < iters; i++) {
+            uint32_t pair = (src[i] & DARKEN_MASK) >> 1; // darken both pixels
+            uint32_t px0 = pair & 0xFFFFu;
+            uint32_t px1 = pair >> 16;
+            *dst++ = px0 | (px0 << 16); // duplicate pixel 0
+            *dst++ = px1 | (px1 << 16); // duplicate pixel 1
+        }
+    } else {
+        for (uint32_t i = 0; i < iters; i++) {
+            uint32_t pair = src[i];
+            uint32_t px0 = pair & 0xFFFFu;
+            uint32_t px1 = pair >> 16;
+            *dst++ = px0 | (px0 << 16);
+            *dst++ = px1 | (px1 << 16);
         }
     }
 }

--- a/drivers/pico_hdmi/hstx.c
+++ b/drivers/pico_hdmi/hstx.c
@@ -27,6 +27,32 @@ void hstx_waitForVSync(void)
         tight_loop_contents();
     }
 }
+
+void hstx_paceFrame(bool init)
+{
+    // Slack-aware 60fps pacing. Waits for the next vsync only if we haven't
+    // already passed our target frame. If the caller overran a frame, resync
+    // to the current counter instead of stalling another ~16.6ms, which would
+    // otherwise harmonic-lock the loop to 30fps.
+    static uint32_t target_frame = 0;
+    if (init)
+    {
+        target_frame = video_frame_count;
+    }
+    target_frame++;
+    uint32_t current = video_frame_count;
+    if ((int32_t)(current - target_frame) < 0)
+    {
+        while (video_frame_count != target_frame)
+        {
+            tight_loop_contents();
+        }
+    }
+    else
+    {
+        target_frame = current;
+    }
+}
 uint8_t *hstx_getframebuffer(void)
 {
     // Return the pointer to the framebuffer

--- a/drivers/pico_hdmi/hstx.h
+++ b/drivers/pico_hdmi/hstx.h
@@ -17,6 +17,7 @@ extern volatile bool HSTX_vblank;
 #endif
 uint32_t hstx_getframecounter(void);
 void hstx_waitForVSync(void);
+void hstx_paceFrame(bool init);
 uint8_t *hstx_getframebuffer(void);
 void hstx_setScanLines(int enable);
 uint16_t *hstx_getlineFromFramebuffer(int scanline);

--- a/drivers/pico_hdmi/video_output.c
+++ b/drivers/pico_hdmi/video_output.c
@@ -13,10 +13,16 @@
 #include "hardware/structs/clocks.h"
 #include "hardware/structs/hstx_ctrl.h"
 #include "hardware/structs/hstx_fifo.h"
+#include "hardware/structs/pll.h"
 
 #include <math.h>
 #include <string.h>
 #include "hstx.h"
+#include "stdio.h"
+
+#ifndef HSTX_DEBUG
+#define HSTX_DEBUG 0
+#endif
 
 // ============================================================================
 // DVI/HSTX Constants
@@ -66,7 +72,10 @@
 uint16_t frame_width = 0;
 uint16_t frame_height = 0;
 volatile uint32_t video_frame_count = 0;
+
+#if HSTX_DEBUG
 static volatile uint32_t irq_count = 0;
+#endif
 
 // DVI mode: when true, disables all HDMI Data Islands (pure DVI output, no audio)
 // Some monitors have trouble syncing with HDMI Data Islands
@@ -91,6 +100,7 @@ static video_output_vsync_cb_t vsync_callback = NULL;
 // to request a full HSTX+DMA reset. Consumed in video_output_core1_run().
 static volatile bool resync_requested = false;
 static volatile int resync_count = 0;
+static volatile int soft_recovery_count = 0;
 #define DMACH_PING 0
 #define DMACH_PONG 1
 
@@ -386,7 +396,9 @@ static inline void __not_in_flash_func(video_output_handle_active_data)(dma_chan
 
 void __not_in_flash_func(dma_irq_handler)(void)
 {
+    #if HSTX_DEBUG
     irq_count++;
+    #endif
     uint32_t ch_num = dma_pong ? DMACH_PONG : DMACH_PING;
     dma_channel_hw_t *ch = &dma_hw->ch[ch_num];
     dma_hw->intr = 1U << ch_num;
@@ -655,57 +667,126 @@ void video_output_core1_run(void)
     // time_us_32 wraps every ~71 min, irrelevant for the 500 ms window and
     // ~10x cheaper than time_us_64 in a hot loop.
     #define VIDEO_OUTPUT_WATCHDOG_US 500000u
+
+    // Rate-limit watchdog: no real display exceeds ~65 Hz vertical. If
+    // video_frame_count advances above this, HSTX has fallen into the
+    // overspeed state (observed ~158 Hz). First attempt a soft recovery
+    // (toggle HSTX CSR.EN) to clear any expander shadow state without
+    // disturbing DMA. If the next 1-second window is still over-rate,
+    // fall back to a full hstx_resync().
+    #define VIDEO_OUTPUT_OVERRATE_FPS 75u
     uint32_t last_frame_us = time_us_32();
     uint32_t last_frame_count_seen = video_frame_count;
-
+    uint32_t overrate_last_us = last_frame_us;
+    uint32_t overrate_last_frames = last_frame_count_seen;
+    bool soft_recovery_attempted = false;
+#if HSTX_DEBUG
     // 1 Hz rate-diagnostic baseline
     uint32_t rate_last_us = last_frame_us;
     uint32_t rate_last_frames = last_frame_count_seen;
     uint32_t rate_last_irqs = irq_count;
-
+#endif
     while (1) {
-        uint32_t now = time_us_32();
-        uint32_t current_count = video_frame_count;
-        if (current_count != last_frame_count_seen) {
-            last_frame_count_seen = current_count;
-            last_frame_us = now;
+        if (dvi_mode)
+        {
+            uint32_t now = time_us_32();
+            uint32_t current_count = video_frame_count;
+            if (current_count != last_frame_count_seen)
+            {
+                last_frame_count_seen = current_count;
+                last_frame_us = now;
+            }
+#if HSTX_DEBUG
+            if ((now - rate_last_us) >= 1000000u)
+            {
+                uint32_t d_us = now - rate_last_us;
+                uint32_t d_frames = current_count - rate_last_frames;
+                uint32_t d_irqs = irq_count - rate_last_irqs;
+                printf("video rate: %lu frames/s, %lu irqs/s (dvi=%d) clk_sys=%lu clk_hstx=%lu csr=%08lx soft=%d hard=%d\n",
+                       (unsigned long)((uint64_t)d_frames * 1000000u / d_us),
+                       (unsigned long)((uint64_t)d_irqs * 1000000u / d_us),
+                       dvi_mode ? 1 : 0,
+                       (unsigned long)clock_get_hz(clk_sys),
+                       (unsigned long)clock_get_hz(clk_hstx),
+                       (unsigned long)hstx_ctrl_hw->csr,
+                       soft_recovery_count,
+                       resync_count);
+                printf("  hstx_div=%08lx exp_sh=%08lx exp_tmds=%08lx ping_ctrl=%08lx pong_ctrl=%08lx\n",
+                       (unsigned long)clocks_hw->clk[clk_hstx].div,
+                       (unsigned long)hstx_ctrl_hw->expand_shift,
+                       (unsigned long)hstx_ctrl_hw->expand_tmds,
+                       (unsigned long)dma_hw->ch[DMACH_PING].al1_ctrl,
+                       (unsigned long)dma_hw->ch[DMACH_PONG].al1_ctrl);
+                uint32_t fc_sys_khz = frequency_count_khz(CLOCKS_FC0_SRC_VALUE_CLK_SYS);
+                uint32_t fc_hstx_khz = frequency_count_khz(CLOCKS_FC0_SRC_VALUE_CLK_HSTX);
+                printf("  sys_ctrl=%08lx sys_div=%08lx pll_fbdiv=%lu pll_prim=%08lx fc_sys=%lu kHz fc_hstx=%lu kHz\n",
+                       (unsigned long)clocks_hw->clk[clk_sys].ctrl,
+                       (unsigned long)clocks_hw->clk[clk_sys].div,
+                       (unsigned long)pll_sys_hw->fbdiv_int,
+                       (unsigned long)pll_sys_hw->prim,
+                       (unsigned long)fc_sys_khz,
+                       (unsigned long)fc_hstx_khz);
+                rate_last_us = now;
+                rate_last_frames = current_count;
+                rate_last_irqs = irq_count;
+            }
+#endif
+            // Rate-limit watchdog: 1-second sliding window. Two-stage recovery:
+            // soft (HSTX enable toggle) on first trip, full resync on repeat.
+            if ((now - overrate_last_us) >= 1000000u)
+            {
+                uint32_t d_us = now - overrate_last_us;
+                uint32_t d_frames = current_count - overrate_last_frames;
+                uint32_t fps = (uint32_t)((uint64_t)d_frames * 1000000u / d_us);
+                if (fps > VIDEO_OUTPUT_OVERRATE_FPS)
+                {
+                    if (!soft_recovery_attempted)
+                    {
+                        // Soft recovery: clear any HSTX expander shadow state
+                        // by toggling CSR.EN. DMA stalls on DREQ while HSTX is
+                        // off, then resumes when re-enabled; chain state stays
+                        // intact. If this alone fixes the overspeed, the root
+                        // cause is HSTX-internal (not DMA config drift).
+                        irq_set_enabled(DMA_IRQ_0, false);
+                        hstx_ctrl_hw->csr &= ~HSTX_CTRL_CSR_EN_BITS;
+                        __asm volatile("nop\nnop\nnop\nnop");
+                        hstx_ctrl_hw->csr |= HSTX_CTRL_CSR_EN_BITS;
+                        irq_set_enabled(DMA_IRQ_0, true);
+                        soft_recovery_attempted = true;
+                        soft_recovery_count++;
+                    }
+                    else
+                    {
+                        // Soft didn't clear it — escalate to full resync.
+                        resync_requested = true;
+                        soft_recovery_attempted = false;
+                    }
+                }
+                else
+                {
+                    soft_recovery_attempted = false;
+                }
+                overrate_last_us = now;
+                overrate_last_frames = current_count;
+            }
+
+            bool do_resync = resync_requested ||
+                             (now - last_frame_us) > VIDEO_OUTPUT_WATCHDOG_US;
+
+            if (do_resync)
+            {
+                resync_count++;
+                irq_set_enabled(DMA_IRQ_0, false);
+                hstx_resync();
+                resync_requested = false;
+                irq_set_enabled(DMA_IRQ_0, true);
+                last_frame_us = time_us_32();
+                last_frame_count_seen = video_frame_count;
+                overrate_last_us = last_frame_us;
+                overrate_last_frames = video_frame_count;
+                printf("HSTX resync performed! Total resyncs since boot: %d\n", resync_count);
+            }
         }
-
-        if ((now - rate_last_us) >= 1000000u) {
-            uint32_t d_us = now - rate_last_us;
-            uint32_t d_frames = current_count - rate_last_frames;
-            uint32_t d_irqs = irq_count - rate_last_irqs;
-            printf("video rate: %lu frames/s, %lu irqs/s (dvi=%d) clk_sys=%lu clk_hstx=%lu csr=%08lx\n",
-                   (unsigned long)((uint64_t)d_frames * 1000000u / d_us),
-                   (unsigned long)((uint64_t)d_irqs * 1000000u / d_us),
-                   dvi_mode ? 1 : 0,
-                   (unsigned long)clock_get_hz(clk_sys),
-                   (unsigned long)clock_get_hz(clk_hstx),
-                   (unsigned long)hstx_ctrl_hw->csr);
-            printf("  hstx_div=%08lx exp_sh=%08lx exp_tmds=%08lx ping_ctrl=%08lx pong_ctrl=%08lx\n",
-                   (unsigned long)clocks_hw->clk[clk_hstx].div,
-                   (unsigned long)hstx_ctrl_hw->expand_shift,
-                   (unsigned long)hstx_ctrl_hw->expand_tmds,
-                   (unsigned long)dma_hw->ch[DMACH_PING].al1_ctrl,
-                   (unsigned long)dma_hw->ch[DMACH_PONG].al1_ctrl);
-            rate_last_us = now;
-            rate_last_frames = current_count;
-            rate_last_irqs = irq_count;
-        }
-
-        bool do_resync = resync_requested ||
-                         (now - last_frame_us) > VIDEO_OUTPUT_WATCHDOG_US;
-
-        if (do_resync) {
-            resync_count++;
-            irq_set_enabled(DMA_IRQ_0, false);
-            hstx_resync();
-            resync_requested = false;
-            irq_set_enabled(DMA_IRQ_0, true);
-            last_frame_us = time_us_32();
-            last_frame_count_seen = video_frame_count;
-        }
-
         if (background_task) {
             background_task();
         }

--- a/drivers/pico_hdmi/video_output.c
+++ b/drivers/pico_hdmi/video_output.c
@@ -682,6 +682,12 @@ void video_output_core1_run(void)
                    (unsigned long)clock_get_hz(clk_sys),
                    (unsigned long)clock_get_hz(clk_hstx),
                    (unsigned long)hstx_ctrl_hw->csr);
+            printf("  hstx_div=%08lx exp_sh=%08lx exp_tmds=%08lx ping_ctrl=%08lx pong_ctrl=%08lx\n",
+                   (unsigned long)clocks_hw->clk[clk_hstx].div,
+                   (unsigned long)hstx_ctrl_hw->expand_shift,
+                   (unsigned long)hstx_ctrl_hw->expand_tmds,
+                   (unsigned long)dma_hw->ch[DMACH_PING].al1_ctrl,
+                   (unsigned long)dma_hw->ch[DMACH_PONG].al1_ctrl);
             rate_last_us = now;
             rate_last_frames = current_count;
             rate_last_irqs = irq_count;

--- a/drivers/pico_hdmi/video_output.c
+++ b/drivers/pico_hdmi/video_output.c
@@ -66,6 +66,7 @@
 uint16_t frame_width = 0;
 uint16_t frame_height = 0;
 volatile uint32_t video_frame_count = 0;
+static volatile uint32_t irq_count = 0;
 
 // DVI mode: when true, disables all HDMI Data Islands (pure DVI output, no audio)
 // Some monitors have trouble syncing with HDMI Data Islands
@@ -385,6 +386,7 @@ static inline void __not_in_flash_func(video_output_handle_active_data)(dma_chan
 
 void __not_in_flash_func(dma_irq_handler)(void)
 {
+    irq_count++;
     uint32_t ch_num = dma_pong ? DMACH_PONG : DMACH_PING;
     dma_channel_hw_t *ch = &dma_hw->ch[ch_num];
     dma_hw->intr = 1U << ch_num;
@@ -656,12 +658,30 @@ void video_output_core1_run(void)
     uint32_t last_frame_us = time_us_32();
     uint32_t last_frame_count_seen = video_frame_count;
 
+    // 1 Hz rate-diagnostic baseline
+    uint32_t rate_last_us = last_frame_us;
+    uint32_t rate_last_frames = last_frame_count_seen;
+    uint32_t rate_last_irqs = irq_count;
+
     while (1) {
         uint32_t now = time_us_32();
         uint32_t current_count = video_frame_count;
         if (current_count != last_frame_count_seen) {
             last_frame_count_seen = current_count;
             last_frame_us = now;
+        }
+
+        if ((now - rate_last_us) >= 1000000u) {
+            uint32_t d_us = now - rate_last_us;
+            uint32_t d_frames = current_count - rate_last_frames;
+            uint32_t d_irqs = irq_count - rate_last_irqs;
+            printf("video rate: %lu frames/s, %lu irqs/s (dvi=%d)\n",
+                   (unsigned long)((uint64_t)d_frames * 1000000u / d_us),
+                   (unsigned long)((uint64_t)d_irqs * 1000000u / d_us),
+                   dvi_mode ? 1 : 0);
+            rate_last_us = now;
+            rate_last_frames = current_count;
+            rate_last_irqs = irq_count;
         }
 
         bool do_resync = resync_requested ||

--- a/drivers/pico_hdmi/video_output.c
+++ b/drivers/pico_hdmi/video_output.c
@@ -784,7 +784,7 @@ void video_output_core1_run(void)
                 last_frame_count_seen = video_frame_count;
                 overrate_last_us = last_frame_us;
                 overrate_last_frames = video_frame_count;
-                printf("HSTX resync performed! Total resyncs since boot: %d\n", resync_count);
+                printf("HSTX resync performed! Total resyncs since boot: (hard) %d - (soft) %d\n", resync_count, soft_recovery_count);
             }
         }
         if (background_task) {

--- a/drivers/pico_hdmi/video_output.c
+++ b/drivers/pico_hdmi/video_output.c
@@ -100,7 +100,6 @@ static video_output_vsync_cb_t vsync_callback = NULL;
 // to request a full HSTX+DMA reset. Consumed in video_output_core1_run().
 static volatile bool resync_requested = false;
 static volatile int resync_count = 0;
-static volatile int soft_recovery_count = 0;
 #define DMACH_PING 0
 #define DMACH_PONG 1
 
@@ -669,17 +668,14 @@ void video_output_core1_run(void)
     #define VIDEO_OUTPUT_WATCHDOG_US 500000u
 
     // Rate-limit watchdog: no real display exceeds ~65 Hz vertical. If
-    // video_frame_count advances above this, HSTX has fallen into the
-    // overspeed state (observed ~158 Hz). First attempt a soft recovery
-    // (toggle HSTX CSR.EN) to clear any expander shadow state without
-    // disturbing DMA. If the next 1-second window is still over-rate,
-    // fall back to a full hstx_resync().
+    // video_frame_count advances above 75 fps, DMA chain state has drifted
+    // (observed ~158 Hz in DVI mode); trigger a full hstx_resync() to
+    // recover. A soft HSTX CSR toggle was tested and does not clear it.
     #define VIDEO_OUTPUT_OVERRATE_FPS 75u
     uint32_t last_frame_us = time_us_32();
     uint32_t last_frame_count_seen = video_frame_count;
     uint32_t overrate_last_us = last_frame_us;
     uint32_t overrate_last_frames = last_frame_count_seen;
-    bool soft_recovery_attempted = false;
 #if HSTX_DEBUG
     // 1 Hz rate-diagnostic baseline
     uint32_t rate_last_us = last_frame_us;
@@ -702,14 +698,13 @@ void video_output_core1_run(void)
                 uint32_t d_us = now - rate_last_us;
                 uint32_t d_frames = current_count - rate_last_frames;
                 uint32_t d_irqs = irq_count - rate_last_irqs;
-                printf("video rate: %lu frames/s, %lu irqs/s (dvi=%d) clk_sys=%lu clk_hstx=%lu csr=%08lx soft=%d hard=%d\n",
+                printf("video rate: %lu frames/s, %lu irqs/s (dvi=%d) clk_sys=%lu clk_hstx=%lu csr=%08lx resync=%d\n",
                        (unsigned long)((uint64_t)d_frames * 1000000u / d_us),
                        (unsigned long)((uint64_t)d_irqs * 1000000u / d_us),
                        dvi_mode ? 1 : 0,
                        (unsigned long)clock_get_hz(clk_sys),
                        (unsigned long)clock_get_hz(clk_hstx),
                        (unsigned long)hstx_ctrl_hw->csr,
-                       soft_recovery_count,
                        resync_count);
                 printf("  hstx_div=%08lx exp_sh=%08lx exp_tmds=%08lx ping_ctrl=%08lx pong_ctrl=%08lx\n",
                        (unsigned long)clocks_hw->clk[clk_hstx].div,
@@ -731,8 +726,10 @@ void video_output_core1_run(void)
                 rate_last_irqs = irq_count;
             }
 #endif
-            // Rate-limit watchdog: 1-second sliding window. Two-stage recovery:
-            // soft (HSTX enable toggle) on first trip, full resync on repeat.
+            // Rate-limit watchdog: 1-second sliding window. If video_frame_count
+            // advances above ~75 fps (no display exceeds this), DMA chain state
+            // has drifted; full hstx_resync() is the only recovery that works
+            // (soft CSR toggle was tested and fails reliably).
             if ((now - overrate_last_us) >= 1000000u)
             {
                 uint32_t d_us = now - overrate_last_us;
@@ -740,33 +737,7 @@ void video_output_core1_run(void)
                 uint32_t fps = (uint32_t)((uint64_t)d_frames * 1000000u / d_us);
                 if (fps > VIDEO_OUTPUT_OVERRATE_FPS)
                 {
-                    if (!soft_recovery_attempted)
-                    {
-                        // Soft recovery: clear any HSTX expander shadow state
-                        // by toggling CSR.EN. DMA stalls on DREQ while HSTX is
-                        // off, then resumes when re-enabled; chain state stays
-                        // intact. If this alone fixes the overspeed, the root
-                        // cause is HSTX-internal (not DMA config drift).
-                        // NOTE: Soft recovery does not work, always falls through to hard resync. 
-                        irq_set_enabled(DMA_IRQ_0, false);
-                        hstx_ctrl_hw->csr &= ~HSTX_CTRL_CSR_EN_BITS;
-                        __asm volatile("nop\nnop\nnop\nnop");
-                        hstx_ctrl_hw->csr |= HSTX_CTRL_CSR_EN_BITS;
-                        irq_set_enabled(DMA_IRQ_0, true);
-                        soft_recovery_attempted = true;
-                        soft_recovery_count++;
-                        printf("HSTX soft recovery performed! Total soft recoveries since boot: %d\n", soft_recovery_count);
-                    }
-                    else
-                    {
-                        // Soft didn't clear it — escalate to full resync.
-                        resync_requested = true;
-                        soft_recovery_attempted = false;
-                    }
-                }
-                else
-                {
-                    soft_recovery_attempted = false;
+                    resync_requested = true;
                 }
                 overrate_last_us = now;
                 overrate_last_frames = current_count;
@@ -786,7 +757,7 @@ void video_output_core1_run(void)
                 last_frame_count_seen = video_frame_count;
                 overrate_last_us = last_frame_us;
                 overrate_last_frames = video_frame_count;
-                printf("HSTX resync performed! Total resyncs since boot: (hard) %d - (soft) %d\n", resync_count, soft_recovery_count);
+                printf("HSTX resync performed! Total resyncs since boot: %d\n", resync_count);
             }
         }
         if (background_task) {

--- a/drivers/pico_hdmi/video_output.c
+++ b/drivers/pico_hdmi/video_output.c
@@ -683,86 +683,121 @@ void video_output_core1_run(void)
     uint32_t rate_last_irqs = irq_count;
 #endif
     while (1) {
-        // resync watchdog: if we haven't seen a new frame in a while, the output is probably stuck and monitor looses signal; try to recover with hstx_resync()
-        // Signal loss normally occurs only in DVI mode, never seen in HDMI mode.
-        //  Enable it for HDMI mode as well, just in case.
-        // if (dvi_mode)
-        // {
-            uint32_t now = time_us_32();
-            uint32_t current_count = video_frame_count;
-            if (current_count != last_frame_count_seen)
-            {
-                last_frame_count_seen = current_count;
-                last_frame_us = now;
-            }
+        // ----------------------------------------------------------------
+        // HSTX recovery loop
+        //
+        // The HSTX/DMA pipeline can wedge in two distinct failure modes that
+        // both manifest as the monitor losing signal. Two cooperating
+        // watchdogs detect them; both feed into a single recovery path that
+        // calls hstx_resync() to rebuild the DMA chain from scratch.
+        //
+        //   1. Stuck-frame watchdog (per-iteration check)
+        //      video_frame_count stops advancing — typical after a DMA IRQ
+        //      overrun or HSTX FIFO underflow leaves the ping/pong chain in
+        //      an inconsistent state. Detected when no new frame has been
+        //      observed for VIDEO_OUTPUT_WATCHDOG_US (~500 ms).
+        //
+        //   2. Over-rate watchdog (1 Hz sampling window)
+        //      video_frame_count advances faster than any real display can
+        //      sync to (>75 fps; ~158 Hz observed in DVI mode after the chain
+        //      drifts). Latches resync_requested for the next iteration.
+        //
+        // Originally these checks were gated on dvi_mode (signal loss was
+        // only ever observed in DVI), but they are now run unconditionally
+        // for HDMI as a safety net.
+        //
+        // hstx_resync() is the only recovery that has been shown to work;
+        // a soft HSTX CSR toggle was tested and fails reliably.
+        //
+        // All elapsed-time comparisons use uint32_t subtraction, which is
+        // safe across the ~71 min wrap of time_us_32().
+        // ----------------------------------------------------------------
+
+        uint32_t now = time_us_32();
+        uint32_t current_count = video_frame_count;
+
+        // Stuck-frame watchdog: refresh the "last progress" timestamp
+        // whenever the IRQ-driven frame counter has moved forward.
+        if (current_count != last_frame_count_seen)
+        {
+            last_frame_count_seen = current_count;
+            last_frame_us = now;
+        }
+
 #if HSTX_DEBUG
-            if ((now - rate_last_us) >= 1000000u)
-            {
-                uint32_t d_us = now - rate_last_us;
-                uint32_t d_frames = current_count - rate_last_frames;
-                uint32_t d_irqs = irq_count - rate_last_irqs;
-                printf("video rate: %lu frames/s, %lu irqs/s (dvi=%d) clk_sys=%lu clk_hstx=%lu csr=%08lx resync=%d\n",
-                       (unsigned long)((uint64_t)d_frames * 1000000u / d_us),
-                       (unsigned long)((uint64_t)d_irqs * 1000000u / d_us),
-                       dvi_mode ? 1 : 0,
-                       (unsigned long)clock_get_hz(clk_sys),
-                       (unsigned long)clock_get_hz(clk_hstx),
-                       (unsigned long)hstx_ctrl_hw->csr,
-                       resync_count);
-                printf("  hstx_div=%08lx exp_sh=%08lx exp_tmds=%08lx ping_ctrl=%08lx pong_ctrl=%08lx\n",
-                       (unsigned long)clocks_hw->clk[clk_hstx].div,
-                       (unsigned long)hstx_ctrl_hw->expand_shift,
-                       (unsigned long)hstx_ctrl_hw->expand_tmds,
-                       (unsigned long)dma_hw->ch[DMACH_PING].al1_ctrl,
-                       (unsigned long)dma_hw->ch[DMACH_PONG].al1_ctrl);
-                uint32_t fc_sys_khz = frequency_count_khz(CLOCKS_FC0_SRC_VALUE_CLK_SYS);
-                uint32_t fc_hstx_khz = frequency_count_khz(CLOCKS_FC0_SRC_VALUE_CLK_HSTX);
-                printf("  sys_ctrl=%08lx sys_div=%08lx pll_fbdiv=%lu pll_prim=%08lx fc_sys=%lu kHz fc_hstx=%lu kHz\n",
-                       (unsigned long)clocks_hw->clk[clk_sys].ctrl,
-                       (unsigned long)clocks_hw->clk[clk_sys].div,
-                       (unsigned long)pll_sys_hw->fbdiv_int,
-                       (unsigned long)pll_sys_hw->prim,
-                       (unsigned long)fc_sys_khz,
-                       (unsigned long)fc_hstx_khz);
-                rate_last_us = now;
-                rate_last_frames = current_count;
-                rate_last_irqs = irq_count;
-            }
+        // 1 Hz diagnostic dump: frame/IRQ rates plus a snapshot of every
+        // clock and HSTX/DMA register relevant to debugging a wedge.
+        if ((now - rate_last_us) >= 1000000u)
+        {
+            uint32_t d_us = now - rate_last_us;
+            uint32_t d_frames = current_count - rate_last_frames;
+            uint32_t d_irqs = irq_count - rate_last_irqs;
+            printf("video rate: %lu frames/s, %lu irqs/s (dvi=%d) clk_sys=%lu clk_hstx=%lu csr=%08lx resync=%d\n",
+                   (unsigned long)((uint64_t)d_frames * 1000000u / d_us),
+                   (unsigned long)((uint64_t)d_irqs * 1000000u / d_us),
+                   dvi_mode ? 1 : 0,
+                   (unsigned long)clock_get_hz(clk_sys),
+                   (unsigned long)clock_get_hz(clk_hstx),
+                   (unsigned long)hstx_ctrl_hw->csr,
+                   resync_count);
+            printf("  hstx_div=%08lx exp_sh=%08lx exp_tmds=%08lx ping_ctrl=%08lx pong_ctrl=%08lx\n",
+                   (unsigned long)clocks_hw->clk[clk_hstx].div,
+                   (unsigned long)hstx_ctrl_hw->expand_shift,
+                   (unsigned long)hstx_ctrl_hw->expand_tmds,
+                   (unsigned long)dma_hw->ch[DMACH_PING].al1_ctrl,
+                   (unsigned long)dma_hw->ch[DMACH_PONG].al1_ctrl);
+            uint32_t fc_sys_khz = frequency_count_khz(CLOCKS_FC0_SRC_VALUE_CLK_SYS);
+            uint32_t fc_hstx_khz = frequency_count_khz(CLOCKS_FC0_SRC_VALUE_CLK_HSTX);
+            printf("  sys_ctrl=%08lx sys_div=%08lx pll_fbdiv=%lu pll_prim=%08lx fc_sys=%lu kHz fc_hstx=%lu kHz\n",
+                   (unsigned long)clocks_hw->clk[clk_sys].ctrl,
+                   (unsigned long)clocks_hw->clk[clk_sys].div,
+                   (unsigned long)pll_sys_hw->fbdiv_int,
+                   (unsigned long)pll_sys_hw->prim,
+                   (unsigned long)fc_sys_khz,
+                   (unsigned long)fc_hstx_khz);
+            rate_last_us = now;
+            rate_last_frames = current_count;
+            rate_last_irqs = irq_count;
+        }
 #endif
-            // Rate-limit watchdog: 1-second sliding window. If video_frame_count
-            // advances above ~75 fps (no display exceeds this), DMA chain state
-            // has drifted; full hstx_resync() is the only recovery that works
-            // (soft CSR toggle was tested and fails reliably).
-            if ((now - overrate_last_us) >= 1000000u)
-            {
-                uint32_t d_us = now - overrate_last_us;
-                uint32_t d_frames = current_count - overrate_last_frames;
-                uint32_t fps = (uint32_t)((uint64_t)d_frames * 1000000u / d_us);
-                if (fps > VIDEO_OUTPUT_OVERRATE_FPS)
-                {
-                    resync_requested = true;
-                }
-                overrate_last_us = now;
-                overrate_last_frames = current_count;
-            }
 
-            bool do_resync = resync_requested ||
-                             (now - last_frame_us) > VIDEO_OUTPUT_WATCHDOG_US;
-
-            if (do_resync)
+        // Over-rate watchdog: once per second, compute fps over the elapsed
+        // window. Above VIDEO_OUTPUT_OVERRATE_FPS the DMA chain has drifted
+        // and the recovery is queued for this iteration's resync block.
+        if ((now - overrate_last_us) >= 1000000u)
+        {
+            uint32_t d_us = now - overrate_last_us;
+            uint32_t d_frames = current_count - overrate_last_frames;
+            uint32_t fps = (uint32_t)((uint64_t)d_frames * 1000000u / d_us);
+            if (fps > VIDEO_OUTPUT_OVERRATE_FPS)
             {
-                resync_count++;
-                irq_set_enabled(DMA_IRQ_0, false);
-                hstx_resync();
-                resync_requested = false;
-                irq_set_enabled(DMA_IRQ_0, true);
-                last_frame_us = time_us_32();
-                last_frame_count_seen = video_frame_count;
-                overrate_last_us = last_frame_us;
-                overrate_last_frames = video_frame_count;
-                printf("HSTX resync performed! Total resyncs since boot: %d\n", resync_count);
+                resync_requested = true;
             }
-       // }
+            overrate_last_us = now;
+            overrate_last_frames = current_count;
+        }
+
+        // Trigger recovery if either watchdog has fired. The DMA IRQ is
+        // masked across hstx_resync() so it cannot observe the chain in a
+        // half-rebuilt state, then all watchdog baselines are reset so the
+        // next iteration measures fresh post-recovery progress.
+        bool do_resync = resync_requested ||
+                         (now - last_frame_us) > VIDEO_OUTPUT_WATCHDOG_US;
+
+        if (do_resync)
+        {
+            resync_count++;
+            irq_set_enabled(DMA_IRQ_0, false);
+            hstx_resync();
+            resync_requested = false;
+            irq_set_enabled(DMA_IRQ_0, true);
+            last_frame_us = time_us_32();
+            last_frame_count_seen = video_frame_count;
+            overrate_last_us = last_frame_us;
+            overrate_last_frames = video_frame_count;
+            printf("HSTX resync performed! Total resyncs since boot: %d\n", resync_count);
+        }
+
         if (background_task) {
             background_task();
         }

--- a/drivers/pico_hdmi/video_output.c
+++ b/drivers/pico_hdmi/video_output.c
@@ -683,8 +683,11 @@ void video_output_core1_run(void)
     uint32_t rate_last_irqs = irq_count;
 #endif
     while (1) {
-        if (dvi_mode)
-        {
+        // resync watchdog: if we haven't seen a new frame in a while, the output is probably stuck and monitor looses signal; try to recover with hstx_resync()
+        // Signal loss normally occurs only in DVI mode, never seen in HDMI mode.
+        //  Enable it for HDMI mode as well, just in case.
+        // if (dvi_mode)
+        // {
             uint32_t now = time_us_32();
             uint32_t current_count = video_frame_count;
             if (current_count != last_frame_count_seen)
@@ -759,7 +762,7 @@ void video_output_core1_run(void)
                 overrate_last_frames = video_frame_count;
                 printf("HSTX resync performed! Total resyncs since boot: %d\n", resync_count);
             }
-        }
+       // }
         if (background_task) {
             background_task();
         }

--- a/drivers/pico_hdmi/video_output.c
+++ b/drivers/pico_hdmi/video_output.c
@@ -754,6 +754,7 @@ void video_output_core1_run(void)
                         irq_set_enabled(DMA_IRQ_0, true);
                         soft_recovery_attempted = true;
                         soft_recovery_count++;
+                        printf("HSTX soft recovery performed! Total soft recoveries since boot: %d\n", soft_recovery_count);
                     }
                     else
                     {

--- a/drivers/pico_hdmi/video_output.c
+++ b/drivers/pico_hdmi/video_output.c
@@ -747,6 +747,7 @@ void video_output_core1_run(void)
                         // off, then resumes when re-enabled; chain state stays
                         // intact. If this alone fixes the overspeed, the root
                         // cause is HSTX-internal (not DMA config drift).
+                        // NOTE: Soft recovery does not work, always falls through to hard resync. 
                         irq_set_enabled(DMA_IRQ_0, false);
                         hstx_ctrl_hw->csr &= ~HSTX_CTRL_CSR_EN_BITS;
                         __asm volatile("nop\nnop\nnop\nnop");

--- a/drivers/pico_hdmi/video_output.c
+++ b/drivers/pico_hdmi/video_output.c
@@ -142,6 +142,12 @@ static uint32_t vblank_avi_infoframe[64], vblank_avi_infoframe_len;
 
 static void __not_in_flash_func(hstx_resync)(void)
 {
+    // RP2350-E5: clear EN on the aborted channel AND any channel it chains
+    // from, otherwise a chained partner can re-trigger the aborted channel
+    // while abort is in flight and leave it latched live with stale config.
+    hw_clear_bits(&dma_hw->ch[DMACH_PING].al1_ctrl, DMA_CH0_CTRL_TRIG_EN_BITS);
+    hw_clear_bits(&dma_hw->ch[DMACH_PONG].al1_ctrl, DMA_CH0_CTRL_TRIG_EN_BITS);
+
     // 1. Abort DMA chains
     dma_channel_abort(DMACH_PING);
     dma_channel_abort(DMACH_PONG);
@@ -159,21 +165,26 @@ static void __not_in_flash_func(hstx_resync)(void)
     line_buf_fill_idx = 0;
     line_buf_dma_idx = 0;
 
-    // 4. Clear any pending DMA interrupts
+    // 4. Clear any pending DMA interrupts (including spurious completion
+    //    interrupts that abort can latch per RP2350-E5 / SDK docs).
     dma_hw->ints0 = (1U << DMACH_PING) | (1U << DMACH_PONG);
 
-    // 5. Configure DMA PING to start from beginning of frame (Line 0)
+    // 5. Restore the EN bits cleared above so the channels are live again.
+    hw_set_bits(&dma_hw->ch[DMACH_PING].al1_ctrl, DMA_CH0_CTRL_TRIG_EN_BITS);
+    hw_set_bits(&dma_hw->ch[DMACH_PONG].al1_ctrl, DMA_CH0_CTRL_TRIG_EN_BITS);
+
+    // 6. Configure DMA PING to start from beginning of frame (Line 0)
     dma_channel_hw_t *ch_ping = &dma_hw->ch[DMACH_PING];
     ch_ping->read_addr = (uintptr_t)vblank_line_vsync_off;
     ch_ping->transfer_count = count_of(vblank_line_vsync_off);
 
-    // 6. Configure DMA PONG for the NEXT line (Line 1)
+    // 7. Configure DMA PONG for the NEXT line (Line 1)
     // This ensures that when PING finishes and chains to PONG, PONG is ready.
     dma_channel_hw_t *ch_pong = &dma_hw->ch[DMACH_PONG];
     ch_pong->read_addr = (uintptr_t)vblank_line_vsync_off; // Line 1 is also blank
     ch_pong->transfer_count = count_of(vblank_line_vsync_off);
 
-    // 7. Re-enable HSTX then start DMA
+    // 8. Re-enable HSTX then start DMA
     hstx_ctrl_hw->csr |= HSTX_CTRL_CSR_EN_BITS;
     dma_channel_start(DMACH_PING);
 }

--- a/drivers/pico_hdmi/video_output.c
+++ b/drivers/pico_hdmi/video_output.c
@@ -71,7 +71,13 @@ volatile uint32_t video_frame_count = 0;
 // Some monitors have trouble syncing with HDMI Data Islands
 static bool dvi_mode = false; // Default to HDMI mode (full features with audio)
 
-static uint16_t line_buffer[MODE_H_ACTIVE_PIXELS] __attribute__((aligned(4)));
+// Double-buffered line buffer. While DMA reads line_buffer[dma_idx] for the
+// current active line, the scanline callback fills line_buffer[fill_idx] with
+// the next line's pixels. This removes the write/read race and lets us
+// reconfigure the DMA *before* calling the (slow) scanline callback.
+static uint16_t line_buffer[2][MODE_H_ACTIVE_PIXELS] __attribute__((aligned(4)));
+static uint8_t line_buf_fill_idx = 0;  // buffer the callback writes into
+static uint8_t line_buf_dma_idx = 0;   // buffer the next pixel-data DMA reads
 static uint32_t v_scanline = 2;
 static bool vactive_cmdlist_posted = false;
 static bool dma_pong = false;
@@ -80,6 +86,10 @@ static video_output_task_fn background_task = NULL;
 static video_output_scanline_cb_t scanline_callback = NULL;
 static video_output_vsync_cb_t vsync_callback = NULL;
 
+// Auto-resync watchdog: set by core 0 (or by the core-1 main-loop watchdog)
+// to request a full HSTX+DMA reset. Consumed in video_output_core1_run().
+static volatile bool resync_requested = false;
+static volatile int resync_count = 0;
 #define DMACH_PING 0
 #define DMACH_PONG 1
 
@@ -146,6 +156,8 @@ static void __not_in_flash_func(hstx_resync)(void)
     v_scanline = 0;
     vactive_cmdlist_posted = false;
     dma_pong = false;
+    line_buf_fill_idx = 0;
+    line_buf_dma_idx = 0;
 
     // 4. Clear any pending DMA interrupts
     dma_hw->ints0 = (1U << DMACH_PING) | (1U << DMACH_PONG);
@@ -276,19 +288,12 @@ static inline void __not_in_flash_func(video_output_handle_vsync)(dma_channel_hw
 
 static inline void __not_in_flash_func(video_output_handle_active_start)(dma_channel_hw_t *ch, uint32_t v_scanline, uint32_t active_line, bool dma_pong)
 {
-    uint32_t *dst32 = (uint32_t *)line_buffer;
-
-    if (scanline_callback) {
-        scanline_callback(v_scanline, active_line, dst32);
-    } else {
-        // If no callback, just output black pixels
-        for (uint32_t i = 0; i < MODE_H_ACTIVE_PIXELS / 2; i++) {
-            dst32[i] = 0;
-        }
-    }
-
+    // 1. Arm the cmdlist DMA FIRST, before any slow work. This channel will be
+    //    chain-triggered when the currently-running pixel-data DMA completes,
+    //    so it must be armed well before then. Doing this first means that
+    //    even if the scanline callback below overruns, the cmdlist chain is
+    //    safe and HSTX keeps emitting valid sync.
     if (dvi_mode) {
-        // Pure DVI: simple active line without Data Islands
         ch->read_addr = (uintptr_t)vactive_line_dvi;
         ch->transfer_count = count_of(vactive_line_dvi);
     } else {
@@ -301,6 +306,27 @@ static inline void __not_in_flash_func(video_output_handle_active_start)(dma_cha
         } else {
             ch->read_addr = (uintptr_t)vactive_di_null;
             ch->transfer_count = vactive_di_null_len;
+        }
+    }
+
+    // 2. Pick the line buffer that's NOT currently being read by the pixel
+    //    data DMA, and record it for the next handle_active_data() to point
+    //    DMA at. Doing the handoff here (with IRQs serialised by NVIC) is
+    //    race-free: the next IRQ can only run after this one returns.
+    uint8_t fill_idx = line_buf_fill_idx;
+    line_buf_dma_idx = fill_idx;
+    line_buf_fill_idx = fill_idx ^ 1;
+
+    // 3. Fill the line buffer (slow: ~21 us for 640-wide 2x doubling with
+    //    optional scanline darken). DMA is already armed, so if this overruns
+    //    the active region we still chain to a valid cmdlist rather than
+    //    zero-length garbage.
+    uint32_t *dst32 = (uint32_t *)line_buffer[fill_idx];
+    if (scanline_callback) {
+        scanline_callback(v_scanline, active_line, dst32);
+    } else {
+        for (uint32_t i = 0; i < MODE_H_ACTIVE_PIXELS / 2; i++) {
+            dst32[i] = 0;
         }
     }
 }
@@ -338,7 +364,7 @@ static inline void __not_in_flash_func(video_output_handle_blanking)(dma_channel
 
 static inline void __not_in_flash_func(video_output_handle_active_data)(dma_channel_hw_t *ch)
 {
-    ch->read_addr = (uintptr_t)line_buffer;
+    ch->read_addr = (uintptr_t)line_buffer[line_buf_dma_idx];
     ch->transfer_count = (MODE_H_ACTIVE_PIXELS * sizeof(uint16_t)) / sizeof(uint32_t);
 }
 
@@ -487,6 +513,11 @@ void video_output_set_background_task(video_output_task_fn task)
     background_task = task;
 }
 
+void video_output_request_resync(void)
+{
+    resync_requested = true;
+}
+
 bool video_output_get_dvi_mode(void)
 {
     return dvi_mode;
@@ -604,7 +635,37 @@ void video_output_core1_run(void)
     bus_ctrl_hw->priority = BUSCTRL_BUS_PRIORITY_DMA_W_BITS | BUSCTRL_BUS_PRIORITY_DMA_R_BITS;
     dma_channel_start(DMACH_PING);
 
+    // Watchdog: if video_frame_count stops advancing (e.g. DMA chain wedged
+    // after an IRQ overrun, HSTX FIFO underflow), hstx_resync() brings the
+    // pipeline back up without a reboot. 500 ms is ~30 frames at 60 Hz, long
+    // enough not to false-trigger at boot but short enough to recover quickly.
+    // time_us_32 wraps every ~71 min, irrelevant for the 500 ms window and
+    // ~10x cheaper than time_us_64 in a hot loop.
+    #define VIDEO_OUTPUT_WATCHDOG_US 500000u
+    uint32_t last_frame_us = time_us_32();
+    uint32_t last_frame_count_seen = video_frame_count;
+
     while (1) {
+        uint32_t now = time_us_32();
+        uint32_t current_count = video_frame_count;
+        if (current_count != last_frame_count_seen) {
+            last_frame_count_seen = current_count;
+            last_frame_us = now;
+        }
+
+        bool do_resync = resync_requested ||
+                         (now - last_frame_us) > VIDEO_OUTPUT_WATCHDOG_US;
+
+        if (do_resync) {
+            resync_count++;
+            irq_set_enabled(DMA_IRQ_0, false);
+            hstx_resync();
+            resync_requested = false;
+            irq_set_enabled(DMA_IRQ_0, true);
+            last_frame_us = time_us_32();
+            last_frame_count_seen = video_frame_count;
+        }
+
         if (background_task) {
             background_task();
         }
@@ -617,6 +678,14 @@ void pico_hdmi_set_audio_sample_rate(uint32_t sample_rate)
     configure_audio_packets(sample_rate);
 }
 
-
+/// @brief Returns the number of times the video output has auto-resynced
+/// (via hstx_resync()) since boot. This can be used to detect if the output is having trouble
+/// keeping up and is frequently resyncing.
+/// @param  
+/// @return /
+int get_video_output_resync_count(void)
+{
+    return resync_count;
+}
 
 

--- a/drivers/pico_hdmi/video_output.c
+++ b/drivers/pico_hdmi/video_output.c
@@ -675,10 +675,13 @@ void video_output_core1_run(void)
             uint32_t d_us = now - rate_last_us;
             uint32_t d_frames = current_count - rate_last_frames;
             uint32_t d_irqs = irq_count - rate_last_irqs;
-            printf("video rate: %lu frames/s, %lu irqs/s (dvi=%d)\n",
+            printf("video rate: %lu frames/s, %lu irqs/s (dvi=%d) clk_sys=%lu clk_hstx=%lu csr=%08lx\n",
                    (unsigned long)((uint64_t)d_frames * 1000000u / d_us),
                    (unsigned long)((uint64_t)d_irqs * 1000000u / d_us),
-                   dvi_mode ? 1 : 0);
+                   dvi_mode ? 1 : 0,
+                   (unsigned long)clock_get_hz(clk_sys),
+                   (unsigned long)clock_get_hz(clk_hstx),
+                   (unsigned long)hstx_ctrl_hw->csr);
             rate_last_us = now;
             rate_last_frames = current_count;
             rate_last_irqs = irq_count;

--- a/drivers/pico_hdmi/video_output.h
+++ b/drivers/pico_hdmi/video_output.h
@@ -135,5 +135,14 @@ void video_output_core1_run(void);
  */
 void pico_hdmi_set_audio_sample_rate(uint32_t sample_rate);
 
+/**
+ * Request a full HSTX + DMA resync. The request is latched and serviced by
+ * the core-1 main loop, so this is safe to call from core 0 at any time.
+ * A watchdog in the core-1 loop also auto-triggers a resync if the frame
+ * counter stops advancing for ~500 ms.
+ */
+void video_output_request_resync(void);
+
+int get_video_output_resync_count(void);
 
 #endif // VIDEO_OUTPUT_H

--- a/menu.cpp
+++ b/menu.cpp
@@ -2988,8 +2988,8 @@ void menu(const char *title, char *errorMessage, bool isFatal, bool showSplash, 
     hstx_setScanLines(false);
 #endif
     abSwapped = 1; // Swap A and B buttons, so menu is consistent across different emulators
-    //Frens::PaceFrames60fps(true);
-    Frens::waitForVSync();
+    Frens::PaceFrames60fps(true);
+    //Frens::waitForVSync();
     //
     menutitle = (char *)title;
     int totalFrames = -1;
@@ -3555,6 +3555,6 @@ void menu(const char *title, char *errorMessage, bool isFatal, bool showSplash, 
         // Never return
     }
     Frens::restoreScanlines();
-    //Frens::PaceFrames60fps(true); // reset frame pacing
-    Frens::waitForVSync();
+    Frens::PaceFrames60fps(true); // reset frame pacing
+    //Frens::waitForVSync();
 }

--- a/menu.cpp
+++ b/menu.cpp
@@ -2088,6 +2088,13 @@ int showSettingsMenu(bool calledFromGame)
     int marginbottom = 0;
     settingsActive = true;
     // Allocate screen buffer if called from game
+    #if HSTX
+        if (settings.flags.useDVIModeForHDMI)
+        {
+            video_output_request_resync();
+        }
+
+    #endif
     if (calledFromGame)
     {
 #if 0

--- a/menu.cpp
+++ b/menu.cpp
@@ -2087,14 +2087,14 @@ int showSettingsMenu(bool calledFromGame)
     int margintop = 0;
     int marginbottom = 0;
     settingsActive = true;
+    
+    // #if HSTX
+    //     if (settings.flags.useDVIModeForHDMI)
+    //     {
+    //         video_output_request_resync();
+    //     }
+    // #endif
     // Allocate screen buffer if called from game
-    #if HSTX
-        if (settings.flags.useDVIModeForHDMI)
-        {
-            video_output_request_resync();
-        }
-
-    #endif
     if (calledFromGame)
     {
 #if 0

--- a/menu.cpp
+++ b/menu.cpp
@@ -2172,7 +2172,7 @@ int showSettingsMenu(bool calledFromGame)
         // -1 is always hidden
         if (g_settings_visibility[i] >= 0)
         {
-            if (g_settings_visibility[i] || (i == MenuSettingsIndex::MOPT_EXIT_GAME || i == MenuSettingsIndex::MOPT_SAVE_RESTORE_STATE) && calledFromGame)
+            if (g_settings_visibility[i] || (i == MenuSettingsIndex::MOPT_EXIT_GAME || i == MenuSettingsIndex::MOPT_SAVE_RESTORE_STATE || i == MenuSettingsIndex::MOPT_RESET_GAME) && calledFromGame)
             {
                 visibleIndices[visibleCount++] = i;
             }
@@ -2185,7 +2185,6 @@ int showSettingsMenu(bool calledFromGame)
     // spacerAfterOptionsRow (blank)
     // paletteStartRow .. paletteStartRow+3 : 4 rows of 16 color blocks (64 colors total)
     // paletteInfoRow: textual FG/BG info using working colors
-    // spacerAfterPaletteRow (blank)
     // SAVE
     // CANCEL
     // DEFAULT
@@ -2194,8 +2193,7 @@ int showSettingsMenu(bool calledFromGame)
     const int paletteStartRow = spacerAfterOptionsRow + 1;
     const int paletteRowCount = 4;                                // 4 x 16 = 64
     const int paletteInfoRow = paletteStartRow + paletteRowCount; // textual line
-    const int spacerAfterPaletteRow = paletteInfoRow + 1;
-    const int saveRowScreen = spacerAfterPaletteRow + 1;
+    const int saveRowScreen = paletteInfoRow + 1;
     const int cancelRowScreen = saveRowScreen + 1;
     const int defaultRowScreen = cancelRowScreen + 1;
     const int helpRowScreen = defaultRowScreen + 2; // extra spacer before help line
@@ -2236,6 +2234,12 @@ int showSettingsMenu(bool calledFromGame)
                 {
                     label = "Back to main menu";
                 }
+                value = "";
+                break;
+            }
+            case MenuSettingsIndex::MOPT_RESET_GAME:
+            {
+                label = "Reset game";
                 value = "";
                 break;
             }
@@ -2427,7 +2431,7 @@ int showSettingsMenu(bool calledFromGame)
                 value = "";
                 break;
             }
-            snprintf(line, sizeof(line), "%s%s%s", label, (optIndex == MOPT_EXIT_GAME || optIndex == MOPT_SAVE_RESTORE_STATE || optIndex == MOPT_ENTER_BOOTSEL_MODE) ? "" : ": ", value);
+            snprintf(line, sizeof(line), "%s%s%s", label, (optIndex == MOPT_EXIT_GAME || optIndex == MOPT_SAVE_RESTORE_STATE || optIndex == MOPT_ENTER_BOOTSEL_MODE || optIndex == MOPT_RESET_GAME) ? "" : ": ", value);
             putText(0, row++, line, CBLACK, CWHITE);
         }
         // Blank spacer after last option
@@ -2461,8 +2465,6 @@ int showSettingsMenu(bool calledFromGame)
         if (infoCol < 0)
             infoCol = 0;
         putText(infoCol, row++, line, working.fgcolor, working.bgcolor);
-        // Spacer after palette/info
-        putText(0, row++, "", CBLACK, CWHITE);
         if (settingsChanged)
         {
             putText(0, row++, "SAVE *", CBLACK, CWHITE);
@@ -2479,7 +2481,8 @@ int showSettingsMenu(bool calledFromGame)
         {
             if (visibleIndices[selectedRowLocal - rowStartOptions] == MOPT_EXIT_GAME ||
                 visibleIndices[selectedRowLocal - rowStartOptions] == MOPT_SAVE_RESTORE_STATE ||
-                visibleIndices[selectedRowLocal - rowStartOptions] == MOPT_ENTER_BOOTSEL_MODE)
+                visibleIndices[selectedRowLocal - rowStartOptions] == MOPT_ENTER_BOOTSEL_MODE ||
+                visibleIndices[selectedRowLocal - rowStartOptions] == MOPT_RESET_GAME)
             {
                 snprintf(line, sizeof(line), "UP/DOWN: Move, %s: select", buttonLabel1);
             }
@@ -2627,8 +2630,7 @@ int showSettingsMenu(bool calledFromGame)
                     } while (
                         selectedRowLocal == spacerAfterOptionsRow ||
                         (selectedRowLocal >= paletteStartRow && selectedRowLocal < paletteStartRow + paletteRowCount) ||
-                        selectedRowLocal == paletteInfoRow ||
-                        selectedRowLocal == spacerAfterPaletteRow);
+                        selectedRowLocal == paletteInfoRow);
                 }
                 else
                 {
@@ -2646,15 +2648,14 @@ int showSettingsMenu(bool calledFromGame)
                     } while (
                         selectedRowLocal == spacerAfterOptionsRow ||
                         (selectedRowLocal >= paletteStartRow && selectedRowLocal < paletteStartRow + paletteRowCount) ||
-                        selectedRowLocal == paletteInfoRow ||
-                        selectedRowLocal == spacerAfterPaletteRow);
+                        selectedRowLocal == paletteInfoRow);
                 }
                 else
                 {
                     selectedRowLocal = rowStartOptions; // wrap
                 }
             }
-            else if (pad & LEFT || pad & RIGHT || ((pad & A) && (optIndex == MOPT_EXIT_GAME || optIndex == MOPT_SAVE_RESTORE_STATE || optIndex == MOPT_ENTER_BOOTSEL_MODE)))
+            else if (pad & LEFT || pad & RIGHT || ((pad & A) && (optIndex == MOPT_EXIT_GAME || optIndex == MOPT_SAVE_RESTORE_STATE || optIndex == MOPT_ENTER_BOOTSEL_MODE || optIndex == MOPT_RESET_GAME)))
             {
                 if (optIndex != -1)
                 {
@@ -2675,6 +2676,12 @@ int showSettingsMenu(bool calledFromGame)
                     case MOPT_SAVE_RESTORE_STATE:
                     {
                         rval = 4; // save/restore state
+                        exitMenu = true;
+                        break;
+                    }
+                     case MOPT_RESET_GAME:
+                    {
+                        rval = 5; // reset game
                         exitMenu = true;
                         break;
                     }

--- a/menu.cpp
+++ b/menu.cpp
@@ -2947,6 +2947,7 @@ int showSettingsMenu(bool calledFromGame)
     wavplayer::reset(); // stop menu music
 #endif
     settingsActive = false; 
+    Frens::PaceFrames60fps(true); // ensure normal timing after menu
     return rval;
 }
 void setclockInFlashAndReboot(uint32_t freq, vreg_voltage voltage)

--- a/menu.cpp
+++ b/menu.cpp
@@ -215,7 +215,7 @@ int Menu_LoadFrame()
 #else
         hstx_getframecounter();
 #endif
-    EXT_AUDIO_POLL_HEADPHONE();
+    Frens::pollHeadPhoneJack();
     auto onOff = hw_divider_s32_quotient_inlined(count, 60) & 1;
     Frens::blinkLed(onOff);
 #if NES_PIN_CLK != -1

--- a/menu.cpp
+++ b/menu.cpp
@@ -204,7 +204,8 @@ static bool isArtWorkEnabled()
 
 int Menu_LoadFrame()
 {
-    Frens::waitForVSync();
+    //Frens::waitForVSync();
+    Frens::PaceFrames60fps(false);
 #if NES_PIN_CLK != -1
     nespad_read_start();
 #endif
@@ -2068,8 +2069,8 @@ bool showSaveStateMenu(int (*savestatefunc)(const char *path), int (*loadstatefu
 #else
     hstx_setScanLines(settings.flags.scanlineOn);
 #endif
-    //Frens::PaceFrames60fps(true);
-    Frens::waitForVSync();
+    Frens::PaceFrames60fps(true);
+    //Frens::waitForVSync();
     printf("Exiting save state menu.\n");
     Frens::f_free(screenBuffer);
     return saveStateLoadedOK;
@@ -2940,8 +2941,8 @@ int showSettingsMenu(bool calledFromGame)
         // Speaker can be muted/unmuted from settings menu
         //EXT_AUDIO_MUTE_INTERNAL_SPEAKER(settings.flags.fruitJamEnableInternalSpeaker == 0);
         EXT_AUDIO_SETVOLUME(settings.fruitjamVolumeLevel);
-        //Frens::PaceFrames60fps(true);
-        Frens::waitForVSync();
+        Frens::PaceFrames60fps(true);
+        //Frens::waitForVSync();
     }
 #if USE_I2S_AUDIO == PICO_AUDIO_I2S_DRIVER_TLV320
     wavplayer::reset(); // stop menu music

--- a/menu_settings.h
+++ b/menu_settings.h
@@ -6,6 +6,7 @@
 
 enum MenuSettingsIndex {
     MOPT_EXIT_GAME = 0,
+    MOPT_RESET_GAME,
     MOPT_SAVE_RESTORE_STATE,
     MOPT_SCREENMODE,
     MOPT_SCANLINES,
@@ -29,6 +30,7 @@ enum MenuSettingsIndex {
 // Create and initialize an array which explains each option in a short description of max 40 characters
 const char* const g_settings_descriptions[MOPT_COUNT] = {
     "Exit game and return to main menu",
+    "Reset the currently running game",
     "Save or load emulator state",
     "Screen scaling & scanline mode",
     "Toggle scanlines effect",

--- a/settings.cpp
+++ b/settings.cpp
@@ -110,7 +110,7 @@ namespace FrensSettings
         settings.flags.rapidFireOnA = 0; // default: rapid fire off
         settings.flags.rapidFireOnB = 0; // default: rapid fire off
         settings.fruitjamVolumeLevel = 16; // default volume level in db to mid (0-24)
-        settings.flags.useDVIModeForHDMI = (HW_CONFIG == 13);; // default on Murmulator M2 (HW_CONFIG == 13) to use DVI mode for HDMI output
+        settings.flags.useDVIModeForHDMI = (HW_CONFIG == 13 && ENABLEDVI); // default on Murmulator M2 (HW_CONFIG == 13) to use DVI mode for HDMI output
         settings.version = SETTINGS_VERSION;
         // clear all the reserved settings
         settings.flags.reserved = 0;

--- a/wavplayer.cpp
+++ b/wavplayer.cpp
@@ -451,7 +451,7 @@ namespace wavplayer
             return;
         // if (!settings.flags.audioEnabled)
         //     return;
-
+        bool hpConnected = Frens::isHeadPhoneJackConnected();
         if (g_wav.kind == WavSrcKind::Memory)
         {
 #if !HSTX
@@ -530,7 +530,7 @@ namespace wavplayer
                 const int16_t *p = g_wav.pcm_mem + (g_wav.frame_pos * 2);
                 int16_t l = p[0], r = p[1];
                 l = apply_gain(l); r = apply_gain(r);
-                if (settings.flags.useExtAudio) {
+                if (settings.flags.useExtAudio || hpConnected) {
                     EXT_AUDIO_ENQUEUE_SAMPLE(l, r);
                 } else {
                     hstx_push_audio_sample(l, r);
@@ -573,7 +573,7 @@ namespace wavplayer
 
 #if !HSTX
 #if EXT_AUDIO_IS_ENABLED
-                if (settings.flags.useExtAudio)
+                if (settings.flags.useExtAudio || hpConnected)
                 {
                     if (g_wav.bits_per == 16)
                     {
@@ -689,7 +689,7 @@ namespace wavplayer
                         int16_t l = *src16++;
                         int16_t r = *src16++;
                         l = apply_gain(l); r = apply_gain(r);
-                        if (settings.flags.useExtAudio) {
+                        if (settings.flags.useExtAudio || hpConnected) {
                             EXT_AUDIO_ENQUEUE_SAMPLE(l, r);
                         } else {
                             hstx_push_audio_sample(l, r);


### PR DESCRIPTION
This pull request introduces several improvements and new features, primarily focused on HDMI/DVI video output support for the RP2350 platform, enhancements to audio handling (including headphone jack detection), and some minor code quality improvements. The most significant changes are the addition of a new HDMI output backend, robust audio packet scheduling, and support for detecting and responding to headphone jack events.

**HDMI/DVI Output and Audio Enhancements:**

* Added a new HDMI/DVI video output backend for the RP2350 platform, including core files such as `hstx.c`, `hstx.h`, and supporting data island queue management with `hstx_data_island_queue.c` and `hstx_data_island_queue.h`. This backend includes framebuffer management, scanline effects, audio sample queuing, and frame pacing for smooth 60fps video. [[1]](diffhunk://#diff-0152243baed5599e7065c0111e94ca4f97a1d6cb22b5879dc7fefa14a9b173efR1-R191) [[2]](diffhunk://#diff-6cc13607296dbb42fe104f6c7614ad6e1c213d68a17ab9eabf3ddeaacebc544fR1-R30) [[3]](diffhunk://#diff-b1cceefedf2a3fc458f821483af604980e84c27672b2d25fa4c7e0b8a68bbd7eR1-R92) [[4]](diffhunk://#diff-dc9ddcc8fc4297210457ee251091e4f6a1bda45b4a59034d366ce4a1e0e31a70R1-R44)
* Implemented robust audio Data Island scheduling for HDMI audio, with both dynamic (heap-allocated) and static (array-allocated) ring buffer variants for silent packet handling, ensuring continuous audio even when the queue is empty. [[1]](diffhunk://#diff-b1cceefedf2a3fc458f821483af604980e84c27672b2d25fa4c7e0b8a68bbd7eR1-R92) [[2]](diffhunk://#diff-d53fd2e2be919dbc4174cd8ad803d0a559e4e5bd097f83532f87f2f2fb287839R1-R91)
* Updated CMake configuration to conditionally include HDMI support and link necessary hardware libraries only for the RP2350 platform.
* Added a watchdog loop in video_output.c to force a resync when a signal loss in DVI mode occurs.

**Audio/Headphone Jack Detection:**

* Added headphone jack detection and handling: introduced a new `headphone_toggle_t` enum, updated the TLV320 audio driver to report headphone insert/remove events, and exposed polling/status APIs (`audio_i2s_poll_headphone_status`, `Frens::pollHeadPhoneJack`, `Frens::isHeadPhoneJackConnected`) for use in higher-level code. [[1]](diffhunk://#diff-40c0a706d5bad835a14480c2cc15dc181c806a909e85391fa434219ab5c0935bL78-R95) [[2]](diffhunk://#diff-aff1644b58be567c5103b4a1af00272c2d6ae41f4c35c0c92f9195c79e74e7d7L263-R263) [[3]](diffhunk://#diff-aff1644b58be567c5103b4a1af00272c2d6ae41f4c35c0c92f9195c79e74e7d7R289) [[4]](diffhunk://#diff-aff1644b58be567c5103b4a1af00272c2d6ae41f4c35c0c92f9195c79e74e7d7L673-R683) [[5]](diffhunk://#diff-47e62d520f7eae50d3519dbc612bbebcb49fef07fc4079a79b177921ac064db8R61) [[6]](diffhunk://#diff-47e62d520f7eae50d3519dbc612bbebcb49fef07fc4079a79b177921ac064db8R1748-R1763) [[7]](diffhunk://#diff-5f5975e512c19f502d53f7be6bdadfa01cafa61f5514a26e7a13870fd871080bR156-R158)
* Updated internal state tracking for external speaker enable/disable based on headphone jack status. [[1]](diffhunk://#diff-47e62d520f7eae50d3519dbc612bbebcb49fef07fc4079a79b177921ac064db8R61) [[2]](diffhunk://#diff-47e62d520f7eae50d3519dbc612bbebcb49fef07fc4079a79b177921ac064db8R1748-R1763)

**General Improvements and Maintenance:**

* Improved sorting stability in the ROM lister by switching from `std::sort` to `std::stable_sort` for directory/file ordering.
* Added new DVI enable flag and related preprocessor guards for conditional compilation.
* Refactored and clarified frame pacing and vsync handling for video output. [[1]](diffhunk://#diff-47e62d520f7eae50d3519dbc612bbebcb49fef07fc4079a79b177921ac064db8R211-R219) [[2]](diffhunk://#diff-47e62d520f7eae50d3519dbc612bbebcb49fef07fc4079a79b177921ac064db8R233-R234)

These changes collectively improve video and audio output reliability, add new hardware features, and enhance user experience with better peripheral detection and handling.This pull request introduces several enhancements and refactorings, primarily focused on improving audio handling (especially headphone detection and toggling) and adding support for HDMI/DVI video output on the RP2350 platform. The changes include new utility functions for headphone jack polling, significant additions for HDMI video output (including scanline effects and audio packet scheduling), and some minor code quality improvements.

**Audio Handling Improvements:**

* Added headphone jack polling and detection logic in `FrensHelpers.cpp` and `FrensHelpers.h`, including `pollHeadPhoneJack()` and `isHeadPhoneJackConnected()` functions, and a new `extSpeakerEnabled` state variable. This enables the system to detect when headphones are plugged in or unplugged and switch audio output accordingly. [[1]](diffhunk://#diff-47e62d520f7eae50d3519dbc612bbebcb49fef07fc4079a79b177921ac064db8R61) [[2]](diffhunk://#diff-47e62d520f7eae50d3519dbc612bbebcb49fef07fc4079a79b177921ac064db8R1748-R1763) [[3]](diffhunk://#diff-5f5975e512c19f502d53f7be6bdadfa01cafa61f5514a26e7a13870fd871080bR156-R158)
* Refactored the audio driver (`audio_i2s.c` and `audio_i2s.h`) to return a new `headphone_toggle_t` enum from headphone polling functions, allowing the main application to react to changes in headphone connection status. [[1]](diffhunk://#diff-aff1644b58be567c5103b4a1af00272c2d6ae41f4c35c0c92f9195c79e74e7d7L263-R263) [[2]](diffhunk://#diff-aff1644b58be567c5103b4a1af00272c2d6ae41f4c35c0c92f9195c79e74e7d7R289) [[3]](diffhunk://#diff-aff1644b58be567c5103b4a1af00272c2d6ae41f4c35c0c92f9195c79e74e7d7L673-R683) [[4]](diffhunk://#diff-40c0a706d5bad835a14480c2cc15dc181c806a909e85391fa434219ab5c0935bL78-R95)

**HDMI/DVI Video Output Support (RP2350):**

* Added new HDMI/DVI video output backend for the RP2350 platform, including scanline effects, framebuffer management, and audio sample pushing. The implementation includes new files such as `hstx.c`, `hstx.h`, `hstx_data_island_queue.c`, and `hstx_data_island_queue.h`. [[1]](diffhunk://#diff-0152243baed5599e7065c0111e94ca4f97a1d6cb22b5879dc7fefa14a9b173efR1-R191) [[2]](diffhunk://#diff-6cc13607296dbb42fe104f6c7614ad6e1c213d68a17ab9eabf3ddeaacebc544fR1-R30) [[3]](diffhunk://#diff-b1cceefedf2a3fc458f821483af604980e84c27672b2d25fa4c7e0b8a68bbd7eR1-R92) [[4]](diffhunk://#diff-dc9ddcc8fc4297210457ee251091e4f6a1bda45b4a59034d366ce4a1e0e31a70R1-R44)
* Introduced CMake configuration logic to conditionally build the HDMI backend only for the RP2350 platform.

**Video Output Timing and Frame Pacing:**

* Added `hstx_paceFrame()` and `hstx_waitForVSync()` functions for accurate frame pacing and synchronization in the new HDMI backend, improving video timing and reducing visual artifacts.

**Code Quality and Miscellaneous:**

* Changed sorting in `RomLister.cpp` from `std::sort` to `std::stable_sort` to maintain the relative order of equivalent elements, which can improve user experience in ROM listings.
* Added missing macro guards and configuration defaults in `FrensHelpers.h`.

These changes collectively improve the platform's audio and video capabilities, especially for systems using the RP2350, and lay the groundwork for more robust multimedia support.This pull request introduces support for detecting headphone jack events and routing audio output accordingly, as well as improvements to the settings menu, including a new "Reset Game" option. The main changes are grouped into audio handling enhancements and settings menu improvements.

**Audio handling enhancements:**

* Added headphone jack detection: Introduced functions in `FrensHelpers.cpp`/`.h` to poll headphone jack status and track whether external speakers or headphones should be used. The audio driver (`audio_i2s.c`/`.h`) now reports headphone connection events using a new `headphone_toggle_t` enum, allowing the main application to respond to hardware changes. (`[[1]](diffhunk://#diff-47e62d520f7eae50d3519dbc612bbebcb49fef07fc4079a79b177921ac064db8R61)`, `[[2]](diffhunk://#diff-47e62d520f7eae50d3519dbc612bbebcb49fef07fc4079a79b177921ac064db8R1737-R1752)`, `[[3]](diffhunk://#diff-5f5975e512c19f502d53f7be6bdadfa01cafa61f5514a26e7a13870fd871080bR156-R158)`, `[[4]](diffhunk://#diff-40c0a706d5bad835a14480c2cc15dc181c806a909e85391fa434219ab5c0935bL78-R95)`, `[[5]](diffhunk://#diff-aff1644b58be567c5103b4a1af00272c2d6ae41f4c35c0c92f9195c79e74e7d7L263-R263)`, `[[6]](diffhunk://#diff-aff1644b58be567c5103b4a1af00272c2d6ae41f4c35c0c92f9195c79e74e7d7R289)`, `[[7]](diffhunk://#diff-aff1644b58be567c5103b4a1af00272c2d6ae41f4c35c0c92f9195c79e74e7d7L673-R683)`, `[[8]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L218-R218)`)
* Audio output routing: The `wavplayer` module now checks headphone connection status and routes audio to the appropriate output (external audio or internal speaker), rather than relying solely on user settings. (`[[1]](diffhunk://#diff-2fca9411dcabc0ed3ed38ceb604be2cd667cde2f27ed218593b2b807adaff9b8L454-R454)`, `[[2]](diffhunk://#diff-2fca9411dcabc0ed3ed38ceb604be2cd667cde2f27ed218593b2b807adaff9b8L533-R533)`, `[[3]](diffhunk://#diff-2fca9411dcabc0ed3ed38ceb604be2cd667cde2f27ed218593b2b807adaff9b8L576-R576)`, `[[4]](diffhunk://#diff-2fca9411dcabc0ed3ed38ceb604be2cd667cde2f27ed218593b2b807adaff9b8L692-R692)`)

**Settings menu improvements:**

* Added "Reset Game" option: The settings menu (`menu.cpp`, `menu_settings.h`) now includes a "Reset Game" entry, allowing users to restart the current game from the menu. This includes changes to menu navigation, display, and action handling. (`[[1]](diffhunk://#diff-00942d15d2efd75e38630de1594be8470880d55ce6fc00a8315a508a1a832d1eR9)`, `[[2]](diffhunk://#diff-00942d15d2efd75e38630de1594be8470880d55ce6fc00a8315a508a1a832d1eR33)`, `[[3]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L2175-R2175)`, `[[4]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79R2239-R2244)`, `[[5]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L2430-R2434)`, `[[6]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L2482-R2485)`, `[[7]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L2649-R2658)`, `[[8]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79R2681-R2686)`)
* Menu layout and navigation tweaks: Adjusted palette row handling, spacers, and navigation logic for a smoother user experience. (`[[1]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L2188)`, `[[2]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L2197-R2196)`, `[[3]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L2464-L2465)`, `[[4]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L2630-R2633)`)
* Ensured normal timing after exiting the menu by calling `Frens::PaceFrames60fps(true)`. (`[menu.cppR2950](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79R2950)`)

**Other improvements:**

* Used `std::stable_sort` instead of `std::sort` in `RomLister.cpp` for consistent ordering of ROM entries. (`[RomLister.cppL188-R188](diffhunk://#diff-6e374881b3200170d573407b9b2c5e8f3d2de8eac7b7da0e338261c446e3b230L188-R188)`)
* Made DVI mode default conditional on both hardware config and the `ENABLEDVI` macro in `settings.cpp`. (`[settings.cppL113-R113](diffhunk://#diff-014d386d7f6ac8bbe4a0dc992031ea561c9e8929605a90078bdc2c3407e9017fL113-R113)`)
* Defined `ENABLEDVI` macro default in `FrensHelpers.h` for clarity. (`[FrensHelpers.hR72-R74](diffhunk://#diff-5f5975e512c19f502d53f7be6bdadfa01cafa61f5514a26e7a13870fd871080bR72-R74)`)

These changes collectively improve hardware integration for audio and enhance the usability of the settings menu.This pull request introduces improvements to how headphone jack detection and external audio output are handled, along with some related configuration and code cleanup. The changes add a proper API for polling headphone jack status, update the logic for enabling external speakers, and ensure that audio routing responds dynamically to headphone connection status. Additionally, there are minor updates to configuration flags for DVI mode.

**Headphone jack detection and audio output routing:**

* Added a new `headphone_toggle_t` enum and updated the audio driver API (`audio_i2s_poll_headphone_status`) to return headphone connection events, enabling more reliable detection of headphone insert/remove actions. (`drivers/pico_audio_i2s/audio_i2s.h` [[1]](diffhunk://#diff-40c0a706d5bad835a14480c2cc15dc181c806a909e85391fa434219ab5c0935bL78-R95) `drivers/pico_audio_i2s/audio_i2s.c` [[2]](diffhunk://#diff-aff1644b58be567c5103b4a1af00272c2d6ae41f4c35c0c92f9195c79e74e7d7L263-R263) [[3]](diffhunk://#diff-aff1644b58be567c5103b4a1af00272c2d6ae41f4c35c0c92f9195c79e74e7d7R289) [[4]](diffhunk://#diff-aff1644b58be567c5103b4a1af00272c2d6ae41f4c35c0c92f9195c79e74e7d7L673-R683)
* Implemented `Frens::pollHeadPhoneJack()` and `Frens::isHeadPhoneJackConnected()` to track and expose the current headphone connection state, replacing previous direct polling macro usage. (`FrensHelpers.cpp` [[1]](diffhunk://#diff-47e62d520f7eae50d3519dbc612bbebcb49fef07fc4079a79b177921ac064db8R1737-R1750) `FrensHelpers.h` [[2]](diffhunk://#diff-5f5975e512c19f502d53f7be6bdadfa01cafa61f5514a26e7a13870fd871080bR156-R158) `FrensHelpers.cpp` [[3]](diffhunk://#diff-47e62d520f7eae50d3519dbc612bbebcb49fef07fc4079a79b177921ac064db8R61)
* Updated `wavplayer` audio output logic to check headphone connection status and route audio to the appropriate output (external audio or internal speaker) dynamically, rather than relying solely on the `useExtAudio` flag. (`wavplayer.cpp` [[1]](diffhunk://#diff-2fca9411dcabc0ed3ed38ceb604be2cd667cde2f27ed218593b2b807adaff9b8L454-R454) [[2]](diffhunk://#diff-2fca9411dcabc0ed3ed38ceb604be2cd667cde2f27ed218593b2b807adaff9b8L533-R533) [[3]](diffhunk://#diff-2fca9411dcabc0ed3ed38ceb604be2cd667cde2f27ed218593b2b807adaff9b8L576-R576) [[4]](diffhunk://#diff-2fca9411dcabc0ed3ed38ceb604be2cd667cde2f27ed218593b2b807adaff9b8L692-R692)
* Changed the main menu frame loop to use the new headphone polling function for consistent state updates. (`menu.cpp` [menu.cppL218-R218](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L218-R218))

**Configuration and build improvements:**

* Modified the default for the DVI mode flag to only enable DVI output when both the hardware version and the `ENABLEDVI` macro are set, improving configurability for HDMI/DVI output. (`settings.cpp` [[1]](diffhunk://#diff-014d386d7f6ac8bbe4a0dc992031ea561c9e8929605a90078bdc2c3407e9017fL113-R113) `FrensHelpers.h` [[2]](diffhunk://#diff-5f5975e512c19f502d53f7be6bdadfa01cafa61f5514a26e7a13870fd871080bR72-R74)