### PR TITLE
Refresh selectedRomOrFolder on navigation changes

### DIFF
--- a/menu.cpp
+++ b/menu.cpp
@@ -3488,6 +3488,10 @@ void menu(const char *title, char *errorMessage, bool isFatal, bool showSplash, 
 #endif
             }
         }
+        // Refresh selectedRomOrFolder in case navigation changed selectedRow this frame
+        auto newIdx = settings.selectedRow - STARTROW + settings.firstVisibleRowINDEX;
+        selectedRomOrFolder = (romlister.Count() > 0) ? entries[newIdx].Path : nullptr;
+
         // scroll selected row horizontally if textsize exceeds rowlength
         if (selectedRomOrFolder)
         {

--- a/settings.cpp
+++ b/settings.cpp
@@ -25,7 +25,7 @@ namespace FrensSettings
         if ( emu == emulators::MULTI ) {
             emulatorType = emulators::NES;
         }   
-        loadsettings();
+       // loadsettings();
     }
     void setEmulatorType(const char * fileextension)
     {


### PR DESCRIPTION
This pull request introduces a minor fix to the menu navigation logic and comments out an unnecessary settings load in the emulator initialization code.

- **Menu Navigation Fixes:**
  * [`menu.cpp`](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79R3491-R3494): Updates the assignment of `selectedRomOrFolder` to ensure it reflects the currently selected row after navigation changes within the menu. This prevents inconsistencies when the user moves through the list.

- **Settings Initialization:**
  * [`settings.cpp`](diffhunk://#diff-014d386d7f6ac8bbe4a0dc992031ea561c9e8929605a90078bdc2c3407e9017fL28-R28): Comments out the call to `loadsettings()` in the emulator initialization because the SD driver is not loaded yet.