### PR TITLE
FDS disk switching and other fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Release notes
 
+## 2/5/2026
+
+- **Menu navigation fixes**:
+  - Fixed menu selection refresh when navigating folders and files.
+  - Improved handling of `selectedRomOrFolder` state during menu navigation changes.
+
+- **Settings initialization fix**:
+  - Fixed premature settings loading in `initSettings()` before SD driver is ready. Settings are now loaded only after the SD card is initialized.
+
 ## 25/4/2025
 
 - **New `pico_hdmi` HSTX driver** by [@fliperama86](https://github.com/fliperama86/pico_hdmi) replaces the in-tree HSTX driver used previously.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2/5/2026
 
-- **EMulator Specific**:
+- **Emulator Specific**:
   - NES: Added support for FDS disk switching in settings menu.
 
 - **Menu navigation fixes**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 2/5/2026
 
+- **EMulator Specific**:
+  - NES: Added support for FDS disk switching in settings menu.
+
 - **Menu navigation fixes**:
   - Fixed menu selection refresh when navigating folders and files.
   - Improved handling of `selectedRomOrFolder` state during menu navigation changes.

--- a/menu.cpp
+++ b/menu.cpp
@@ -27,6 +27,18 @@
 #include "wavplayer.h"
 const int8_t *g_settings_visibility;
 const uint8_t *g_available_screen_modes;
+
+// FDS disk-swap hooks. Null in builds (or ROM contexts) where FDS is
+// not active; the menu option is also kept hidden in those cases via
+// g_settings_visibility[MOPT_FDS_DISK_SWAP].
+static const MenuFdsHooks *s_fdsHooks = nullptr;
+void menuSetFdsHooks(const MenuFdsHooks *hooks) { s_fdsHooks = hooks; }
+
+// LEFT/RIGHT preview the disk choice without committing — A on the
+// option commits (or triggers Reset). -1 means "not initialised yet,
+// use the live current side". Set to "current side" each time the
+// menu opens.
+static int s_fdsPendingChoice = -1;
 #if !HSTX
 #define CC(x) (((x >> 1) & 15) | (((x >> 6) & 15) << 4) | (((x >> 11) & 15) << 8))
 const __UINT16_TYPE__ NesMenuPalette[64] = {
@@ -2087,6 +2099,9 @@ int showSettingsMenu(bool calledFromGame)
     int margintop = 0;
     int marginbottom = 0;
     settingsActive = true;
+    // Re-seed the FDS preview from the live current side on every menu
+    // open. The render switch fills it in on first draw.
+    s_fdsPendingChoice = -1;
     
     // #if HSTX
     //     if (settings.flags.useDVIModeForHDMI)
@@ -2175,8 +2190,15 @@ int showSettingsMenu(bool calledFromGame)
     // visibleCount+3: DEFAULT
     int visibleIndices[MOPT_COUNT];
     int visibleCount = 0;
+    // FDS disk swap goes first so it's auto-selected when an FDS game
+    // is running and the BIOS prompts the user to flip the disk.
+    if (g_settings_visibility[MOPT_FDS_DISK_SWAP] > 0)
+    {
+        visibleIndices[visibleCount++] = MOPT_FDS_DISK_SWAP;
+    }
     for (int i = 0; i < MOPT_COUNT; ++i)
     {
+        if (i == MOPT_FDS_DISK_SWAP) continue; // already handled above
         // -1 is always hidden
         if (g_settings_visibility[i] >= 0)
         {
@@ -2434,6 +2456,42 @@ int showSettingsMenu(bool calledFromGame)
                 value = working.flags.rapidFireOnB ? "ON" : "OFF";
                 break;
             }
+            case MenuSettingsIndex::MOPT_FDS_DISK_SWAP:
+            {
+                label = "Disk";
+                static char fdsBuf[16];
+                if (!s_fdsHooks || !s_fdsHooks->get_num_sides)
+                {
+                    value = "N/A";
+                }
+                else
+                {
+                    int n = s_fdsHooks->get_num_sides();
+                    if (s_fdsPendingChoice < 0)
+                    {
+                        // First render after menu open: seed pending choice
+                        // from the live current side (or 0 if ejected).
+                        int v = s_fdsHooks->get_swap_value();
+                        s_fdsPendingChoice = (v >= n) ? 0 : v;
+                    }
+                    if (s_fdsPendingChoice == n)
+                    {
+                        value = "Reset";
+                    }
+                    else if (n == 1)
+                    {
+                        value = "Disk A";
+                    }
+                    else
+                    {
+                        // 0 -> "Disk A", 1 -> "Disk B", ...
+                        snprintf(fdsBuf, sizeof(fdsBuf), "Disk %c",
+                                 'A' + s_fdsPendingChoice);
+                        value = fdsBuf;
+                    }
+                }
+                break;
+            }
             default:
                 label = "Unknown";
                 value = "";
@@ -2663,7 +2721,7 @@ int showSettingsMenu(bool calledFromGame)
                     selectedRowLocal = rowStartOptions; // wrap
                 }
             }
-            else if (pad & LEFT || pad & RIGHT || ((pad & A) && (optIndex == MOPT_EXIT_GAME || optIndex == MOPT_SAVE_RESTORE_STATE || optIndex == MOPT_ENTER_BOOTSEL_MODE || optIndex == MOPT_RESET_GAME)))
+            else if (pad & LEFT || pad & RIGHT || ((pad & A) && (optIndex == MOPT_EXIT_GAME || optIndex == MOPT_SAVE_RESTORE_STATE || optIndex == MOPT_ENTER_BOOTSEL_MODE || optIndex == MOPT_RESET_GAME || optIndex == MOPT_FDS_DISK_SWAP)))
             {
                 if (optIndex != -1)
                 {
@@ -2847,6 +2905,45 @@ int showSettingsMenu(bool calledFromGame)
 
                         working.flags.rapidFireOnB = !working.flags.rapidFireOnB;
 
+                        break;
+                    }
+                    case MOPT_FDS_DISK_SWAP:
+                    {
+                        if (!s_fdsHooks || !s_fdsHooks->get_num_sides) break;
+                        int n = s_fdsHooks->get_num_sides();
+                        if (n <= 0) break;
+                        int total = n + 1; // sides + Reset
+
+                        if (s_fdsPendingChoice < 0)
+                        {
+                            int v = s_fdsHooks->get_swap_value();
+                            s_fdsPendingChoice = (v >= n) ? 0 : v;
+                        }
+
+                        if (pad & A)
+                        {
+                            // Commit. n means "Reset", anything else is a side index.
+                            if (s_fdsPendingChoice == n)
+                            {
+                                rval = 5; // reset game (same as MOPT_RESET_GAME)
+                            }
+                            else
+                            {
+                                if (s_fdsHooks->request_swap)
+                                    s_fdsHooks->request_swap(s_fdsPendingChoice);
+                                rval = 0; // stay in game, no settings save needed
+                            }
+                            exitMenu = true;
+                            s_fdsPendingChoice = -1; // reset for next open
+                        }
+                        else
+                        {
+                            // LEFT/RIGHT just preview the next choice; do not
+                            // commit until the user presses A.
+                            s_fdsPendingChoice = right
+                                ? (s_fdsPendingChoice + 1) % total
+                                : (s_fdsPendingChoice + total - 1) % total;
+                        }
                         break;
                     }
                     default:

--- a/menu.h
+++ b/menu.h
@@ -45,6 +45,19 @@ void ClearScreen(int color);
 void putText(int x, int y, const char *text, int fgcolor, int bgcolor, bool wraplines = false, int offset = 0);
 void splash();  // is emulator specific
 int showSettingsMenu(bool calledFromGame = false);
+
+// Optional FDS disk-swap hooks. The NES emulator wires these up to its
+// FDS implementation at startup; other emulators leave it null and the
+// menu hides the option via g_settings_visibility[MOPT_FDS_DISK_SWAP].
+struct MenuFdsHooks
+{
+    int  (*get_swap_value)();          // 0..NumSides-1 for "Side N", NumSides for "Ejected"
+    int  (*get_num_sides)();           // total disk sides
+    void (*request_swap)(int newSide); // schedule eject + insert with newSide
+    void (*request_eject)();           // hold disk ejected
+};
+void menuSetFdsHooks(const MenuFdsHooks *hooks);
+
 bool showSaveStateMenu(int (*savestatefunc)(const char *path), int (*loadstatefunc)(const char *path), const char *extraMessage, SaveStateTypes quickSave);
 void getQuickSavePath(char *path, size_t pathsize);
 void getSaveStatePath(char *path, size_t pathsize, int slot);

--- a/menu_settings.h
+++ b/menu_settings.h
@@ -25,6 +25,7 @@ enum MenuSettingsIndex {
     MOPT_RAPID_FIRE_ON_A,
     MOPT_RAPID_FIRE_ON_B,
     MOPT_ENTER_BOOTSEL_MODE,
+    MOPT_FDS_DISK_SWAP,
     MOPT_COUNT
 };
 // Create and initialize an array which explains each option in a short description of max 40 characters
@@ -48,7 +49,8 @@ const char* const g_settings_descriptions[MOPT_COUNT] = {
     "Select border artwork",
     "Enable rapid fire for this button",
     "Enable rapid fire for this button",
-    "Reboot to BOOTSEL mode for flashing"
+    "Reboot to BOOTSEL mode for flashing",
+    "Eject / insert FDS disk side"
 };
 
 extern const int8_t *g_settings_visibility; // Visibility configuration for options menu

--- a/settings.h
+++ b/settings.h
@@ -66,9 +66,11 @@ namespace FrensSettings
     const char *getEmulatorTypeString(bool forSettings = false);
     emulators getEmulatorTypeForSettings();
 }
-extern const int8_t *g_settings_visibility; 
+extern const int8_t *g_settings_visibility;
 extern const uint8_t *g_available_screen_modes;
-extern const int8_t g_settings_visibility_nes[];
+// Non-const so the FDS disk-swap entry can be flipped on at runtime
+// when a .fds image is loaded (see main.cpp).
+extern int8_t g_settings_visibility_nes[];
 extern const int8_t g_settings_visibility_gb[];
 extern const int8_t g_settings_visibility_sms[];
 extern const int8_t g_settings_visibility_md[];


### PR DESCRIPTION
This pull request introduces support for Famicom Disk System (FDS) disk swapping in the NES emulator's settings menu, alongside several improvements to menu navigation and settings initialization. The FDS disk swap option is dynamically shown or hidden based on the loaded ROM, and the user can preview and commit disk changes directly from the menu. Additionally, fixes were made to menu state handling and the initialization sequence for settings.

**FDS Disk Swapping Support:**

* Added a new `MOPT_FDS_DISK_SWAP` menu option for FDS disk side selection, allowing users to preview sides with LEFT/RIGHT and commit changes with A; includes a "Reset" option and hides itself when FDS is not active. (`menu.cpp` [[1]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79R30-R41) [[2]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79R2459-R2494) [[3]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79R2910-R2948) [[4]](diffhunk://#diff-00942d15d2efd75e38630de1594be8470880d55ce6fc00a8315a508a1a832d1eR28) [[5]](diffhunk://#diff-00942d15d2efd75e38630de1594be8470880d55ce6fc00a8315a508a1a832d1eL51-R53) [[6]](diffhunk://#diff-57c3f339b379900ba3d98e0593d8ffdb78d9d190381c3533b4a29cb021488b4bR48-R60)
* Introduced the `MenuFdsHooks` struct and related functions to allow the menu to interact with the emulator's FDS implementation, with hooks for getting/setting disk side and handling ejection. (`menu.h` [menu.hR48-R60](diffhunk://#diff-57c3f339b379900ba3d98e0593d8ffdb78d9d190381c3533b4a29cb021488b4bR48-R60))
* Made `g_settings_visibility_nes` non-const so the FDS disk swap menu entry can be enabled/disabled at runtime depending on the loaded ROM. (`settings.h` [settings.hL71-R73](diffhunk://#diff-88a0bc26086d1758930207158e74ec237a7ea0cbe46a612d6364f001c869fcd9L71-R73))

**Menu Navigation and State Handling:**

* Improved menu selection refresh and handling of `selectedRomOrFolder` state when navigating folders and files, ensuring the correct state is maintained during navigation. (`CHANGELOG.md` [CHANGELOG.mdR3-R14](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R14))
* Ensured the FDS disk swap option is auto-selected when an FDS game is running and the BIOS prompts for disk flipping. (`menu.cpp` [menu.cppR2193-R2201](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79R2193-R2201))

**Settings Initialization Fix:**

* Fixed a bug where settings were loaded prematurely in `initSettings()` before the SD driver was ready; settings are now loaded only after SD card initialization. (`CHANGELOG.md` [CHANGELOG.mdR3-R14](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R14))

**Changelog Update:**

* Documented all of the above changes in the `CHANGELOG.md` for the 2/5/2026 release. (`CHANGELOG.md` [CHANGELOG.mdR3-R14](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R14))