### PR TITLE
Fix memory allocation issues and enhance logging in FrensHelpers (#65)

### DIFF
--- a/FrensHelpers.cpp
+++ b/FrensHelpers.cpp
@@ -689,15 +689,15 @@ namespace Frens
             void *pMem = psram_.Malloc(size);
             if (!pMem)
             {
-                panic("Cannot allocate %zu bytes in PSRAM\n", size);
+                panic("[f_malloc] Cannot allocate %zu bytes in PSRAM\n", size);
             }
-            printf("Allocated %zu bytes in PSRAM at %p\n", size, pMem);
+            printf("[f_malloc] Allocated %zu bytes in PSRAM at %p\n", size, pMem);
             return pMem;
         }
 #endif
         // PSRAM not enabled, use malloc
         void *pMem = malloc(size); // panics if unavailable
-        printf("Allocated %zu bytes in RAM at %p\n", size, pMem);
+        printf("[f_malloc] Allocated %zu bytes in RAM at %p\n", size, pMem);
         return pMem;
     }
 
@@ -714,7 +714,7 @@ namespace Frens
         {
             PicoPlusPsram &psram_ = PicoPlusPsram::getInstance();
             size_t uFreeing = psram_.GetSize(pMem);
-            printf("Freeing %zu bytes from PSRAM at %p\n", uFreeing, pMem);
+            printf("[f_malloc] Freeing %zu bytes from PSRAM at %p\n", uFreeing, pMem);
             psram_.Free(pMem);
             return;
         }
@@ -722,7 +722,7 @@ namespace Frens
         // PSRAM not enabled, use free
         if (pMem)
         {
-            printf("Freeing memory at %p\n", pMem);
+            printf("[f_malloc] Freeing memory at %p\n", pMem);
             free(pMem);
         }
     }
@@ -743,13 +743,13 @@ namespace Frens
             {
                 panic("Cannot allocate %zu bytes in PSRAM\n", newSize);
             }
-            printf("re-Allocated %zu bytes in PSRAM at %p\n", newSize, newMem);
+            printf("[f_malloc] Re-Allocated %zu bytes in PSRAM at %p\n", newSize, newMem);
             return newMem;
         }
 #endif
         // PSRAM not enabled, use realloc
         newMem = realloc(pMem, newSize);
-        printf("Re-Allocated memory at %p to %zu bytes\n", pMem, newSize);
+        printf("[f_malloc] Re-Allocated memory at %p to %zu bytes\n", pMem, newSize);
         return newMem;
     }
 

--- a/drivers/pico_hdmi/hstx_data_island_queue.c
+++ b/drivers/pico_hdmi/hstx_data_island_queue.c
@@ -32,11 +32,9 @@ void hstx_di_queue_init(void)
     audio_sample_accum = 0;
     // Allocate memory for the ring buffer
     if (di_ring_buffer == NULL) {
-        printf("Allocating memory for HSTX DI ring buffer: %d bytes\n", DI_RING_BUFFER_SIZE * sizeof(hstx_data_island_t));  
-        di_ring_buffer = (hstx_data_island_t *)frens_f_malloc(DI_RING_BUFFER_SIZE * sizeof(hstx_data_island_t));
+        printf("Allocating memory for HSTX DI ring buffer: %d bytes\n", DI_RING_BUFFER_SIZE * sizeof(hstx_data_island_t));
+        di_ring_buffer = (hstx_data_island_t *)malloc(DI_RING_BUFFER_SIZE * sizeof(hstx_data_island_t));
     }
-    // Build a single silent audio packet with fixed B-frame flags.
-    di_ring_buffer = (hstx_data_island_t *)malloc(DI_RING_BUFFER_SIZE * sizeof(hstx_data_island_t));
     // Build a single silent audio packet with fixed B-frame flags.
     hstx_packet_t packet;
     audio_sample_t samples[4] = {0};

--- a/menu.cpp
+++ b/menu.cpp
@@ -3027,35 +3027,13 @@ int showSettingsMenu(bool calledFromGame)
     // restore contents of swap file back to altScreenbuffer when not nullptr
     if (calledFromGame)
     {
-#if 0
-        FIL fil;
-        FRESULT fr;
-        fr = f_open(&fil, "/swapfile.DAT", FA_READ);
-        if (fr == FR_OK) {
-            size_t br;
-            fr = f_read(&fil, altscreenBuffer, altscreenBufferSize, &br);
-            if (fr != FR_OK || br != altscreenBufferSize) {
-                printf("Error reading swapfile.DAT: %d, read %d bytes\n", fr, br);
-            } else {        
-                printf("Read %d bytes from swapfile.DAT\n", br);
-            }
-            f_close(&fil);
-            // delete the swap file
-            fr = f_unlink("/swapfile.DAT");
-            if (fr != FR_OK) {
-                printf("Error deleting swapfile.DAT: %d\n", fr);
-            } else {
-                printf("Deleted swapfile.DAT\n");
-            }
-        } else {
-            printf("Error opening swapfile.DAT for reading: %d\n", fr);
-        }
-#else
-        Frens::f_free((void *)screenBuffer);
-#endif
+
         ClearScreen(CBLACK); // Removes artifacts from previous screen
-                             // Wait until user has released all buttons
         waitForNoButtonPress();
+        Frens::f_free((void *)screenBuffer);
+        screenBuffer = nullptr;
+
+      
 #if !HSTX
         scaleMode8_7_ = Frens::applyScreenMode(settings.screenMode);
         // Reset the screen mode to the original settings


### PR DESCRIPTION
* Fix double memory allocation bug for HSTX DI ring buffer in hstx_di_queue_init

* Enhance memory allocation logging in FrensHelpers to include function context

* Fix use after free bug in settings menu. Clean dead code.