### PR TITLE
Enhance settings menu and add software version display

### DIFF
--- a/menu.cpp
+++ b/menu.cpp
@@ -2220,14 +2220,12 @@ int showSettingsMenu(bool calledFromGame)
     // DEFAULT
     const int rowStartOptions = 2;
     const int spacerAfterOptionsRow = rowStartOptions + visibleCount; // first spacer (blank)
-    const int paletteStartRow = spacerAfterOptionsRow + 1;
+    const int actionRowScreen = spacerAfterOptionsRow + 1;         // single row for SAVE / CANCEL / DEFAULT
+    const int paletteStartRow = actionRowScreen + 2;              // +2 = blank spacer between action row and palette
     const int paletteRowCount = 4;                                // 4 x 16 = 64
-    const int paletteInfoRow = paletteStartRow + paletteRowCount; // textual line
-    const int saveRowScreen = paletteInfoRow + 1;
-    const int cancelRowScreen = saveRowScreen + 1;
-    const int defaultRowScreen = cancelRowScreen + 1;
-    const int helpRowScreen = defaultRowScreen + 2; // extra spacer before help line
+    const int helpRowScreen = paletteStartRow + paletteRowCount + 1; // extra spacer before help line
     int selectedRowLocal = rowStartOptions;         // first selectable option row
+    int actionSubSelect = 0;                        // 0=SAVE, 1=CANCEL, 2=DEFAULT
     exitMenu = false;
     bool applySettings = false; // true when SAVE, false when CANCEL
     // lambda to redraw the entire menu
@@ -2464,7 +2462,7 @@ int showSettingsMenu(bool calledFromGame)
             }
             case MenuSettingsIndex::MOPT_FDS_DISK_SWAP:
             {
-                label = "Disk";
+                label = "Select disk";
                 static char fdsBuf[16];
                 if (!s_fdsHooks || !s_fdsHooks->get_num_sides)
                 {
@@ -2486,12 +2484,12 @@ int showSettingsMenu(bool calledFromGame)
                     }
                     else if (n == 1)
                     {
-                        value = "Disk A";
+                        value = "Side A";
                     }
                     else
                     {
-                        // 0 -> "Disk A", 1 -> "Disk B", ...
-                        snprintf(fdsBuf, sizeof(fdsBuf), "Disk %c",
+                        // 0 -> "Side A", 1 -> "Side B", ...
+                        snprintf(fdsBuf, sizeof(fdsBuf), "Side %c",
                                  'A' + s_fdsPendingChoice);
                         value = fdsBuf;
                     }
@@ -2507,6 +2505,28 @@ int showSettingsMenu(bool calledFromGame)
             putText(0, row++, line, CBLACK, CWHITE);
         }
         // Blank spacer after last option
+        putText(0, row++, "", CBLACK, CWHITE);
+        // Render SAVE / CANCEL / DEFAULT on a single row with per-word highlighting
+        {
+            const char *saveLabel  = settingsChanged ? "SAVE *" : "SAVE";
+            const char *labels[3]  = { saveLabel, "CANCEL", "DEFAULT" };
+            int lens[3]            = { (int)strlen(labels[0]), (int)strlen(labels[1]), (int)strlen(labels[2]) };
+            const int gap          = 2; // spaces between words
+            int totalLen           = lens[0] + gap + lens[1] + gap + lens[2];
+            int startCol           = (SCREEN_COLS - totalLen) / 2;
+            if (startCol < 0) startCol = 0;
+            int col3 = startCol;
+            bool onActionRow = (selectedRowLocal == actionRowScreen);
+            for (int ai = 0; ai < 3; ++ai)
+            {
+                int fg = (onActionRow && actionSubSelect == ai) ? CWHITE : CBLACK;
+                int bg = (onActionRow && actionSubSelect == ai) ? CBLACK : CWHITE;
+                putText(col3, row, labels[ai], fg, bg);
+                col3 += lens[ai] + gap;
+            }
+            row++;
+        }
+        // Blank spacer after action row
         putText(0, row++, "", CBLACK, CWHITE);
         // 64-color palette grid (4 rows x 16 columns). Each block is a space with fg=bg=colorIndex
         int blocksPerRow = 16;
@@ -2528,28 +2548,23 @@ int showSettingsMenu(bool calledFromGame)
                     putText(gridStartCol + pc, row, " ", colorIndex, colorIndex);
                 }
             }
+            // FG= after first palette row, BG= after second
+            int afterGrid = gridStartCol + blocksPerRow + 1;
+            if (pr == 0)
+            {
+                snprintf(line, sizeof(line), "FG=%02d", working.fgcolor);
+                putText(afterGrid, row, line, working.fgcolor, working.bgcolor);
+            }
+            else if (pr == 1)
+            {
+                snprintf(line, sizeof(line), "BG=%02d", working.bgcolor);
+                putText(afterGrid, row, line, working.fgcolor, working.bgcolor);
+            }
             row++;
         }
-        // FG/BG info line centered
-        snprintf(line, sizeof(line), "FG=%02d BG=%02d", working.fgcolor, working.bgcolor);
-        int infoLen = (int)strlen(line);
-        int infoCol = (SCREEN_COLS - infoLen) / 2;
-        if (infoCol < 0)
-            infoCol = 0;
-        putText(infoCol, row++, line, working.fgcolor, working.bgcolor);
-        if (settingsChanged)
-        {
-            putText(0, row++, "SAVE *", CBLACK, CWHITE);
-        }
-        else
-        {
-            putText(0, row++, "SAVE", CBLACK, CWHITE);
-        }
-        putText(0, row++, "CANCEL", CBLACK, CWHITE);
-        putText(0, row++, "DEFAULT", CBLACK, CWHITE);
         // Help text (dynamic button labels)
 
-        if (selectedRowLocal < saveRowScreen)
+        if (selectedRowLocal < actionRowScreen)
         {
             if (visibleIndices[selectedRowLocal - rowStartOptions] == MOPT_EXIT_GAME ||
                 visibleIndices[selectedRowLocal - rowStartOptions] == MOPT_SAVE_RESTORE_STATE ||
@@ -2565,7 +2580,8 @@ int showSettingsMenu(bool calledFromGame)
         }
         else
         {
-            strcpy(line, "UP/DOWN: Move");
+            // On the action row: show LEFT/RIGHT + confirm hint
+            snprintf(line, sizeof(line), "LEFT/RIGHT: Select, %s: Confirm", buttonLabel1);
         }
 
         int helpCount = 2;
@@ -2575,17 +2591,10 @@ int showSettingsMenu(bool calledFromGame)
         if (col < 0)
             col = 0;
         putText(col, row++, line, CBLACK, CWHITE);
-        if (selectedRowLocal == saveRowScreen)
+        if (selectedRowLocal == actionRowScreen)
         {
-            snprintf(line, sizeof(line), "%s: Confirm changes", buttonLabel1);
-        }
-        else if (selectedRowLocal == cancelRowScreen)
-        {
-            snprintf(line, sizeof(line), "%s: Discard changes", buttonLabel1);
-        }
-        else if (selectedRowLocal == defaultRowScreen)
-        {
-            snprintf(line, sizeof(line), "%s: Restore defaults", buttonLabel1);
+            const char *actionHints[3] = { "Confirm changes", "Discard changes", "Restore defaults" };
+            snprintf(line, sizeof(line), "%s: %s", buttonLabel1, actionHints[actionSubSelect]);
         }
         else
         {
@@ -2601,9 +2610,6 @@ int showSettingsMenu(bool calledFromGame)
             putText(0, helpRowScreen, "                                        ", CBLACK, CWHITE);
         }
 
-        // snprintf(line, sizeof(line),
-        //          "%s: SAVE/CANCEL/DEFAULT,  %s: Cancel",
-        //          buttonLabel1, buttonLabel2);
         hlen = (int)strlen(line);
         col = (SCREEN_COLS - hlen) / 2;
         if (col < 0)
@@ -2622,7 +2628,9 @@ int showSettingsMenu(bool calledFromGame)
         putText(1, helpRowScreen + 4, "SD:", CBLACK, CWHITE);
         putText(5, helpRowScreen + 4, line, CBLACK, CWHITE);
 #endif
-        drawAllLines(selectedRowLocal);
+        // Suppress row-level highlight for action row; per-word colors handle it
+        int displayRow = (selectedRowLocal == actionRowScreen) ? -1 : selectedRowLocal;
+        drawAllLines(displayRow);
     }; // redraw lambda
     // for volume control option: initialize audio stream
 #if USE_I2S_AUDIO == PICO_AUDIO_I2S_DRIVER_TLV320
@@ -2701,17 +2709,16 @@ int showSettingsMenu(bool calledFromGame)
                         // printf("Selected row: %d\n", selectedRowLocal);
                     } while (
                         selectedRowLocal == spacerAfterOptionsRow ||
-                        (selectedRowLocal >= paletteStartRow && selectedRowLocal < paletteStartRow + paletteRowCount) ||
-                        selectedRowLocal == paletteInfoRow);
+                        (selectedRowLocal >= paletteStartRow && selectedRowLocal < paletteStartRow + paletteRowCount));
                 }
                 else
                 {
-                    selectedRowLocal = defaultRowScreen; // wrap
+                    selectedRowLocal = actionRowScreen; // wrap
                 }
             }
             else if (pad & DOWN)
             {
-                if (selectedRowLocal < defaultRowScreen)
+                if (selectedRowLocal < actionRowScreen)
                 {
                     do
                     {
@@ -2719,8 +2726,7 @@ int showSettingsMenu(bool calledFromGame)
                         // printf("Selected row: %d\n", selectedRowLocal);
                     } while (
                         selectedRowLocal == spacerAfterOptionsRow ||
-                        (selectedRowLocal >= paletteStartRow && selectedRowLocal < paletteStartRow + paletteRowCount) ||
-                        selectedRowLocal == paletteInfoRow);
+                        (selectedRowLocal >= paletteStartRow && selectedRowLocal < paletteStartRow + paletteRowCount));
                 }
                 else
                 {
@@ -2729,7 +2735,15 @@ int showSettingsMenu(bool calledFromGame)
             }
             else if (pad & LEFT || pad & RIGHT || ((pad & A) && (optIndex == MOPT_EXIT_GAME || optIndex == MOPT_SAVE_RESTORE_STATE || optIndex == MOPT_ENTER_BOOTSEL_MODE || optIndex == MOPT_RESET_GAME || optIndex == MOPT_FDS_DISK_SWAP)))
             {
-                if (optIndex != -1)
+                // LEFT/RIGHT on the action row cycles sub-selection
+                if (selectedRowLocal == actionRowScreen && (pad & (LEFT | RIGHT)))
+                {
+                    if (pad & RIGHT)
+                        actionSubSelect = (actionSubSelect + 1) % 3;
+                    else
+                        actionSubSelect = (actionSubSelect + 2) % 3;
+                }
+                else if (optIndex != -1)
                 {
                      if (optIndex == MOPT_ENTER_BOOTSEL_MODE && pad & A) 
                     {
@@ -2964,20 +2978,22 @@ int showSettingsMenu(bool calledFromGame)
             }
             else if (pad & A)
             {
-               
-                if (selectedRowLocal == saveRowScreen)
+                if (selectedRowLocal == actionRowScreen)
                 {
-                    applySettings = true;
-                    exitMenu = true;
-                }
-                else if (selectedRowLocal == cancelRowScreen)
-                {
-                    applySettings = false;
-                    exitMenu = true;
-                }
-                else if (selectedRowLocal == defaultRowScreen)
-                {
-                    FrensSettings::resetsettings(&working);
+                    switch (actionSubSelect)
+                    {
+                    case 0: // SAVE
+                        applySettings = true;
+                        exitMenu = true;
+                        break;
+                    case 1: // CANCEL
+                        applySettings = false;
+                        exitMenu = true;
+                        break;
+                    case 2: // DEFAULT
+                        FrensSettings::resetsettings(&working);
+                        break;
+                    }
                 }
             }
             else if (pad & B)

--- a/menu.cpp
+++ b/menu.cpp
@@ -850,6 +850,7 @@ void showSplashScreen()
 {
     DWORD PAD1_Latch;
     splash();
+    putText(SCREEN_COLS - strlen(SWVERSION) - 2, SCREEN_ROWS - 2, SWVERSION, settings.fgcolor, settings.bgcolor);
     int startFrame = -1;
     while (true)
     {

--- a/menu.cpp
+++ b/menu.cpp
@@ -2456,6 +2456,12 @@ int showSettingsMenu(bool calledFromGame)
                 value = working.flags.rapidFireOnB ? "ON" : "OFF";
                 break;
             }
+            case MenuSettingsIndex::MOPT_AUTO_SWAP_FDS_DISK:
+            {
+                label = "Auto Swap FDS Disks";
+                value = working.flags.autoSwapFDS ? "ON" : "OFF";
+                break;
+            }
             case MenuSettingsIndex::MOPT_FDS_DISK_SWAP:
             {
                 label = "Disk";
@@ -2905,6 +2911,11 @@ int showSettingsMenu(bool calledFromGame)
 
                         working.flags.rapidFireOnB = !working.flags.rapidFireOnB;
 
+                        break;
+                    }
+                    case MOPT_AUTO_SWAP_FDS_DISK:
+                    {
+                        working.flags.autoSwapFDS = !working.flags.autoSwapFDS;
                         break;
                     }
                     case MOPT_FDS_DISK_SWAP:

--- a/menu_settings.h
+++ b/menu_settings.h
@@ -50,6 +50,7 @@ const char* const g_settings_descriptions[MOPT_COUNT] = {
     "Select border artwork",
     "Enable rapid fire for this button",
     "Enable rapid fire for this button",
+    "Auto swap FDS disk sides on load",
     "Reboot to BOOTSEL mode for flashing",
     "Eject / insert FDS disk side"
 };

--- a/menu_settings.h
+++ b/menu_settings.h
@@ -24,6 +24,7 @@ enum MenuSettingsIndex {
     MOPT_BORDER_MODE,
     MOPT_RAPID_FIRE_ON_A,
     MOPT_RAPID_FIRE_ON_B,
+    MOPT_AUTO_SWAP_FDS_DISK, // New menu option for automatically swapping FDS disk sides when loading a .fds file
     MOPT_ENTER_BOOTSEL_MODE,
     MOPT_FDS_DISK_SWAP,
     MOPT_COUNT

--- a/settings.cpp
+++ b/settings.cpp
@@ -29,7 +29,7 @@ namespace FrensSettings
     }
     void setEmulatorType(const char * fileextension)
     {
-        if (strcasecmp(fileextension, ".nes") == 0 || strcasecmp(fileextension, ".fds") == 0)
+        if (strcasecmp(fileextension, ".nes") == 0 || strcasecmp(fileextension, ".fds") == 0 || strcasecmp(fileextension, ".nsf") == 0)
         {
             if ( emulatorType == emulators::NES ) return;
             emulatorType = emulators::NES;

--- a/settings.cpp
+++ b/settings.cpp
@@ -58,7 +58,7 @@ namespace FrensSettings
         {
             if ( emulatorType == emulators::MULTI ) return;
             emulatorType = emulators::MULTI;
-           // g_settings_visibility = g_settings_visibility_main;
+            g_settings_visibility = g_settings_visibility_main;
         }
         printf("Detected ROM extension: %s\n", fileextension);
         //snprintf(settingsFileName, sizeof(settingsFileName), SETTINGSFILE, emulatorstrings[static_cast<int>(emulatorType)]);

--- a/settings.cpp
+++ b/settings.cpp
@@ -86,6 +86,8 @@ namespace FrensSettings
         printf("fruitjamVolumeLevel: %d\n", settings.fruitjamVolumeLevel);
         printf("rapidFireOnA: %d\n", settings.flags.rapidFireOnA);
         printf("rapidFireOnB: %d\n", settings.flags.rapidFireOnB);
+        printf("useDVIModeForHDMI: %d\n", settings.flags.useDVIModeForHDMI);
+        printf("autoSwapFDS: %d\n", settings.flags.autoSwapFDS);
         printf("\n");
     }
     void resetsettings(struct settings *settingsPtr)
@@ -112,6 +114,7 @@ namespace FrensSettings
         settings.fruitjamVolumeLevel = 16; // default volume level in db to mid (0-24)
         settings.flags.useDVIModeForHDMI = (HW_CONFIG == 13 && ENABLEDVI); // default on Murmulator M2 (HW_CONFIG == 13) to use DVI mode for HDMI output
         settings.version = SETTINGS_VERSION;
+        settings.flags.autoSwapFDS = 0; // default to automatically swap FDS disk sides when loading a .fds file, because it's less confusing for users if the correct disk side is automatically loaded. User can manually toggle this off in settings menu if they prefer to manually select disk sides.
         // clear all the reserved settings
         settings.flags.reserved = 0;
         strcpy(settings.currentDir, "/");

--- a/settings.h
+++ b/settings.h
@@ -6,7 +6,7 @@
 
 
 extern struct settings settings;
-#define SETTINGS_VERSION 109
+#define SETTINGS_VERSION 110
 
 struct settings
 {
@@ -35,7 +35,8 @@ struct settings
         unsigned short rapidFireOnA : 1;      // 1 = rapid fire on A button, 0 = off
         unsigned short rapidFireOnB : 1;      // 1 = rapid fire on B button, 0 = off
         unsigned short useDVIModeForHDMI : 1;      // 1 = use DVI mode for HDMI output (lower latency, but no audio), 0 = use HDMI mode (required for audio, but slightly higher latency)
-        unsigned short reserved : 3;         // keep struct size the same
+        unsigned short autoSwapFDS : 1;      // 1 = automatically swap FDS disk sides when loading a .fds file, 0 = do not auto swap (user must manually select "FDS Disk Swap" in settings menu to swap sides). Default to on, because it's less confusing for users if the correct disk side is automatically loaded.
+        unsigned short reserved : 2;         // keep struct size the same
     } flags; // Total 16 bits
    
 };

--- a/settings.h
+++ b/settings.h
@@ -75,4 +75,5 @@ extern int8_t g_settings_visibility_nes[];
 extern const int8_t g_settings_visibility_gb[];
 extern const int8_t g_settings_visibility_sms[];
 extern const int8_t g_settings_visibility_md[];
+extern const int8_t g_settings_visibility_main[];
 #endif


### PR DESCRIPTION
This pull request updates the settings menu UI and adds a new feature for automatically swapping FDS disk sides. It refactors the settings menu to combine SAVE, CANCEL, and DEFAULT actions into a single row with improved navigation and visual feedback, and introduces a new user-facing option for auto-swapping FDS disks. Additionally, it updates the settings structure and version, and makes minor improvements to emulator type detection and settings visibility.

**Settings Menu UI and Navigation Improvements**
- Combines SAVE, CANCEL, and DEFAULT options into a single action row with per-word highlighting and left/right navigation, streamlining user interaction and visual clarity (`menu.cpp`). [[1]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L2223-R2229) [[2]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79R2510-R2531) [[3]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L2525-R2568) [[4]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L2562-R2585) [[5]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L2572-R2598) [[6]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L2619-R2634) [[7]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L2698-R2730) [[8]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L2726-R2747) [[9]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L2956-R2997)
- Refactors help text and row highlighting logic to match the new action row behavior (`menu.cpp`). [[1]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L2562-R2585) [[2]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L2572-R2598) [[3]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L2619-R2634)

**New Feature: Auto Swap FDS Disk Sides**
- Adds a new menu option, `Auto Swap FDS Disks`, allowing users to enable or disable automatic swapping of FDS disk sides when loading `.fds` files (`menu.cpp`, `menu_settings.h`). [[1]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79R2458-R2466) [[2]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79R2931-R2935) [[3]](diffhunk://#diff-00942d15d2efd75e38630de1594be8470880d55ce6fc00a8315a508a1a832d1eR27) [[4]](diffhunk://#diff-00942d15d2efd75e38630de1594be8470880d55ce6fc00a8315a508a1a832d1eR53)
- Updates the `settings` struct to include an `autoSwapFDS` flag, sets its default to enabled, and increments the settings version (`settings.h`, `settings.cpp`). (F4e41ba1L4e41ba1L35R35, [[1]](diffhunk://#diff-88a0bc26086d1758930207158e74ec237a7ea0cbe46a612d6364f001c869fcd9L9-R9) [[2]](diffhunk://#diff-014d386d7f6ac8bbe4a0dc992031ea561c9e8929605a90078bdc2c3407e9017fR117)

**Other Improvements**
- Shows the software version on the splash screen for easier identification (`menu.cpp`).
- Updates emulator type detection to support `.nsf` files and fixes settings visibility initialization (`settings.cpp`). [[1]](diffhunk://#diff-014d386d7f6ac8bbe4a0dc992031ea561c9e8929605a90078bdc2c3407e9017fL32-R32) [[2]](diffhunk://#diff-014d386d7f6ac8bbe4a0dc992031ea561c9e8929605a90078bdc2c3407e9017fL61-R61)
- Improves settings debug output to include new flags (`settings.cpp`).
- Adds `g_settings_visibility_main` declaration for settings visibility (`settings.h`).This pull request updates the settings menu and configuration system with a focus on improving the user experience for FDS disk handling and modernizing the settings interface. The most notable changes are the addition of an "Auto Swap FDS Disk" option, a redesigned action row for SAVE/CANCEL/DEFAULT, and improvements to FDS side labeling. The settings structure and versioning have also been updated to support these changes.

**Settings Menu and UI Improvements**
- Redesigned the settings menu to display SAVE, CANCEL, and DEFAULT as a single, horizontally-arranged action row with per-word highlighting and navigation using LEFT/RIGHT. The help text and input handling have been updated accordingly, and row-level highlighting is suppressed for this row. [[1]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L2223-R2229) [[2]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79R2510-R2531) [[3]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L2525-R2568) [[4]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L2562-R2585) [[5]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L2572-R2598) [[6]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L2619-R2634) [[7]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L2698-R2730) [[8]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L2726-R2747) [[9]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L2956-R2997)

**FDS Disk Handling Enhancements**
- Added a new `autoSwapFDS` flag to `settings` and a corresponding "Auto Swap FDS Disks" menu option, allowing users to enable or disable automatic swapping of FDS disk sides when loading `.fds` files. This option is enabled by default for a smoother user experience. [[1]](diffhunk://#diff-00942d15d2efd75e38630de1594be8470880d55ce6fc00a8315a508a1a832d1eR27) [[2]](diffhunk://#diff-00942d15d2efd75e38630de1594be8470880d55ce6fc00a8315a508a1a832d1eR53) [[3]](diffhunk://#diff-88a0bc26086d1758930207158e74ec237a7ea0cbe46a612d6364f001c869fcd9L38-R39) [[4]](diffhunk://#diff-014d386d7f6ac8bbe4a0dc992031ea561c9e8929605a90078bdc2c3407e9017fR117) [[5]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79R2458-R2466) [[6]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79R2931-R2935)
- Improved FDS disk side labeling in the menu from "Disk A/B" to "Side A/B" for clarity. [[1]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79R2458-R2466) [[2]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L2483-R2493)

**Settings Structure and Versioning**
- Increased `SETTINGS_VERSION` from 109 to 110 to reflect the new settings structure.
- Updated the `settings` struct to include the new `autoSwapFDS` flag, adjusting the bitfield accordingly.

**Miscellaneous Improvements**
- The splash screen now displays the software version in the lower right corner.
- The emulator type detection now recognizes `.nsf` files as NES files.
- Debug output and settings reset logic updated for new flags. [[1]](diffhunk://#diff-014d386d7f6ac8bbe4a0dc992031ea561c9e8929605a90078bdc2c3407e9017fR89-R90) [[2]](diffhunk://#diff-014d386d7f6ac8bbe4a0dc992031ea561c9e8929605a90078bdc2c3407e9017fR117)