### PR TITLE
Add PCE and O2E emulator support with improved audio and memory management

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,8 +21,17 @@ wavplayer.cpp
 FlashParams.cpp
 #PicoPlusPsram.cpp
 )
-add_subdirectory(drivers/pico_fatfs)     
-add_subdirectory(drivers/pico_audio_i2s)
+add_subdirectory(drivers/pico_fatfs)
+add_subdirectory(drivers/tlv320dac3100)
+
+option(USE_PICO_EXTRAS_I2S "Use the pico-extras based I2S audio driver instead of the custom one" OFF)
+if (USE_PICO_EXTRAS_I2S)
+    message(STATUS "Using pico-extras I2S audio driver")
+    add_subdirectory(drivers/pico_audio_i2s_pe)
+else()
+    message(STATUS "Using legacy I2S audio driver")
+    add_subdirectory(drivers/pico_audio_i2s)
+endif()
 add_subdirectory(drivers/lwmem)
 # add_subdirectory(drivers/pico_hstx)
 # add_subdirectory(drivers/pico_audio_mcp4822) # SPI Audio using MCP4822 DAC. Works but not used
@@ -32,8 +41,9 @@ add_subdirectory(drivers/pico_hdmi)
 target_include_directories(pico_shared INTERFACE
         .
 )
-target_compile_definitions(pico_shared INTERFACE 
+target_compile_definitions(pico_shared INTERFACE
  NOHSTXCLOCK=1 # Do not set the hstx clock in the pico_hdmi driver, as it is already set FrensHelpers.cpp
+ USE_PICO_EXTRAS_I2S=$<BOOL:${USE_PICO_EXTRAS_I2S}>
 )
 pico_generate_pio_header(${projectname} ${CMAKE_CURRENT_LIST_DIR}/ws2812.pio)
 target_link_libraries(pico_shared 

--- a/FrensHelpers.cpp
+++ b/FrensHelpers.cpp
@@ -1864,4 +1864,14 @@ extern "C"
     {
         Frens::f_free(ptr);
     }
+
+    void *frens_f_realloc(void *ptr, size_t newSize)
+    {
+        // Frens::f_realloc returns nullptr / panics when ptr is null, so handle
+        // the malloc/free degenerate cases here for C callers that expect
+        // standard realloc semantics.
+        if (!ptr) return Frens::f_malloc(newSize);
+        if (newSize == 0) { Frens::f_free(ptr); return nullptr; }
+        return Frens::f_realloc(ptr, newSize);
+    }
 }

--- a/FrensHelpers.cpp
+++ b/FrensHelpers.cpp
@@ -50,6 +50,7 @@ static void (*vsyncWaitTask)(void) = nullptr;
 // When set, PaceFrames locks the frame rate to that buffer draining to ~half,
 // i.e. to the audio-consumption clock. nullptr → fall back to timer pacing.
 static int (*audioFillQuery)(void) = nullptr;
+static bool paceTimerInited = false;
 #endif
 char ErrorMessage[ERRORMESSAGESIZE];
 bool scaleMode8_7_ = true;
@@ -191,6 +192,7 @@ namespace Frens
     void setAudioPaceQuery(int (*query)(void))
     {
         audioFillQuery = query;
+        paceTimerInited = false;
     }
 #endif
     void waitForVSync()
@@ -211,7 +213,7 @@ namespace Frens
 #if 1
     /// @brief Poor way to pace frames to 60fps
     /// @param init
-    void PaceFrames60fps(bool init)
+    void PaceFrames60fps(bool init, bool usePicoDVIvsyncWait)
     {
 #if !HSTX
 #if USE_PCE_FRAMEBUFFER_PACING
@@ -220,6 +222,17 @@ namespace Frens
         // Caused some line artifacts in pico-infonesPlus
         if (Frens::isFrameBufferUsed())
         {
+            // must be set to true when called from menu
+            // otherwise sreensaver will run too fast.
+            if (usePicoDVIvsyncWait)
+            {
+                while (vsync == false)
+                {
+                    // busy wait
+                    tight_loop_contents();
+                }
+                return;
+            }
             // CD games prefetch a sector every frame, regardless of which
             // pacing path runs below, so the CD audio ring never starves.
             if (vsyncWaitTask)
@@ -249,11 +262,10 @@ namespace Frens
                 // stream to lock onto). Resync on overrun so a slow frame can't
                 // harmonic-lock the loop to 30fps.
                 static absolute_time_t next_frame;
-                static bool timer_inited = false;
-                if (init || !timer_inited)
+                if (init || !paceTimerInited)
                 {
                     next_frame = make_timeout_time_us(16667); // 1/60s
-                    timer_inited = true;
+                    paceTimerInited = true;
                 }
                 if (time_reached(next_frame))
                 {

--- a/FrensHelpers.cpp
+++ b/FrensHelpers.cpp
@@ -1570,18 +1570,34 @@ namespace Frens
         sleep_ms(100);
         set_sys_clock_khz(cpuFreqKHz, true);
         sleep_ms(100);
-        // Reconfigure HSTX clock to 126 Mhz, so display can run at 60Hz.
+        // Reconfigure HSTX clock to 126 MHz, so display can run at 60Hz.
+        //
+        // SGX-at-378 MHz path only: *force* the PLL_USB-sourced HSTX route
+        // even for clk_sys values that are integer multiples of 126. Reason:
+        // deriving clk_hstx from clk_sys propagates PLL_SYS jitter into the
+        // TMDS bit clock at 378 MHz, producing dots / short dotted lines on
+        // strict HDMI receivers (eye-pattern closure). PLL_USB at a fixed
+        // 126 MHz keeps the TMDS clock decoupled from CPU clock.
+        //
+        // Only safe to reconfigure PLL_USB when the build uses PIO-USB for
+        // gamepads (CFG_TUH_RPI_PIO_USB=1). On TinyUSB-native-USB builds
+        // PLL_USB MUST stay at 48 MHz for USB hardware, so we keep the
+        // original clk_sys-derived HSTX path. Those builds should either
+        // stay at 252 MHz for SGX (no artifacts) or accept the dots at
+        // 378 MHz — the chip has no third clean PLL to use for HSTX.
         bool hstx_ok = true;
-        if ((cpuFreqKHz / 1000) % 126 != 0)
+#if SGX && CFG_TUH_RPI_PIO_USB
+        const bool force_pll_usb_hstx = true;
+#else
+        const bool force_pll_usb_hstx = false;
+#endif
+        if (force_pll_usb_hstx || ((cpuFreqKHz / 1000) % 126 != 0))
         {
-            // (Re)configure PLL_USB for 126 MHz HSTX source, so that we can get a 60Hz display output.
-            // This will break tinyusb, but PIO USB will still work.
-            // Used by Pico-GenesisPlus when set at 340Mhz.
+            // (Re)configure PLL_USB for 126 MHz HSTX source.
             pll_deinit(pll_usb);
             pll_init(pll_usb, 1, 756000000, 6, 1); // 756 / (6*1) = 126 MHz
 
             const uint32_t target_hstx_hz = 126000000u;
-            uint32_t chosen_hstx_hz = target_hstx_hz;
             hstx_ok = clock_configure(
                 clk_hstx,
                 0,
@@ -1589,12 +1605,17 @@ namespace Frens
                 target_hstx_hz,
                 target_hstx_hz);
 
-            // configure clk_peri to be same as clk_sys. This makes stdio over UART work correctly.
+            // Keep clk_peri sourced from PLL_SYS at sys_hz — same as the
+            // previous non-SGX path that the user has confirmed boots at
+            // 378 MHz. Re-routing clk_peri during clock init (which the
+            // earlier revision did) caused a boot loop. Peripheral drivers
+            // read clock_get_hz(clk_peri) for their own dividers, so they
+            // adapt to whatever clk_peri ends up at.
             clock_configure(clk_peri,
-                            0, // no GLMUX
+                            0,
                             CLOCKS_CLK_PERI_CTRL_AUXSRC_VALUE_CLKSRC_PLL_SYS,
-                            cpuFreqKHz * 1000,  // input freq (PLL SYS)
-                            cpuFreqKHz * 1000); // target clk_peri
+                            cpuFreqKHz * 1000,
+                            cpuFreqKHz * 1000);
         }
         else
         {

--- a/FrensHelpers.cpp
+++ b/FrensHelpers.cpp
@@ -214,6 +214,10 @@ namespace Frens
     void PaceFrames60fps(bool init)
     {
 #if !HSTX
+#if USE_PCE_FRAMEBUFFER_PACING
+        // Buffer pacing for pico-pcePlus
+        // Not used in other emulators for now.
+        // Caused some line artifacts in pico-infonesPlus
         if (Frens::isFrameBufferUsed())
         {
             // CD games prefetch a sector every frame, regardless of which
@@ -265,30 +269,17 @@ namespace Frens
             }
         }
 #else
-        //static int resync_count = 0;
-        hstx_paceFrame(init);
-        // int current_resync_count = get_video_output_resync_count();
-        // if (current_resync_count != resync_count)
-        // {
-        //     printf("Video output resync count: %d\n", current_resync_count);
-        //     resync_count = current_resync_count;
-        // }
-#if 0
-        static absolute_time_t next_frame_time = {0};
-        if (init)
+        if (Frens::isFrameBufferUsed())
         {
-            next_frame_time = make_timeout_time_us(0); // Reset frame time to 0
+            while (vsync == false)
+            {
+                // busy wait
+                tight_loop_contents();
+            }
         }
-        // Adjust to about 60fps
-        if (to_us_since_boot(next_frame_time) == 0)
-        {
-            next_frame_time = make_timeout_time_us(0);
-        }
-        // Pace to 60fps
-        sleep_until(next_frame_time);
-        next_frame_time = delayed_by_us(next_frame_time, 16666); // 1/60s = 16666us
-
 #endif
+#else
+        hstx_paceFrame(init);
 #endif
     }
 #endif

--- a/FrensHelpers.cpp
+++ b/FrensHelpers.cpp
@@ -249,8 +249,12 @@ namespace Frens
                 // stream to lock onto). Resync on overrun so a slow frame can't
                 // harmonic-lock the loop to 30fps.
                 static absolute_time_t next_frame;
-                if (init)
+                static bool timer_inited = false;
+                if (init || !timer_inited)
+                {
                     next_frame = make_timeout_time_us(16667); // 1/60s
+                    timer_inited = true;
+                }
                 if (time_reached(next_frame))
                 {
                     next_frame = make_timeout_time_us(16667);

--- a/FrensHelpers.cpp
+++ b/FrensHelpers.cpp
@@ -45,6 +45,11 @@
 std::unique_ptr<dvi::DVI> dvi_;
 util::ExclusiveProc exclProc_;
 static volatile bool vsync = false;
+static void (*vsyncWaitTask)(void) = nullptr;
+// Returns the active audio output buffer's fill level in permille (0..1000).
+// When set, PaceFrames locks the frame rate to that buffer draining to ~half,
+// i.e. to the audio-consumption clock. nullptr → fall back to timer pacing.
+static int (*audioFillQuery)(void) = nullptr;
 #endif
 char ErrorMessage[ERRORMESSAGESIZE];
 bool scaleMode8_7_ = true;
@@ -176,8 +181,18 @@ namespace Frens
 
         return 1 << rxbuf[3];
     }
-
+#if !HSTX
     /// @brief Wait for vertical sync
+    void setVSyncWaitTask(void (*task)(void))
+    {
+        vsyncWaitTask = task;
+    }
+
+    void setAudioPaceQuery(int (*query)(void))
+    {
+        audioFillQuery = query;
+    }
+#endif
     void waitForVSync()
     {
 #if !HSTX
@@ -201,10 +216,52 @@ namespace Frens
 #if !HSTX
         if (Frens::isFrameBufferUsed())
         {
-            while (vsync == false)
+            // CD games prefetch a sector every frame, regardless of which
+            // pacing path runs below, so the CD audio ring never starves.
+            if (vsyncWaitTask)
+                vsyncWaitTask();
+
+            if (audioFillQuery)
             {
-                // busy wait
-                tight_loop_contents();
+                // Pace to the audio-consumption clock: wait until the active
+                // output buffer (HDMI ring or I2S ring — the caller's query
+                // abstracts which) drains back to ~half full. This locks the
+                // emulator to the exact 60.00fps audio rate so production
+                // matches consumption with no drift (a fixed 16667us timer is
+                // 59.998fps, which slowly drained the buffer and caused
+                // periodic refill-burst artifacts). The half-full buffer
+                // cushions brief sub-60fps dips; the >60fps catch-up refills it.
+                while (audioFillQuery() > 500)
+                {
+                    if (vsyncWaitTask)
+                        vsyncWaitTask();
+                    else
+                        tight_loop_contents();
+                }
+            }
+            else
+            {
+                // Menu / non-CD: slack-aware timer pacing (no continuous audio
+                // stream to lock onto). Resync on overrun so a slow frame can't
+                // harmonic-lock the loop to 30fps.
+                static absolute_time_t next_frame;
+                if (init)
+                    next_frame = make_timeout_time_us(16667); // 1/60s
+                if (time_reached(next_frame))
+                {
+                    next_frame = make_timeout_time_us(16667);
+                }
+                else
+                {
+                    while (!time_reached(next_frame))
+                    {
+                        if (vsyncWaitTask)
+                            vsyncWaitTask(); // keep prefetching CD audio
+                        else
+                            tight_loop_contents();
+                    }
+                    next_frame = delayed_by_us(next_frame, 16667);
+                }
             }
         }
 #else

--- a/FrensHelpers.cpp
+++ b/FrensHelpers.cpp
@@ -757,13 +757,17 @@ namespace Frens
             {
                 panic("[f_malloc] Cannot allocate %zu bytes in PSRAM\n", size);
             }
+#if F_MALLOC_DEBUG
             printf("[f_malloc] Allocated %zu bytes in PSRAM at %p\n", size, pMem);
+#endif
             return pMem;
         }
 #endif
         // PSRAM not enabled, use malloc
         void *pMem = malloc(size); // panics if unavailable
+#if F_MALLOC_DEBUG
         printf("[f_malloc] Allocated %zu bytes in RAM at %p\n", size, pMem);
+#endif
         return pMem;
     }
 
@@ -780,7 +784,9 @@ namespace Frens
         {
             PicoPlusPsram &psram_ = PicoPlusPsram::getInstance();
             size_t uFreeing = psram_.GetSize(pMem);
+#if F_MALLOC_DEBUG
             printf("[f_malloc] Freeing %zu bytes from PSRAM at %p\n", uFreeing, pMem);
+#endif
             psram_.Free(pMem);
             return;
         }
@@ -788,7 +794,9 @@ namespace Frens
         // PSRAM not enabled, use free
         if (pMem)
         {
+#if F_MALLOC_DEBUG
             printf("[f_malloc] Freeing memory at %p\n", pMem);
+#endif
             free(pMem);
         }
     }
@@ -809,13 +817,17 @@ namespace Frens
             {
                 panic("Cannot allocate %zu bytes in PSRAM\n", newSize);
             }
+#if F_MALLOC_DEBUG
             printf("[f_malloc] Re-Allocated %zu bytes in PSRAM at %p\n", newSize, newMem);
+#endif
             return newMem;
         }
 #endif
         // PSRAM not enabled, use realloc
         newMem = realloc(pMem, newSize);
+#if F_MALLOC_DEBUG
         printf("[f_malloc] Re-Allocated memory at %p to %zu bytes\n", pMem, newSize);
+#endif
         return newMem;
     }
 
@@ -859,6 +871,36 @@ namespace Frens
             return nullptr;
         }
         FSIZE_t filesize = f_size(&fil);
+
+        // Large-disc-image fast path: when the file is bigger than what fits
+        // in available PSRAM (the .chd images for CD games can be hundreds
+        // of MB), we can't preload it. Instead read the first 4 KB into a
+        // stack buffer, CRC that as a stable savestate-folder key, and
+        // return without allocating. The caller (main.cpp) detects this
+        // via ROM_FILE_ADDR == 0 and routes straight to the disc-image
+        // opener (LoadDisc) which streams the file from SD.
+        {
+            uint availMem = Frens::GetAvailableMemory();
+            // Leave ~512 KB margin for libchdr / FS buffers / lwmem overhead.
+            const FSIZE_t margin = 512 * 1024;
+            if (availMem > margin && filesize > (availMem - margin))
+            {
+                uint8_t head[4096];
+                UINT br = 0;
+                f_read(&fil, head, sizeof(head), &br);
+                f_close(&fil);
+                if (br > 0)
+                {
+                    crc = compute_crc32_buffer(head, br, 0);
+                    crcOfRom = crc;
+                }
+                printf("Skipping PSRAM preload (file %llu bytes > avail %u): "
+                       "CRC of first %u bytes = 0x%08X\n",
+                       (unsigned long long)filesize, availMem, (unsigned)br, crc);
+                return nullptr;
+            }
+        }
+
         void *pMem = Frens::f_malloc(filesize);
         if (!pMem)
         {

--- a/FrensHelpers.cpp
+++ b/FrensHelpers.cpp
@@ -885,9 +885,28 @@ namespace Frens
             const FSIZE_t margin = 512 * 1024;
             if (availMem > margin && filesize > (availMem - margin))
             {
-                uint8_t head[4096];
+                // 4 KB scratch lives in PSRAM via f_malloc + f_free,
+                // NOT on the stack. The menu → loadRomInPsRam →
+                // flashromtoPsram → f_read → disk_read → rcvr_datablock
+                // → rcvr_spi_multi call chain already runs close to
+                // PICO_STACK_SIZE (3 KB); a 4 KB local array overflowed
+                // into adjacent .bss / framebuffer state. Observed
+                // symptom: PicoDVI core1 hardfault in the TMDS encoder
+                // while core0 was deep in SD I/O on game select. PSRAM
+                // is the right place — it's a one-shot read+CRC and the
+                // buffer is freed before we return.
+                uint8_t *head = (uint8_t *)Frens::f_malloc(4096);
+                if (!head)
+                {
+                    // PSRAM exhausted (extreme; the size guard above
+                    // already implies we're tight). Bail and let the
+                    // caller report no rom loaded.
+                    f_close(&fil);
+                    selectdRom[0] = 0;
+                    return nullptr;
+                }
                 UINT br = 0;
-                f_read(&fil, head, sizeof(head), &br);
+                f_read(&fil, head, 4096, &br);
                 f_close(&fil);
                 if (br > 0)
                 {
@@ -897,6 +916,7 @@ namespace Frens
                 printf("Skipping PSRAM preload (file %llu bytes > avail %u): "
                        "CRC of first %u bytes = 0x%08X\n",
                        (unsigned long long)filesize, availMem, (unsigned)br, crc);
+                Frens::f_free(head);
                 return nullptr;
             }
         }

--- a/FrensHelpers.cpp
+++ b/FrensHelpers.cpp
@@ -1138,6 +1138,7 @@ namespace Frens
     }
 
     static WORD *buffer;
+
     /// @brief Render function in core1 to render the framebuffers
     /// @param
     /// @return
@@ -1465,18 +1466,20 @@ namespace Frens
         tusb_init();
 #endif
 #if !HSTX
+        // Add a small stack for core1
+        static uint32_t core1_stack[512 / sizeof(uint32_t)];
 #if FRAMEBUFFERISPOSSIBLE
+      
         if (usingFramebuffer)
-        {
-
-            multicore_launch_core1(coreFB_main);
+        {   
+            multicore_launch_core1_with_stack(coreFB_main,  core1_stack, sizeof(core1_stack));
         }
         else
         {
-            multicore_launch_core1(core1_main);
+            multicore_launch_core1_with_stack(core1_main,  core1_stack, sizeof(core1_stack));
         }
 #else
-        multicore_launch_core1(core1_main);
+        multicore_launch_core1_with_stack(core1_main,  core1_stack, sizeof(core1_stack));
 #endif
 #endif // DVI
         initVintageControllers(CPUFreqKHz);

--- a/FrensHelpers.h
+++ b/FrensHelpers.h
@@ -139,6 +139,17 @@ namespace Frens
     bool isPsramEnabled();
     void *flashromtoPsram(char *selectdRom, bool swapbytes, uint32_t &crc, int crcOffset);
     void PaceFrames60fps(bool init);
+    // Optional task run repeatedly while PaceFrames60fps is waiting out slack
+    // before the next frame (framebuffer DVI path only). Lets the otherwise
+    // idle wait do useful work — e.g. prefetch CD audio sectors from SD — so it
+    // overlaps the wait instead of adding to frame time. Pass nullptr to clear.
+    void setVSyncWaitTask(void (*task)(void));
+    // Audio-clock pacing (framebuffer DVI path). The query returns the active
+    // audio output buffer's fill in permille (0..1000); PaceFrames waits until
+    // it drains below ~half, locking the frame rate to audio consumption. This
+    // is output-agnostic — the caller's query picks HDMI ring vs I2S ring.
+    // Pass nullptr to fall back to plain timer pacing.
+    void setAudioPaceQuery(int (*query)(void));
     void toggleScanLines();
     void restoreScanlines();
     void *f_malloc(size_t size);

--- a/FrensHelpers.h
+++ b/FrensHelpers.h
@@ -138,7 +138,7 @@ namespace Frens
 #endif
     bool isPsramEnabled();
     void *flashromtoPsram(char *selectdRom, bool swapbytes, uint32_t &crc, int crcOffset);
-    void PaceFrames60fps(bool init);
+    void PaceFrames60fps(bool init, bool usePicoDVIvsyncWait = false);
     // Optional task run repeatedly while PaceFrames60fps is waiting out slack
     // before the next frame (framebuffer DVI path only). Lets the otherwise
     // idle wait do useful work — e.g. prefetch CD audio sectors from SD — so it

--- a/FrensHelpers.h
+++ b/FrensHelpers.h
@@ -78,7 +78,9 @@ enum class ScanlineType : uint8_t
 #ifndef SGX
 #define SGX 0
 #endif
-
+#ifndef F_MALLOC_DEBUG
+#define F_MALLOC_DEBUG 0
+#endif
 #ifndef ENABLEDVI
 #define ENABLEDVI 0 
 #endif

--- a/FrensHelpers.h
+++ b/FrensHelpers.h
@@ -75,6 +75,9 @@ enum class ScanlineType : uint8_t
 #ifndef RETROJAM
 #define RETROJAM 0
 #endif
+#ifndef SGX
+#define SGX 0
+#endif
 
 #ifndef ENABLEDVI
 #define ENABLEDVI 0 

--- a/RomLister.cpp
+++ b/RomLister.cpp
@@ -182,6 +182,45 @@ namespace Frens
 			}
 		}
 		f_closedir(pDir);
+
+		// PCE CD-ROM: a .cue in this folder means it's a CD game folder; any
+		// .pce file here is presumed a per-game BIOS (loaded by LoadDisc as a
+		// per-game override over /bios/), not a HuCard. Hide it from the menu
+		// so it can't be picked accidentally. No-op for folders without a
+		// .cue (other emulators / HuCard-only folders) so it's safe to apply
+		// universally.
+		{
+			bool hasCue = false;
+			for (size_t i = 0; i < numberOfEntries; i++) {
+				if (entries[i].IsDirectory) continue;
+				char ext[10];
+				Frens::getextensionfromfilename(entries[i].Path, ext, sizeof(ext));
+				if (strcasecmp(ext, ".cue") == 0) { hasCue = true; break; }
+			}
+			if (hasCue) {
+				size_t write = 0;
+				size_t hidden = 0;
+				for (size_t read = 0; read < numberOfEntries; read++) {
+					if (!entries[read].IsDirectory) {
+						char ext[10];
+						Frens::getextensionfromfilename(entries[read].Path, ext, sizeof(ext));
+						if (strcasecmp(ext, ".pce") == 0) {
+							hidden++;
+							continue;
+						}
+					}
+					if (write != read) entries[write] = entries[read];
+					write++;
+				}
+				numberOfEntries = write;
+				if (hidden > 0) {
+					printf("RomLister: hiding %u .pce file(s) in CD folder %s "
+					       "(presumed BIOS)\n",
+					       (unsigned)hidden, directoryname);
+				}
+			}
+		}
+
 		// Sort: directories first (case-insensitive), then files (case-insensitive)
 		if (numberOfEntries > 1)
 		{

--- a/RomLister.cpp
+++ b/RomLister.cpp
@@ -148,8 +148,18 @@ namespace Frens
 					{
 						if (IsextensionAllowed(romInfo.Path))
 						{
-							// availMem already computed earlier (unchanged)
-							if (pFile->fsize < availMem)
+							// Streamed CD-image extensions (.cue/.chd) are
+							// read sector-by-sector from SD by the CD-ROM
+							// emulator, never preloaded — exempt them from
+							// the size check, which compares the file size
+							// against available PSRAM and would otherwise
+							// reject hundreds-of-MB CHDs that fit on SD fine.
+							char ext[10];
+							Frens::getextensionfromfilename(romInfo.Path, ext, sizeof(ext));
+							const bool streamedExt =
+								(strcasecmp(ext, ".cue") == 0) ||
+								(strcasecmp(ext, ".chd") == 0);
+							if (streamedExt || pFile->fsize < availMem)
 							{
 								entries[numberOfEntries++] = romInfo;
 							}
@@ -184,19 +194,20 @@ namespace Frens
 		}
 		f_closedir(pDir);
 
-		// PCE CD-ROM: a .cue in this folder means it's a CD game folder; any
-		// .pce file here is presumed a per-game BIOS (loaded by LoadDisc as a
-		// per-game override over /bios/), not a HuCard. Hide it from the menu
-		// so it can't be picked accidentally. No-op for folders without a
-		// .cue (other emulators / HuCard-only folders) so it's safe to apply
-		// universally.
+		// PCE CD-ROM: a .cue or .chd in this folder means it's a CD game
+		// folder; any .pce file here is presumed a per-game BIOS (loaded by
+		// LoadDisc as a per-game override over /bios/), not a HuCard. Hide
+		// it from the menu so it can't be picked accidentally. No-op for
+		// folders without a CD image (other emulators / HuCard-only folders)
+		// so it's safe to apply universally.
 		{
 			bool hasCue = false;
 			for (size_t i = 0; i < numberOfEntries; i++) {
 				if (entries[i].IsDirectory) continue;
 				char ext[10];
 				Frens::getextensionfromfilename(entries[i].Path, ext, sizeof(ext));
-				if (strcasecmp(ext, ".cue") == 0) { hasCue = true; break; }
+				if (strcasecmp(ext, ".cue") == 0 ||
+				    strcasecmp(ext, ".chd") == 0) { hasCue = true; break; }
 			}
 			if (hasCue) {
 				size_t write = 0;
@@ -205,7 +216,11 @@ namespace Frens
 					if (!entries[read].IsDirectory) {
 						char ext[10];
 						Frens::getextensionfromfilename(entries[read].Path, ext, sizeof(ext));
-						if (strcasecmp(ext, ".pce") == 0) {
+						// Hide both naming conventions for PC Engine system
+						// BIOS files dropped alongside CD images: .pce ROM
+						// dumps and the common "cd_bios.rom" name.
+						if (strcasecmp(ext, ".pce") == 0 ||
+						    strcasecmp(entries[read].Path, "cd_bios.rom") == 0) {
 							hidden++;
 							continue;
 						}

--- a/RomLister.cpp
+++ b/RomLister.cpp
@@ -134,7 +134,8 @@ namespace Frens
 					strcasecmp(pFile->fname, "SAVES") == 0 ||
 					strcasecmp(pFile->fname, "EDFC") == 0 ||
 					strcasecmp(pFile->fname, "Metadata") == 0 ||
-					strcasecmp(pFile->fname, "SAVESTATES") == 0)
+					strcasecmp(pFile->fname, "SAVESTATES") == 0 ||
+					strcasecmp(pFile->fname, "BIOS") == 0)
 				{
 					continue;
 				}

--- a/bld.sh
+++ b/bld.sh
@@ -13,7 +13,7 @@ APP=${PROJECT}
 function usage() {
 	echo "Build script for the ${PROJECT} project"
 	echo  ""
-	echo "Usage: $0 [-d] [-2 | -r] [-w] [-u] [-m] [-D] [-t path to toolchain] [ -p nprocessors] [-c <hwconfig>]"
+	echo "Usage: $0 [-d] [-2 | -r] [-w] [-u] [-m] [-D] [-e] [-t path to toolchain] [ -p nprocessors] [-c <hwconfig>]"
 	echo "Options:"
 	echo "  -d: build in DEBUG configuration"
 	echo "  -2: build for Pico 2 board (RP2350)"
@@ -41,6 +41,7 @@ function usage() {
 	echo "     13: Murmulator M2 (rp2350 only)"
 	echo "     14: Adafruit Feather RP2350 with TLV320DAC3100 I2S DAC and sdcard breakout board and PIO USB."
 	echo "  -m: Run cmake only, do not build the project"
+	echo "  -e: use the pico-extras based I2S audio driver (default: legacy custom driver)"
 	echo "  -h: display this help"
 	echo ""
 	echo "To install the RISC-V toolchain:"
@@ -87,7 +88,8 @@ USEPIOUSB=0
 CMAKEONLY=0
 USESIMPLEFILENAMES=0
 FORCEDVI=0
-while getopts "muwhd2rc:t:p:iD" opt; do
+USEEXTRASI2S=0
+while getopts "muwhd2rc:t:p:iDe" opt; do
   case $opt in
     p)
 	  BUILDPROC=$OPTARG
@@ -139,6 +141,8 @@ while getopts "muwhd2rc:t:p:iD" opt; do
 	w) USEPICOW=1 
 	  ;;
 	D) FORCEDVI=1
+	  ;;
+	e) USEEXTRASI2S=1
 	  ;;
     \?)
       #echo "Invalid option: -$OPTARG" >&2
@@ -329,25 +333,34 @@ fi
 PIOUSB=
 if [ $USEPIOUSB -eq 1 ] ; then
 	PIOUSB="_piousb"
-fi	
+fi
+PEI2S=
+if [ $USEEXTRASI2S -eq 1 ] ; then
+	PEI2S="_pe"
+fi
 # Only when SIMPLEFILENAMES=0
 if [ $USESIMPLEFILENAMES -eq 0 ] ; then
 	if [ "$PICO_PLATFORM" = "rp2350-riscv" ] ; then
-		UF2="${UF2}_${PICO_BOARD}_riscv${PIOUSB}"
+		UF2="${UF2}_${PICO_BOARD}_riscv${PIOUSB}${PEI2S}"
 	else
-		UF2="${UF2}_${PICO_BOARD}_arm${PIOUSB}"
+		UF2="${UF2}_${PICO_BOARD}_arm${PIOUSB}${PEI2S}"
 	fi
 else
 	if [ "$PICO_PLATFORM" = "rp2350-riscv" ] ; then
-		UF2="${UF2}_riscv${PIOUSB}"
+		UF2="${UF2}_riscv${PIOUSB}${PEI2S}"
 	else
-		UF2="${UF2}_arm${PIOUSB}"
+		UF2="${UF2}_arm${PIOUSB}${PEI2S}"
 	fi
 fi
 UF2="${APP}_${UF2}.uf2"
 echo "Building $PROJECT"
 echo "Using Pico SDK version: $SDKVERSION"
 echo "Building for $PICO_BOARD, platform $PICO_PLATFORM with $BUILD configuration and HWCONFIG=$HWCONFIG"
+if [ $USEEXTRASI2S -eq 1 ] ; then
+	echo "Using pico-extras based I2S audio driver"
+else
+	echo "Using legacy custom I2S audio driver"
+fi
 [ ! -z "$TOOLCHAIN_PATH" ]  && echo "Toolchain path: $TOOLCHAIN_PATH"
 echo "UF2 file: $UF2"
 
@@ -363,9 +376,9 @@ if [ $FORCEDVI -eq 1 ] ; then
 	FORCEDVIOPT="-DFORCE_DVI=1"
 fi
 if [ -z "$TOOLCHAIN_PATH" ] ; then
-	cmake -DCMAKE_BUILD_TYPE=$BUILD -DPICO_BOARD=$PICO_BOARD -DHW_CONFIG=$HWCONFIG -DPICO_PLATFORM=$PICO_PLATFORM -DENABLE_PIO_USB=$USEPIOUSB $FORCEDVIOPT .. || exit 1
+	cmake -DCMAKE_BUILD_TYPE=$BUILD -DPICO_BOARD=$PICO_BOARD -DHW_CONFIG=$HWCONFIG -DPICO_PLATFORM=$PICO_PLATFORM -DENABLE_PIO_USB=$USEPIOUSB -DUSE_PICO_EXTRAS_I2S=$USEEXTRASI2S $FORCEDVIOPT .. || exit 1
 else
-	cmake -DCMAKE_BUILD_TYPE=$BUILD -DPICO_BOARD=$PICO_BOARD -DHW_CONFIG=$HWCONFIG -DPICO_PLATFORM=$PICO_PLATFORM -DENABLE_PIO_USB=$USEPIOUSB -DPICO_TOOLCHAIN_PATH=$TOOLCHAIN_PATH $FORCEDVIOPT .. ||  exit 1
+	cmake -DCMAKE_BUILD_TYPE=$BUILD -DPICO_BOARD=$PICO_BOARD -DHW_CONFIG=$HWCONFIG -DPICO_PLATFORM=$PICO_PLATFORM -DENABLE_PIO_USB=$USEPIOUSB -DUSE_PICO_EXTRAS_I2S=$USEEXTRASI2S -DPICO_TOOLCHAIN_PATH=$TOOLCHAIN_PATH $FORCEDVIOPT .. ||  exit 1
 fi
 if [ $CMAKEONLY -eq 1 ] ; then
 	echo "CMake configuration done, exiting as requested."

--- a/drivers/pico_audio_i2s/CMakeLists.txt
+++ b/drivers/pico_audio_i2s/CMakeLists.txt
@@ -7,5 +7,16 @@ target_sources(pico_audio_i2s INTERFACE
 target_include_directories(pico_audio_i2s INTERFACE
             ${CMAKE_CURRENT_LIST_DIR}
     )
-target_link_libraries(pico_audio_i2s INTERFACE pico_stdlib hardware_spi hardware_i2c hardware_pwm hardware_adc hardware_pio hardware_dma)
+target_link_libraries(pico_audio_i2s INTERFACE
+    pico_stdlib
+    hardware_pio
+    hardware_dma
+    tlv320dac3100
+    # Note: hardware_spi/hardware_pwm/hardware_adc are linked here for
+    # backwards compatibility — the rest of the project picks them up
+    # transitively from pico_audio_i2s. Remove only after auditing callers.
+    hardware_spi
+    hardware_pwm
+    hardware_adc
+)
 endif()

--- a/drivers/pico_audio_i2s/audio_i2s.c
+++ b/drivers/pico_audio_i2s/audio_i2s.c
@@ -271,6 +271,14 @@ int audio_i2s_get_freebuffer_size()
 	return (read_index - write_index - 1) & AUDIO_RING_MASK;
 }
 
+// Current fill level of the I2S ring in permille (0..1000), for audio-clock
+// frame pacing (lets the caller treat the I2S buffer like the HDMI ring).
+int audio_i2s_get_fill_permille()
+{
+	size_t used = (write_index - read_index) & AUDIO_RING_MASK;
+	return (int)(used * 1000u / I2S_AUDIO_RING_SIZE);
+}
+
 void audio_i2s_disable()
 {
 	printf("Disabling I2S audio and release resources\n");

--- a/drivers/pico_audio_i2s/audio_i2s.c
+++ b/drivers/pico_audio_i2s/audio_i2s.c
@@ -13,12 +13,16 @@
  *    - Interrupt-driven buffer refill and underrun handling
  *    - Simple API for initializing, updating, and outputting audio samples
  *
+ *  TLV320DAC3100 codec control lives in the separate tlv320dac3100 module so it
+ *  can be shared with the pico-extras based driver.
+ *
  *  Intended for use in embedded audio applications, emulators, and projects requiring high-quality digital audio output.
  *  Based on: https://github.com/raspberrypi/pico-extras/tree/master/src/rp2_common/pico_audio_i2s
- *            and the xample code provided in https://www.waveshare.com/wiki/Pico-Audio
+ *            and the example code provided in https://www.waveshare.com/wiki/Pico-Audio
  */
 
 #include "audio_i2s.h"
+#include "tlv320dac3100.h"
 #include "hardware/pio.h"
 #include "hardware/clocks.h"
 #include "hardware/dma.h"
@@ -28,7 +32,6 @@
 #include "audio_i2s.pio.h"
 #include "string.h"
 #include "stdio.h"
-#include "hardware/i2c.h"
 
 #define AUDIO_PIO __CONCAT(pio, PICO_AUDIO_I2S_PIO)
 #define GPIO_FUNC_PIOx __CONCAT(GPIO_FUNC_PIO, PICO_AUDIO_I2S_PIO)
@@ -38,9 +41,7 @@ static uint32_t *audio_ring = NULL;
 static volatile size_t write_index = 0;
 static volatile size_t read_index = 0;
 static int _driver = 0;
-static volatile bool speakerIsMuted = false;
-static volatile bool hp_irq_pending = false;
-bool dacError = false;
+
 // Audio I2S hardware structure that holds the state machine, PIO instance, and DMA channel.
 static audio_i2s_hw_t audio_i2s = {
 	.sm = -1,		  // State machine index, initialized to -1 (not set)
@@ -50,653 +51,12 @@ static audio_i2s_hw_t audio_i2s = {
 
 // Sample frequency for the audio I2S interface, initialized to the default PICO_AUDIO_I2S_FREQ.
 static int samplefreq = PICO_AUDIO_I2S_FREQ;
-#define TLV320_ADDR 0x18 // I2C address for the TLV320AIC3204 codec
 
-#define I2C_PORT WIIPAD_I2C // I2C port for the TLV320 codec is tied to WIIPAD_I2C, must be configurable in the future
-#define PIN_SDA WII_PIN_SDA // SDA pin tied to WII_PIN_SDA, must be configurable in the future
-#define PIN_SCL WII_PIN_SCL // SCL pin tied to WII_PIN_SCL, must be configurable in the future
-#define I2C_ADDR 0x18
-#define DAC_I2C_ADDR I2C_ADDR
-#if 0
-/// @brief Write data to the TLV320AIC3204 over I2C
-/// @param data Pointer to the data buffer
-/// @param len Length of the data buffer
-static void write_tlv320(uint8_t *data, size_t len)
-{
-	int ret = i2c_write_blocking(I2C_PORT, I2C_ADDR, data, len, false);
-	if (ret < 0)
-	{
-		printf("I2C write failed: error %d\n", ret);
-	}
-	else if (ret != (int)len)
-	{
-		printf("I2C write incomplete: wrote %d of %d bytes\n", ret, len);
-	}
-#if 0
-	printf("I2C write %d bytes: ", len);
-	for (size_t i = 0; i < len; i++)
-	{
-		printf("%02x ", data[i]);
-	}
-	printf("\n");
-#endif
-}
-
-bool read_tlv320(uint8_t reg, uint8_t *data, size_t len)
-{
-	// Write register address first
-	int result = i2c_write_blocking(I2C_PORT, I2C_ADDR, &reg, 1, true); // true = no stop
-	if (result < 0)
-	{
-		printf("I2C write failed during read (reg=0x%02X)\n", reg);
-		return false;
-	}
-
-	// Read data from device
-	result = i2c_read_blocking(I2C_PORT, I2C_ADDR, data, len, false); // false = stop
-	if (result < 0)
-	{
-		printf("I2C read failed (reg=0x%02X)\n", reg);
-		return false;
-	}
-
-	return true;
-}
-#endif
-/// @brief Perform a hardware reset of the TLV320AIC3204
-/// This function toggles the reset pin to reset the codec hardware.
-static void tlv320_hardware_reset()
-{
-	// assert that the reset pin is defined
-	assert(PICO_AUDIO_I2S_RESET_PIN >= 0 && PICO_AUDIO_I2S_RESET_PIN < NUM_BANK0_GPIOS);
-	printf("Performing TLV320 hardware reset...\n");
-#if 1
-	gpio_put(PICO_AUDIO_I2S_RESET_PIN, 0);
-	gpio_set_dir(PICO_AUDIO_I2S_RESET_PIN, GPIO_OUT);
-	gpio_set_function(PICO_AUDIO_I2S_RESET_PIN, GPIO_FUNC_SIO);
-	sleep_us(20); // Hold low for >10us
-	gpio_put(PICO_AUDIO_I2S_RESET_PIN, 1);
-	gpio_set_dir(PICO_AUDIO_I2S_RESET_PIN, GPIO_OUT);
-	gpio_set_function(PICO_AUDIO_I2S_RESET_PIN, GPIO_FUNC_SIO);
-	sleep_ms(10); // Wait for the chip to reset
-#else
-	gpio_init(PICO_AUDIO_I2S_RESET_PIN);
-	gpio_set_dir(PICO_AUDIO_I2S_RESET_PIN, true);
-	gpio_put(PICO_AUDIO_I2S_RESET_PIN, true); // allow i2s to come out of reset
-#endif
-	printf("TLV320 hardware reset complete\n");
-}
-// Helper functions for reading/writing and modifying registers over I2C
-// From https://github.com/jepler/fruitjam-doom/blob/adafruit-fruitjam/src/i_main.c
-static void writeRegister(uint8_t reg, uint8_t value)
-{
-	uint8_t buf[2];
-	buf[0] = reg;
-	buf[1] = value;
-	int res = i2c_write_timeout_us(I2C_PORT, DAC_I2C_ADDR, buf, sizeof(buf), /* nostop */ false, 1000);
-	if (res != 2)
-	{
-		printf("!!!WARNING!!!: i2s_audio i2c_write_timeout failed: res=%d\n", res);
-		dacError = true;
-	}
-#if PICO_AUDIO_I2S_DEBUG
-	printf("Write Reg: %d = 0x%x\n", reg, value);
-#endif
-}
-
-static uint8_t readRegister(uint8_t reg)
-{
-	uint8_t buf[1];
-	buf[0] = reg;
-	int res = i2c_write_timeout_us(I2C_PORT, DAC_I2C_ADDR, buf, sizeof(buf), /* nostop */ true, 1000);
-	if (res != 1)
-	{
-
-		printf("res=%d\n", res);
-		printf("!!!WARNING!!!: i2s_audio i2c_write_timeout failed: res=%d\n", res);
-		dacError = true;
-	}
-	res = i2c_read_timeout_us(I2C_PORT, DAC_I2C_ADDR, buf, sizeof(buf), /* nostop */ false, 1000);
-	if (res != 1)
-	{
-
-		printf("res=%d\n", res);
-		printf("!!!WARNING!!!: i2s_audio i2c_read_timeout failed: res=%d\n", res);
-		dacError = true;
-	}
-	uint8_t value = buf[0];
-#if PICO_AUDIO_I2S_DEBUG
-	printf("Read Reg: %d = 0x%x\n", reg, value);
-#endif
-	return value;
-}
-
-/// @brief Modify a register on the TLV320AIC3204
-/// @param reg The register address
-/// @param mask tells the function which bits you care about. keeps all other bits as they were.
-/// Example: mask = 0x04 means “only bit 2 matters; ignore the rest.”
-/// @param value contains the desired state for those masked bits.
-/// Example: value = 0x04 means “bit 2 should be 1”
-///          value = 0x00 means “bit 2 should be 0”.
-static void modifyRegister(uint8_t reg, uint8_t mask, uint8_t value)
-{
-	uint8_t current = readRegister(reg);
-#if PICO_AUDIO_I2S_DEBUG
-	printf("Modify Reg: %d = [Before: 0x%x] with mask 0x%x and value 0x%x\n", reg, current, mask, value);
-#endif
-	uint8_t new_value = (current & ~mask) | (value & mask);
-	writeRegister(reg, new_value);
-}
-
-static void setPage(uint8_t page)
-{
-#if PICO_AUDIO_I2S_DEBUG
-	printf("Set page %d\n", page);
-#endif
-	writeRegister(0x00, page);
-}
-
-#define MASK_SPK_UNMUTE (1 << 2) // D2
-
-// HP analog volume (Page 1, Reg 0x24/0x25): 0 = 0 dB, each LSB = -0.5 dB, 0x7F = mute.
-// Speaker level is the init default; HP level adds 20 dB of attenuation so headphones
-// aren't painfully loud at a volume comfortable for the speaker.
-#define HP_ANALOG_VOL_SPEAKER 0x0A  // -5 dB (same as speaker analog vol)
-#define HP_ANALOG_VOL_HP      0x34  // -25 dB (20 dB quieter)
-
-void speakerMute(void)
-{
-	// Switch to page 1
-	setPage(0x01);
-
-	// Set D2 = 0 → mute
-	modifyRegister(0x2A, MASK_SPK_UNMUTE, 0x00);
-}
-
-void speakerUnmute(void)
-{
-	// Switch to page 1
-	setPage(0x01);
-
-	// Set D2 = 1 → unmute
-	modifyRegister(0x2A, MASK_SPK_UNMUTE, MASK_SPK_UNMUTE);
-}
-static volatile uint32_t last_irq_time;
-// Handle the GPIO callback for mute/unmute (button toggle mode)
-static void gpio_callback(uint gpio, uint32_t events)
-{
-	// No printfs in IRQs
-	uint32_t now = to_ms_since_boot(get_absolute_time());
-	if (now - last_irq_time < 50)
-	{
-		return;
-	}
-	last_irq_time = now;
-	if (events & GPIO_IRQ_EDGE_RISE)
-	{
-		speakerIsMuted = !speakerIsMuted; // Toggle mute state
-		if (speakerIsMuted)
-		{
-			speakerMute();
-		}
-		else
-		{
-			speakerUnmute();
-		}
-	}
-}
-
-// Handle the GPIO callback for DAC INT1 headphone detection
-static void hp_int1_callback(uint gpio, uint32_t events)
-{
-	// No printfs in IRQs
-	uint32_t now = to_ms_since_boot(get_absolute_time());
-	if (now - last_irq_time < 200)
-	{
-		return;
-	}
-	last_irq_time = now;
-	if (events & GPIO_IRQ_EDGE_RISE)
-	{
-		hp_irq_pending = true;
-	}
-}
-
-/// @brief Read headphone state from DAC and mute/unmute speaker accordingly.
-/// Reads the sticky flag register (Page 0 / Reg 0x2C) to clear the interrupt,
-/// and the non-sticky flag register (Page 0 / Reg 0x2E) D4 to determine
-/// whether a headset is currently inserted.
-/// Also reads the headset type from Page 0 / Reg 0x43 D6-D5.
-static enum headphone_toggle_t tlv320_handle_headphone_event()
-{
-	setPage(0);
-	// Read sticky flags to acknowledge/clear the interrupt
-	uint8_t sticky = readRegister(0x2C);
-	// Read non-sticky flags for current headphone state
-	uint8_t flags = readRegister(0x2E);
-	bool hp_inserted = (flags & 0x10) != 0; // D4: 1 = headset inserted, 0 = removed
-
-	// Read headset type from register 0x43 D6-D5
-	uint8_t hsdet = readRegister(0x43);
-	uint8_t hstype = (hsdet >> 5) & 0x03;
-	// 00 = no headset, 01 = without mic, 11 = with mic
-
-	printf("Headphone event: %s (type=%d, sticky=0x%02X, flags=0x%02X)\n",
-		   hp_inserted ? "inserted" : "removed", hstype, sticky, flags);
-
-	if (hp_inserted)
-	{
-		printf("HP connected: muting speaker, setting HP analog vol to 0x%02X (-%.1f dB)\n",
-			   HP_ANALOG_VOL_HP, HP_ANALOG_VOL_HP * 0.5f);
-		speakerMute(); // switches to page 1
-		writeRegister(0x24, HP_ANALOG_VOL_HP);
-		writeRegister(0x25, HP_ANALOG_VOL_HP);
-	}
-	else
-	{
-		printf("HP disconnected: unmuting speaker, restoring HP analog vol to 0x%02X (-%.1f dB)\n",
-			   HP_ANALOG_VOL_SPEAKER, HP_ANALOG_VOL_SPEAKER * 0.5f);
-		speakerUnmute(); // switches to page 1
-		writeRegister(0x24, HP_ANALOG_VOL_SPEAKER);
-		writeRegister(0x25, HP_ANALOG_VOL_SPEAKER);
-	}
-	setPage(0);
-	speakerIsMuted = hp_inserted;
-	return hp_inserted ? HP_TOGGLE_CONNECT : HP_TOGGLE_DISCONNECT;
-}
-
-// Set up the IRQ handler to mute/unmute the speaker
-void setupHeadphoneDetectionInterrupt(int gpio, bool gpioisbutton)
-{
-	speakerIsMuted = false; // Reset mute state on headphone detection setup
-	printf("Setting up headphone detection on GPIO %d, is_button=%d\n", gpio, gpioisbutton);
-	if (gpioisbutton)
-	{
-		// Button toggle mode: each press toggles speaker mute state
-		gpio_init(gpio);
-		gpio_set_dir(gpio, GPIO_IN);
-		gpio_pull_down(gpio);
-		gpio_set_irq_enabled_with_callback(gpio, GPIO_IRQ_EDGE_RISE | GPIO_IRQ_EDGE_FALL, true, &gpio_callback);
-	}
-	else
-	{
-		// DAC INT1/GPIO1 mode: the DAC's internal headphone detection block
-		// drives GPIO1 with INT1 pulses on headset insertion/removal events.
-		// The DAC registers are configured in tlv320_init():
-		//   Reg 0x43: Headset detection enabled with debounce
-		//   Reg 0x30: INT1 triggered by headset-insertion detect, multiple pulses
-		//   Reg 0x33: GPIO1 outputs INT1
-		printf("Setting up DAC INT1 headphone detection on GPIO %d\n", gpio);
-		gpio_init(gpio);
-		gpio_set_dir(gpio, GPIO_IN);
-		gpio_pull_down(gpio);
-		gpio_set_irq_enabled_with_callback(gpio, GPIO_IRQ_EDGE_RISE, true, &hp_int1_callback);
-
-		// Check initial headphone state (outside ISR context)
-		tlv320_handle_headphone_event();
-	}
-}
-void audio_i2s_setVolume(int8_t level) {
-	if (_driver != PICO_AUDIO_I2S_DRIVER_TLV320) {
-		return;
-	}
-	if ( level < -63 || level > 23) {
-		printf("Volume level %d out of range (-63 to 23)\n", level);
-		return;
-	}
-	printf("Setting TLV320 volume to level %d\n", level);
-	setPage(0);
-	modifyRegister(0x40, 0x0C, 0x00);
-	writeRegister(0x41, level << 1); // Left DAC Vol  
-	writeRegister(0x42, level << 1); // Right DAC Vol 
-}
-/// @brief Initialize the TLV320AIC3204 codec
-/// This function sets up the codec with default settings for audio playback.
-/// From tlv320dac3100 datasheet, section 6.3.10.15
-/// "Typical EVM I2C register control script"
-/// https://www.ti.com/lit/ds/symlink/tlv320dac3100.pdf?ts=1754043773385
-/// A typical EVM I2C register control script follows to show how to set up the TLV320DAC3100 in playback
-/// mode with fS = 44.1 kHz and MCLK = 11.2896 MHz.
-static void tlv320_init()
-{
-	// Initialize the DAC over I2C
-	printf("Initializing TLV320AIC3204 audio DAC...\n");
-	i2c_init(I2C_PORT, 400 * 1000); // Initialize I2C at 400kHz
-	sleep_ms(10);					// Wait for I2C to stabilize
-	// Set up I2C pins
-	gpio_set_function(PIN_SDA, GPIO_FUNC_I2C);
-    gpio_set_function(PIN_SCL, GPIO_FUNC_I2C);
-    gpio_pull_up(PIN_SDA);
-    gpio_pull_up(PIN_SCL);
-#if 0
-    // Old setup, from DataSheet
-	// 1. Define starting point:
-	// 		(a) Power up applicable external hardware power supplies
-	//     	(b) Set register to Page 0
-	// ### SET REGISTER PAGE 0 ###
-	write_tlv320((uint8_t[]){0x00, 0x00}, 2);
-	// 		(c) Initiate SW reset (PLL is powered off as part of reset)
-	write_tlv320((uint8_t[]){0x01, 0x01}, 2);
-	// 2. Program clock settings
-	// 		(a) Program PLL clock dividers P, J, D, R (if PLL is used)
-	//     		PLL_clkin = MCLK,codec_clkin = PLL_CLK
-	write_tlv320((uint8_t[]){0x04, 0x03}, 2);
-	//     		J = 8
-	write_tlv320((uint8_t[]){0x06, 0x08}, 2);
-	//    		D = 0000, D(13:8) = 0, D(7:0) = 0
-	write_tlv320((uint8_t[]){0x07, 0x00, 0x00}, 3);
-	// 		(b) Power up PLL (if PLL is used)
-	//     		PLL Power up, P = 1, R = 1
-	write_tlv320((uint8_t[]){0x05, 0x91}, 2);
-	// 		(c) Program and power up NDAC
-	//     		NDAC is powered up and set to 8
-	write_tlv320((uint8_t[]){0x0B, 0x88}, 2);
-	// 		(d) Program and power up MDAC
-	//     		MDAC is powered up and set to 2
-	write_tlv320((uint8_t[]){0x0C, 0x82}, 2);
-	// 		(e) Program OSR value
-	//	   		DOSR = 128, DOSR(9:8) = 0, DOSR(7:0) = 128
-	write_tlv320((uint8_t[]){0x0D, 0x00, 0x80}, 3);
-	// 		(f) Program I2S word length if required (16, 20, 24, 32 bits)
-	//     		and master mode (BCLK and WCLK are outputs)
-	//      	mode is i2s, wordlength is 16, slave mode
-	write_tlv320((uint8_t[]){0x1B, 0x00}, 2);
-	// Ensure Interface Control 2 defaults: normal polarity, no offset
-	write_tlv320((uint8_t[]){0x1C, 0x00}, 2);
-	// 		(g) Program the processing block to be used
-	//     		Select Processing Block PRB_P11
-	write_tlv320((uint8_t[]){0x3C, 0x0B}, 2);
-	// ### SET REGISTER PAGE 8 ###
-	write_tlv320((uint8_t[]){0x00, 0x08}, 2);
-	write_tlv320((uint8_t[]){0x01, 0x04}, 2);
-	// ### SET REGISTER PAGE 0 ###
-	write_tlv320((uint8_t[]){0x00, 0x00}, 2);
-	// 		(h) Miscellaneous page 0 controls
-	// 			DAC => volume control thru pin disable
-	write_tlv320((uint8_t[]){0x74, 0x00}, 2);
-	// 			Set DAC digital volume to 0 dB (unity)
-	write_tlv320((uint8_t[]){0x41, 0x00}, 2);
-	write_tlv320((uint8_t[]){0x42, 0x00}, 2);
-	// 3. Program analog blocks
-	// ### SET REGISTER PAGE 1 ###
-	//  	(a) Set register to Page 1
-	write_tlv320((uint8_t[]){0x00, 0x01}, 2);
-	// 		(b) Program common-mode voltage (defalut = 1.35 V)
-	write_tlv320((uint8_t[]){0x1F, 0x04}, 2);
-	//      (c) Program headphone-specific depop settings (in case headphone driver is used)
-	//          De-pop, Power on = 800 ms, Step time = 4 ms
-	write_tlv320((uint8_t[]){0x21, 0x4E}, 2);
-	//      (d) Program routing of DAC output to the output amplifier (headphone/lineout or speaker)
-	//          LDAC routed to HPL out, RDAC routed to HPR out
-	write_tlv320((uint8_t[]){0x23, 0x44}, 2);
-	// 	    (e) Unmute and set gain of output driver
-	//          Unmute HPL, set gain = 0 db
-	write_tlv320((uint8_t[]){0x28, 0x06}, 2);
-	//          Unmute HPR, set gain = 0 dB
-	write_tlv320((uint8_t[]){0x29, 0x06}, 2);
-	//          Unmute Class-D, set gain = 18 dB
-	write_tlv320((uint8_t[]){0x2A, 0x1C}, 2);
-	// 		(f) Power up output drivers
-	//			HPL and HPR powered up
-	// Power up HPL/HPR drivers with standard I2S polarity
-	write_tlv320((uint8_t[]){0x1F, 0xC2}, 2);
-	//  		Power-up Class-D driver
-	write_tlv320((uint8_t[]){0x20, 0x86}, 2);
-	// 			Enable output analog volumes, set to 0 dB
-	write_tlv320((uint8_t[]){0x24, 0x80}, 2);
-	write_tlv320((uint8_t[]){0x25, 0x80}, 2);
-	write_tlv320((uint8_t[]){0x26, 0x80}, 2);
-	// 4. Apply waiting time determined by the de-pop settings and the soft-stepping settings
-	//    of the driver gain or poll page 1 / register 63
-	sleep_ms(800); // Wait for 800 ms as per the de-pop settings
-	//  5. Power up DAC
-	//  ### SET REGISTER PAGE 0 ###
-	//  	(a) Set register to Page 0
-	write_tlv320((uint8_t[]){0x00, 0x00}, 2);
-	// 		(b) Power up DAC channels and set digital gain
-	// 			Powerup DAC left and right channels (soft step enabled)
-	write_tlv320((uint8_t[]){0x3F, 0xD4}, 2);
-	//			DAC Left gain = 0 dB	(was -22 dB)
-	write_tlv320((uint8_t[]){0x41, 0x00}, 2); // Changed 0xD4 to 0x00
-	//			DAC Right gain = 0 dB	(was -22 dB)
-	write_tlv320((uint8_t[]){0x42, 0x00}, 2); // Changed 0xD4 to 0x00
-
-	// Additional settings
-	write_tlv320((uint8_t[]){0x16, 0x10}, 2); // Enable ramping
-	// 		(c) Unmute digital volume control
-	// 			Unmute DAC left and right channels
-	write_tlv320((uint8_t[]){0x40, 0x00}, 2);
-
-
-	// Setup Headphone detection
-	// Enable headphone detection 1 (enabled) 00 (Detection values) 000 (16 ms debounce headset) 00 (0 ms Debounce button) 
-	uint8_t data;
-	data = read_tlv320(0x43, &data, 1);
-	//printf("Headphone detection register before: %02X\n", data);
-	data &= 0b01100000;
-	//printf("Headphone detection register after: %02X\n", data);
-	data |= 0b10010100;
-	//printf("Setting headphone detection register to: %02X\n", data);
-	write_tlv320((uint8_t[]){0x43, data}, 2);
-
-#endif
-	// Better setup, from https://github.com/jepler/fruitjam-doom/blob/adafruit-fruitjam/src/i_main.c
-	// Reset codec
-	writeRegister(0x01, 0x01);
-	sleep_ms(10);
-#if 0
-	// Interface Control
-	modifyRegister(0x1B, 0xC0, 0x00);
-	modifyRegister(0x1B, 0x30, 0x00);
-#else
-	// Set Interface Control 1 (0x1B)
-	// Bits 7-6 = 00 → I²S mode
-	// Bits 5-4 = 00 → 16-bit word length (matches PCM5000A path) (was 11 (0x30) for 32-bit)
-	// Bits 3-0 = 0000 → no offset
-	// PIO sends 16 bits samples in I2S format, so set accordingly
-	writeRegister(0x1B, 0x00);
-
-	// Optional: Interface Control 2 (0x1C)
-	// Make sure data is left-aligned with I²S expectations
-	// 0x00 = defaults (no invert, normal polarity)
-	writeRegister(0x1C, 0x00);
-#endif
-	// Clock MUX and PLL settings
-	modifyRegister(0x04, 0x03, 0x03);
-	modifyRegister(0x04, 0x0C, 0x04);
-
-	writeRegister(0x06, 0x20); // PLL J
-	writeRegister(0x08, 0x00); // PLL D LSB
-	writeRegister(0x07, 0x00); // PLL D MSB
-
-	modifyRegister(0x05, 0x0F, 0x02); // PLL P/R
-	modifyRegister(0x05, 0x70, 0x10);
-
-	// DAC/ADC Config
-	modifyRegister(0x0B, 0x7F, 0x08); // NDAC
-	modifyRegister(0x0B, 0x80, 0x80);
-
-	modifyRegister(0x0C, 0x7F, 0x02); // MDAC
-	modifyRegister(0x0C, 0x80, 0x80);
-
-	modifyRegister(0x12, 0x7F, 0x08); // NADC
-	modifyRegister(0x12, 0x80, 0x80);
-
-	modifyRegister(0x13, 0x7F, 0x02); // MADC
-	modifyRegister(0x13, 0x80, 0x80);
-
-	// PLL Power Up
-	modifyRegister(0x05, 0x80, 0x80);
-
-	// Headset and GPIO Config
-	setPage(1);
-	modifyRegister(0x2e, 0xFF, 0x0b);
-	setPage(0);
-
-	// Configure timer clock to use internal oscillator for headset detection debounce.
-	// Default is external MCLK (D7=1), but MCLK is not connected on this board
-	// (PLL_CLKIN = BCLK). Without this, the debounce clock has no source and
-	// headset detection will not function.
-	// Page 3 / Register 16: D7=0 → internal oscillator
-	setPage(3);
-	modifyRegister(0x10, 0x80, 0x00);
-	setPage(0);
-
-	// Headset detection: enable (D7=1), 64ms debounce for insertion (D4-D2=010)
-	modifyRegister(0x43, 0x9C, 0x88);
-	// INT1: headset-insertion detect (D7=1), multiple pulses until flags read (D0=1)
-	modifyRegister(0x30, 0x81, 0x81);
-	// GPIO1: output = INT1 (D5-D2=0101)
-	modifyRegister(0x33, 0x3C, 0x14);
-
-	// DAC Setup
-	modifyRegister(0x3F, 0xC0, 0xC0);
-
-	// DAC Routing
-	setPage(1);
-	modifyRegister(0x23, 0xC0, 0x40);
-	modifyRegister(0x23, 0x0C, 0x04);
-
-	// DAC Volume Control
-	setPage(0);
-	modifyRegister(0x40, 0x0C, 0x00);
-	writeRegister(0x41, 0x0A); // Left DAC Vol +5 dB (0x20 was +16 dB, clipped NES peaks)
-	writeRegister(0x42, 0x0A); // Right DAC Vol +5 dB
-
-	// ADC Setup
-	modifyRegister(0x51, 0x80, 0x80);
-	modifyRegister(0x52, 0x80, 0x00);
-	writeRegister(0x53, 0x68); // ADC Volume
-
-	// Headphone and Speaker Setup
-	setPage(1);
-	modifyRegister(0x1F, 0xC0, 0xC0); // HP Driver
-	modifyRegister(0x28, 0x04, 0x04); // HP Left Gain
-	modifyRegister(0x29, 0x04, 0x04); // HP Right Gain
-	writeRegister(0x24, 0x0A);		  // Left Analog HP
-	writeRegister(0x25, 0x0A);		  // Right Analog HP
-	modifyRegister(0x28, 0x78, 0x40); // HP Left Gain
-	modifyRegister(0x29, 0x78, 0x40); // HP Right Gain
-
-	// Speaker Amp
-	modifyRegister(0x20, 0x80, 0x80);
-	modifyRegister(0x2A, 0x04, 0x04);
-	modifyRegister(0x2A, 0x18, 0x08);
-	writeRegister(0x26, 0x0A);
-
-	// Return to page 0
-
-	setPage(0);
-
-#if PICO_AUDIO_I2S_INTERRUPT_PIN != -1
-	if (dacError == false)
-	{
-		printf("setup headphone detection interrupt.\n");
-		setupHeadphoneDetectionInterrupt(PICO_AUDIO_I2S_INTERRUPT_PIN, PICO_AUDIO_I2S_INTERRUPT_IS_BUTTON);
-	}
-#endif
-#if 0
-	uint8_t v1b = readRegister(0x1B);
-	uint8_t v1c = readRegister(0x1C);
-	printf("IFACE1=0x%02X (expect 0x30), IFACE2=0x%02X (expect 0x00)\n", v1b, v1c);
-#endif
-	printf("TLV320AIC3204 Initialization complete!\n");
-
-	// Read all registers for verification
-#if 0
-	printf("Reading all registers for verification:\n");
-
-	setPage(0);
-	readRegister(0x00); // AIC31XX_PAGECTL
-	readRegister(0x01); // AIC31XX_RESET
-	readRegister(0x03); // AIC31XX_OT_FLAG
-	readRegister(0x04); // AIC31XX_CLKMUX
-	readRegister(0x05); // AIC31XX_PLLPR
-	readRegister(0x06); // AIC31XX_PLLJ
-	readRegister(0x07); // AIC31XX_PLLDMSB
-	readRegister(0x08); // AIC31XX_PLLDLSB
-	readRegister(0x0B); // AIC31XX_NDAC
-	readRegister(0x0C); // AIC31XX_MDAC
-	readRegister(0x0D); // AIC31XX_DOSRMSB
-	readRegister(0x0E); // AIC31XX_DOSRLSB
-	readRegister(0x10); // AIC31XX_MINI_DSP_INPOL
-	readRegister(0x12); // AIC31XX_NADC
-	readRegister(0x13); // AIC31XX_MADC
-	readRegister(0x14); // AIC31XX_AOSR
-	readRegister(0x19); // AIC31XX_CLKOUTMUX
-	readRegister(0x1A); // AIC31XX_CLKOUTMVAL
-	readRegister(0x1B); // AIC31XX_IFACE1
-	readRegister(0x1C); // AIC31XX_DATA_OFFSET
-	readRegister(0x1D); // AIC31XX_IFACE2
-	readRegister(0x1E); // AIC31XX_BCLKN
-	readRegister(0x1F); // AIC31XX_IFACESEC1
-	readRegister(0x20); // AIC31XX_IFACESEC2
-	readRegister(0x21); // AIC31XX_IFACESEC3
-	readRegister(0x22); // AIC31XX_I2C
-	readRegister(0x24); // AIC31XX_ADCFLAG
-	readRegister(0x25); // AIC31XX_DACFLAG1
-	readRegister(0x26); // AIC31XX_DACFLAG2
-	readRegister(0x27); // AIC31XX_OFFLAG
-	readRegister(0x2C); // AIC31XX_INTRDACFLAG
-	readRegister(0x2D); // AIC31XX_INTRADCFLAG
-	readRegister(0x2E); // AIC31XX_INTRDACFLAG2
-	readRegister(0x2F); // AIC31XX_INTRADCFLAG2
-	readRegister(0x30); // AIC31XX_INT1CTRL
-	readRegister(0x31); // AIC31XX_INT2CTRL
-	readRegister(0x33); // AIC31XX_GPIO1
-	readRegister(0x3C); // AIC31XX_DACPRB
-	readRegister(0x3D); // AIC31XX_ADCPRB
-	readRegister(0x3F); // AIC31XX_DACSETUP
-	readRegister(0x40); // AIC31XX_DACMUTE
-	readRegister(0x41); // AIC31XX_LDACVOL
-	readRegister(0x42); // AIC31XX_RDACVOL
-	readRegister(0x43); // AIC31XX_HSDETECT
-	readRegister(0x51); // AIC31XX_ADCSETUP
-	readRegister(0x52); // AIC31XX_ADCFGA
-	readRegister(0x53); // AIC31XX_ADCVOL
-
-	setPage(1);
-	readRegister(0x1F); // AIC31XX_HPDRIVER
-	readRegister(0x20); // AIC31XX_SPKAMP
-	readRegister(0x21); // AIC31XX_HPPOP
-	readRegister(0x22); // AIC31XX_SPPGARAMP
-	readRegister(0x23); // AIC31XX_DACMIXERROUTE
-	readRegister(0x24); // AIC31XX_LANALOGHPL
-	readRegister(0x25); // AIC31XX_RANALOGHPR
-	readRegister(0x26); // AIC31XX_LANALOGSPL
-	readRegister(0x27); // AIC31XX_RANALOGSPR
-	readRegister(0x28); // AIC31XX_HPLGAIN
-	readRegister(0x29); // AIC31XX_HPRGAIN
-	readRegister(0x2A); // AIC31XX_SPLGAIN
-	readRegister(0x2B); // AIC31XX_SPRGAIN
-	readRegister(0x2C); // AIC31XX_HPCONTROL
-	readRegister(0x2E); // AIC31XX_MICBIAS
-	readRegister(0x2F); // AIC31XX_MICPGA
-	readRegister(0x30); // AIC31XX_MICPGAPI
-	readRegister(0x31); // AIC31XX_MICPGAMI
-	readRegister(0x32); // AIC31XX_MICPGACM
-
-	setPage(3);
-	readRegister(0x10); // AIC31XX_TIMERDIVIDER
-	printf("All I2C writes complete.\n");
-#endif
-	sleep_ms(100);
-}
-
-/// @brief Poll for pending headphone detection events.
-/// Call this periodically from the main loop to process headphone
-/// insertion/removal events detected via DAC INT1.
-/// When no INT1 interrupt is pending, this function returns immediately.
+/// Poll for pending headphone detection events. Delegates to the shared codec
+/// module so the same logic is reused by the pico-extras based driver.
 enum headphone_toggle_t audio_i2s_poll_headphone_status()
 {
-	if (_driver == PICO_AUDIO_I2S_DRIVER_TLV320 && hp_irq_pending)
-	{
-		hp_irq_pending = false;
-		return tlv320_handle_headphone_event();
-	} else {
-		return HP_TOGGLE_NONE;
-	}
-	
+	return tlv320_poll_headphone();
 }
 
 /**
@@ -742,59 +102,35 @@ void __isr dma_handler()
 	// Advance read_index by block size
 	read_index = (read_index + DMA_BLOCK_SIZE) % I2S_AUDIO_RING_SIZE;
 	// Check if we have enough data to continue DMA transfer
-	// If write_index is ahead of read_index, we have data to send
 	size_t available = (write_index >= read_index)
 						   ? (write_index - read_index)
 						   : (I2S_AUDIO_RING_SIZE - read_index + write_index);
-	// printf("DMA handler: read_index=%zu, write_index=%zu, available=%zu\n", read_index, write_index, available);
 	if (available >= DMA_BLOCK_SIZE)
 	{
 		dma_channel_set_read_addr(audio_i2s.dma_chan, &audio_ring[read_index], false);
 		dma_channel_set_trans_count(audio_i2s.dma_chan, DMA_BLOCK_SIZE, true); // true = start immediately
 	}
 }
+
 /**
  * @brief Initializes and sets up the I2S audio hardware with the specified sample frequency.
  *
- * This function configures the I2S hardware interface for audio output at the given frequency (in Hz).
- * It allocates and initializes an audio_i2s_hw_t structure, sets up the necessary hardware peripherals,
- * and prepares the system for audio data transmission.
- *
  * @param driver The I2S driver to use (e.g., PICO_AUDIO_I2S_DRIVER_TLV320).
- * @param resetPin The GPIO pin used to reset the TLV320 codec hardware (if	 applicable).
  * @param freqHZ The sample frequency in Hertz. If set to 0, the default PICO_AUDIO_I2S_FREQ is used.
  * @param dmachan The DMA channel to use for audio transfer. If set to -1, a free DMA channel will be claimed.
  */
 audio_i2s_hw_t *audio_i2s_setup(int driver, int freqHZ, int dmachan)
 {
+	printf("Setting up legacy I2S audio with driver %d, frequency %d Hz, DMA channel %d\n", driver, freqHZ, dmachan);
 	_driver = driver; // Store the selected driver globally
-	dacError = false;
 	if (_driver == PICO_AUDIO_I2S_DRIVER_NONE)
 	{
 		printf("No I2S driver selected, skipping audio setup.\n");
-		return NULL; // No I2S driver selected, return NULL
+		return NULL;
 	}
 	if (_driver == PICO_AUDIO_I2S_DRIVER_TLV320)
 	{
-
-		int retries = 0;
-		printf("Init TLV320 DAC, max 5 retries...\n");
-		do
-		{
-			dacError = false;
-			tlv320_hardware_reset(); // Reset the TLV320 codec hardware
-			tlv320_init();			 // Initialize the TLV320 codec with default settings
-			if (!dacError)
-			{
-				break;
-			}
-			printf("TLV320 init failed, retrying (%d/5)...\n", retries + 1);
-			sleep_ms(500);
-		} while (dacError && ++retries < 5);
-		if (dacError)
-		{
-			printf("TLV320 initialization failed after 5 attempts.\n");
-		}
+		tlv320_init();
 	}
 	audio_i2s.dma_chan = dmachan;
 	if (freqHZ > 0)
@@ -802,10 +138,10 @@ audio_i2s_hw_t *audio_i2s_setup(int driver, int freqHZ, int dmachan)
 		samplefreq = freqHZ;
 	}
 	printf("Allocating %d bytes for audio ring buffer\n", I2S_AUDIO_RING_SIZE * sizeof(uint32_t));
-	audio_ring = malloc(I2S_AUDIO_RING_SIZE * sizeof(uint32_t));   // Allocate memory for the audio ring buffer
-	memset(audio_ring, 0, I2S_AUDIO_RING_SIZE * sizeof(uint32_t)); // Initialize the audio ring buffer to zero
-	write_index = 0; //DMA_BLOCK_SIZE;							   // Start writing after the first block
-	read_index = 0;											   // Reset read index
+	audio_ring = malloc(I2S_AUDIO_RING_SIZE * sizeof(uint32_t));
+	memset(audio_ring, 0, I2S_AUDIO_RING_SIZE * sizeof(uint32_t));
+	write_index = 0;
+	read_index = 0;
 	// Set up the PIO and GPIO pins for I2S audio output
 	gpio_set_function(PICO_AUDIO_I2S_DATA_PIN, GPIO_FUNC_PIOx);
 	gpio_set_function(PICO_AUDIO_I2S_CLOCK_PIN_BASE, GPIO_FUNC_PIOx);
@@ -832,7 +168,6 @@ audio_i2s_hw_t *audio_i2s_setup(int driver, int freqHZ, int dmachan)
 	if (audio_i2s.dma_chan == -1)
 	{
 		audio_i2s.dma_chan = dma_claim_unused_channel(true);
-		//
 	}
 	printf("Using DMA channel %d for audio I2S\n", audio_i2s.dma_chan);
 	dma_channel_config c = dma_channel_get_default_config(audio_i2s.dma_chan);
@@ -852,8 +187,7 @@ audio_i2s_hw_t *audio_i2s_setup(int driver, int freqHZ, int dmachan)
 	);
 
 	// Enable the DMA channel interrupt
-	// This will trigger when the DMA transfer is complete.
-	// chan 1-3 are used for PIO0, chan 4-7 for PIO1
+	// chan 0-3 use IRQ_0, chan 4+ use IRQ_1
 	if (audio_i2s.dma_chan >= 4)
 	{
 		dma_channel_set_irq1_enabled(audio_i2s.dma_chan, true);
@@ -880,46 +214,34 @@ audio_i2s_hw_t *audio_i2s_setup(int driver, int freqHZ, int dmachan)
 	return &audio_i2s;
 }
 
-// DC-blocking high-pass filter.
-// Removes DC offset so DACs without built-in DC blocking (e.g., PCM5102A)
-// output a properly centered AC waveform.
-// 1-pole IIR: y[n] = x[n] - x[n-1] + alpha * y[n-1]
-// alpha = 255/256 ≈ 0.996, cutoff ≈ 28 Hz at 44100 Hz.
-static int32_t dc_xL = 0, dc_yL = 0;
-static int32_t dc_xR = 0, dc_yR = 0;
-
-static inline int16_t dc_block_channel(int16_t x, int32_t *prev_x, int32_t *prev_y)
-{
-	int32_t y = (int32_t)x - *prev_x + ((*prev_y * 255) >> 8);
-	*prev_x = (int32_t)x;
-	*prev_y = y;
-	if (y > 32767) y = 32767;
-	else if (y < -32768) y = -32768;
-	return (int16_t)y;
-}
+#if I2S_AUDIO_COMPENSATE_DC_OFFSET
+static int32_t dc_avg_l = 0;
+static int32_t dc_avg_r = 0;
 
 static inline uint32_t __not_in_flash_func(dc_block_sample)(uint32_t sample32)
 {
-	int16_t l = (int16_t)(sample32 >> 16);
-	int16_t r = (int16_t)(sample32 & 0xFFFF);
-	l = dc_block_channel(l, &dc_xL, &dc_yL);
-	r = dc_block_channel(r, &dc_xR, &dc_yR);
+	int32_t l = (int16_t)(sample32 >> 16);
+	int32_t r = (int16_t)(sample32 & 0xFFFF);
+	dc_avg_l += (l - dc_avg_l) >> I2S_DC_FILTER_SHIFT;
+	dc_avg_r += (r - dc_avg_r) >> I2S_DC_FILTER_SHIFT;
+	l -= dc_avg_l;
+	r -= dc_avg_r;
+	if (l > 32767) l = 32767; else if (l < -32768) l = -32768;
+	if (r > 32767) r = 32767; else if (r < -32768) r = -32768;
 	return ((uint32_t)(uint16_t)l << 16) | (uint16_t)r;
 }
+#endif
 
 /**
  * @brief Enqueues a 32-bit audio sample into the ring buffer for I2S output.
  *
- * This function adds a 32-bit audio sample to the ring buffer. If the buffer is full, it drops the sample
- * and prints a warning message every 100 dropped samples. It also checks if the DMA channel is busy and
- * starts a new DMA transfer if there is enough data available in the ring buffer.
- *
- * @param sample32 The 32-bit audio sample to enqueue.
+ * This function adds a 32-bit audio sample to the ring buffer. If the buffer is full, it drops the sample.
+ * It also checks if the DMA channel is busy and starts a new DMA transfer if there is enough data available.
  */
 void __not_in_flash_func(audio_i2s_enqueue_sample)(uint32_t sample32)
 {
 #if I2S_AUDIO_COMPENSATE_DC_OFFSET
-	if (_driver == PICO_AUDIO_I2S_DRIVER_PCM5000A)
+	//if (_driver == PICO_AUDIO_I2S_DRIVER_PCM5000A)
 		sample32 = dc_block_sample(sample32);
 #endif
 	size_t next_write = (write_index + 1) % I2S_AUDIO_RING_SIZE;
@@ -943,6 +265,7 @@ void __not_in_flash_func(audio_i2s_enqueue_sample)(uint32_t sample32)
 		restore_interrupts(save);
 	}
 }
+
 int audio_i2s_get_freebuffer_size()
 {
 	return (read_index - write_index - 1) & AUDIO_RING_MASK;
@@ -963,18 +286,18 @@ void audio_i2s_disable()
 	free(audio_ring);
 	audio_ring = NULL;
 }
+
 bool audio_i2s_dacError()
 {
-	return dacError;
+	return tlv320_dac_error();
 }
+
+void audio_i2s_setVolume(int8_t level)
+{
+	tlv320_set_volume(level);
+}
+
 void audio_i2s_muteInternalSpeaker(bool mute)
 {
-#if  USE_I2S_AUDIO == PICO_AUDIO_I2S_DRIVER_TLV320
-	speakerIsMuted = mute;
-	if (speakerIsMuted) {
-		speakerMute();
-	} else {
-		speakerUnmute();
-	}
-#endif
+	tlv320_mute_speaker(mute);
 }

--- a/drivers/pico_audio_i2s/audio_i2s.h
+++ b/drivers/pico_audio_i2s/audio_i2s.h
@@ -3,7 +3,7 @@
 #ifndef _PICO_AUDIO_I2S_PIO_H
 #define _PICO_AUDIO_I2S_PIO_H
 
-#include "audio_i2s.h"
+#include "tlv320dac3100.h"
 #include "pico/stdlib.h"
 #include "hardware/pio.h"
 #include "hardware/clocks.h"
@@ -25,10 +25,8 @@ extern "C" {
 #define PICO_AUDIO_I2S_DEBUG 0 // Set to 1 to enable debug output
 #endif
 
-// Reset pin, when using TLV320 codec
-#ifndef PICO_AUDIO_I2S_RESET_PIN
-#define PICO_AUDIO_I2S_RESET_PIN 7
-#endif
+// Note: PICO_AUDIO_I2S_RESET_PIN, PICO_AUDIO_I2S_INTERRUPT_PIN, and
+// PICO_AUDIO_I2S_INTERRUPT_IS_BUTTON are defined in tlv320dac3100.h.
 // Data pin, DIN or SDATA
 #ifndef PICO_AUDIO_I2S_DATA_PIN
 #define PICO_AUDIO_I2S_DATA_PIN 26
@@ -48,21 +46,15 @@ extern "C" {
 #define PICO_AUDIO_I2S_PIO 0
 #endif
 
-// headphone detect pin, when using TLV320 codec
-// #ifndef PICO_AUDIO_I2S_HP_DETECT_PIN
-// #define PICO_AUDIO_I2S_HP_DETECT_PIN -1
-// #endif
-
-#ifndef PICO_AUDIO_I2S_INTERRUPT_PIN
-#define PICO_AUDIO_I2S_INTERRUPT_PIN -1
-#endif
-#ifndef PICO_AUDIO_I2S_INTERRUPT_IS_BUTTON
-#define PICO_AUDIO_I2S_INTERRUPT_IS_BUTTON 0
-#endif
-
-// Compensation for DC offset in PCM5000A driver
+// DC blocking filter: removes DC offset so DACs without built-in DC blocking
+// (e.g. PCM5102A) output a properly centered AC waveform.
+// Uses a leaky integrator to track and subtract the running average.
+// Shift 10 ≈ 7 Hz cutoff at 44100 Hz. Higher = more bass preserved, slower response.
 #ifndef I2S_AUDIO_COMPENSATE_DC_OFFSET
-#define I2S_AUDIO_COMPENSATE_DC_OFFSET 0 // Set to 1 to enable
+#define I2S_AUDIO_COMPENSATE_DC_OFFSET 0
+#endif
+#ifndef I2S_DC_FILTER_SHIFT
+#define I2S_DC_FILTER_SHIFT 10
 #endif
 #ifndef I2S_AUDIO_RING_SIZE
 #define I2S_AUDIO_RING_SIZE (1024) // size of the audio ring buffer (must be a multiple of DMA_BLOCK_SIZE)
@@ -79,11 +71,7 @@ typedef struct {
     PIO pio;     // PIO instance (e.g., pio0 or pio1)
     int dma_chan; // DMA channel for audio transfer
 } audio_i2s_hw_t;
-enum headphone_toggle_t {
-    HP_TOGGLE_NONE = 0,
-    HP_TOGGLE_CONNECT = 1,
-    HP_TOGGLE_DISCONNECT = 2
-};
+// enum headphone_toggle_t is defined in tlv320dac3100.h
 audio_i2s_hw_t *audio_i2s_setup(int driver, int freqHZ, int dmachan);
 void audio_i2s_update_pio_frequency(uint32_t sample_freq);
 void audio_i2s_out_32(uint32_t sample32);

--- a/drivers/pico_audio_i2s/audio_i2s.h
+++ b/drivers/pico_audio_i2s/audio_i2s.h
@@ -78,6 +78,7 @@ void audio_i2s_out_32(uint32_t sample32);
 void audio_i2s_enqueue_sample(uint32_t sample32);
 enum headphone_toggle_t audio_i2s_poll_headphone_status();
 int audio_i2s_get_freebuffer_size();
+int audio_i2s_get_fill_permille();
 void audio_i2s_disable() ;
 bool audio_i2s_dacError();
 void audio_i2s_muteInternalSpeaker(bool mute);

--- a/drivers/pico_audio_i2s_pe/CMakeLists.txt
+++ b/drivers/pico_audio_i2s_pe/CMakeLists.txt
@@ -1,0 +1,33 @@
+if (NOT TARGET pico_audio_i2s)
+    add_library(pico_audio_i2s INTERFACE)
+
+    pico_generate_pio_header(pico_audio_i2s ${CMAKE_CURRENT_LIST_DIR}/audio_i2s.pio)
+
+    target_sources(pico_audio_i2s INTERFACE
+        ${CMAKE_CURRENT_LIST_DIR}/pe_audio_i2s_wrapper.c
+        ${CMAKE_CURRENT_LIST_DIR}/pico_extras/audio.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/pico_extras/buffer.c
+        ${CMAKE_CURRENT_LIST_DIR}/audio_i2s_adapter.c
+    )
+
+    target_include_directories(pico_audio_i2s INTERFACE
+        ${CMAKE_CURRENT_LIST_DIR}                       # legacy-shaped audio_i2s.h
+        ${CMAKE_CURRENT_LIST_DIR}/pico_extras/include   # pico/audio.h, pico/audio_i2s.h, pico/util/buffer.h, pico/sample_conversion.h
+    )
+
+    target_link_libraries(pico_audio_i2s INTERFACE
+        pico_stdlib
+        pico_sync
+        hardware_pio
+        hardware_dma
+        hardware_irq
+        hardware_clocks
+        tlv320dac3100
+        # Same backwards-compatibility set as the legacy driver: other
+        # translation units in this project pick these up transitively
+        # via pico_audio_i2s. Keeps the dependency surface identical.
+        hardware_spi
+        hardware_pwm
+        hardware_adc
+    )
+endif()

--- a/drivers/pico_audio_i2s_pe/audio_i2s.h
+++ b/drivers/pico_audio_i2s_pe/audio_i2s.h
@@ -1,0 +1,102 @@
+/*
+ *  pico_audio_i2s_pe/audio_i2s.h
+ *
+ *  Legacy-shaped header for the pico-extras based driver. The function
+ *  signatures here match the custom driver one-for-one so that callers
+ *  (FrensHelpers, main.cpp, wavplayer.cpp, ...) compile unchanged.
+ *
+ *  The implementation lives in audio_i2s_adapter.c and internally drives a
+ *  pico-extras audio_buffer_pool.
+ */
+
+#ifndef _PICO_AUDIO_I2S_PE_H
+#define _PICO_AUDIO_I2S_PE_H
+
+#include "tlv320dac3100.h"
+#include "pico/stdlib.h"
+#include "hardware/pio.h"
+#include "hardware/clocks.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define PICO_AUDIO_I2S_DRIVER_NONE      0
+#define PICO_AUDIO_I2S_DRIVER_TLV320    1
+#define PICO_AUDIO_I2S_DRIVER_PCM5000A  2
+
+#ifndef PICO_AUDIO_I2S_FREQ
+#define PICO_AUDIO_I2S_FREQ 44100
+#endif
+
+#ifndef PICO_AUDIO_I2S_COUNT
+#define PICO_AUDIO_I2S_COUNT 2
+#endif
+
+#ifndef PICO_AUDIO_I2S_DATA_PIN
+#define PICO_AUDIO_I2S_DATA_PIN 26
+#endif
+
+#ifndef PICO_AUDIO_I2S_CLOCK_PIN_BASE
+#define PICO_AUDIO_I2S_CLOCK_PIN_BASE 27
+#endif
+
+#ifndef PICO_AUDIO_I2S_CLOCK_PINS_SWAPPED
+#define PICO_AUDIO_I2S_CLOCK_PINS_SWAPPED 0
+#endif
+
+#ifndef PICO_AUDIO_I2S_PIO
+#define PICO_AUDIO_I2S_PIO 0
+#endif
+
+// DC blocking filter: removes DC offset so DACs without built-in DC blocking
+// (e.g. PCM5102A) output a properly centered AC waveform.
+// Uses a leaky integrator to track and subtract the running average.
+// Shift 10 ≈ 7 Hz cutoff at 44100 Hz. Higher = more bass preserved, slower response.
+#ifndef I2S_AUDIO_COMPENSATE_DC_OFFSET
+#define I2S_AUDIO_COMPENSATE_DC_OFFSET 0
+#endif
+#ifndef I2S_DC_FILTER_SHIFT
+#define I2S_DC_FILTER_SHIFT 10
+#endif
+
+/* Buffer-pool sizing for the producer side. Total RAM = COUNT * SAMPLES * 4
+ * bytes (stereo S16). Defaults (4 * 256 = 1024 samples) match the legacy
+ * 1024-sample ring buffer exactly. */
+#ifndef PICO_AUDIO_I2S_PE_BUFFER_COUNT
+#define PICO_AUDIO_I2S_PE_BUFFER_COUNT 4
+#endif
+
+#ifndef PICO_AUDIO_I2S_PE_BUFFER_SAMPLES
+#define PICO_AUDIO_I2S_PE_BUFFER_SAMPLES 256
+#endif
+
+/* Backwards-compatible aliases used by callers of the legacy driver. */
+#define I2S_AUDIO_RING_SIZE (PICO_AUDIO_I2S_PE_BUFFER_COUNT * PICO_AUDIO_I2S_PE_BUFFER_SAMPLES)
+#define AUDIO_RING_MASK (I2S_AUDIO_RING_SIZE - 1)
+#define DMA_BLOCK_SIZE PICO_AUDIO_I2S_PE_BUFFER_SAMPLES
+
+typedef struct {
+    int sm;
+    PIO pio;
+    int dma_chan;
+} audio_i2s_hw_t;
+
+/* enum headphone_toggle_t is declared in tlv320dac3100.h */
+
+audio_i2s_hw_t *audio_i2s_setup(int driver, int freqHZ, int dmachan);
+void audio_i2s_update_pio_frequency(uint32_t sample_freq);
+void audio_i2s_out_32(uint32_t sample32);
+void audio_i2s_enqueue_sample(uint32_t sample32);
+enum headphone_toggle_t audio_i2s_poll_headphone_status(void);
+int audio_i2s_get_freebuffer_size(void);
+void audio_i2s_disable(void);
+bool audio_i2s_dacError(void);
+void audio_i2s_muteInternalSpeaker(bool mute);
+void audio_i2s_setVolume(int8_t level);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _PICO_AUDIO_I2S_PE_H */

--- a/drivers/pico_audio_i2s_pe/audio_i2s.pio
+++ b/drivers/pico_audio_i2s_pe/audio_i2s.pio
@@ -1,0 +1,88 @@
+;
+; Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+;
+; SPDX-License-Identifier: BSD-3-Clause
+;
+
+; Transmit a mono or stereo I2S audio stream as stereo
+; This is 16 bits per sample; can be altered by modifying the "set" params,
+; or made programmable by replacing "set x" with "mov x, y" and using Y as a config register.
+;
+; Autopull must be enabled, with threshold set to 32.
+; Since I2S is MSB-first, shift direction should be to left.
+; Hence the format of the FIFO word is:
+;
+; | 31   :   16 | 15   :    0 |
+; | sample ws=0 | sample ws=1 |
+;
+; Data is output at 1 bit per clock. Use clock divider to adjust frequency.
+; Fractional divider will probably be needed to get correct bit clock period,
+; but for common syslck freqs this should still give a constant word select period.
+;
+; One output pin is used for the data output.
+; Two side-set pins are used. Two versions of the program are provided, so that
+; the clock and word select pins can be in either order.
+
+; Send 16 bit words to the PIO for mono, 32 bit words for stereo
+
+.program audio_i2s
+.side_set 2
+
+                    ;        /--- LRCLK
+                    ;        |/-- BCLK
+bitloop1:           ;        ||
+    out pins, 1       side 0b10
+    jmp x-- bitloop1  side 0b11
+    out pins, 1       side 0b00
+    set x, 14         side 0b01
+
+bitloop0:
+    out pins, 1       side 0b00
+    jmp x-- bitloop0  side 0b01
+    out pins, 1       side 0b10
+public entry_point:
+    set x, 14         side 0b11
+
+.program audio_i2s_swapped
+.side_set 2
+
+                    ;        /--- BCLK
+                    ;        |/-- LRCLK
+bitloop1:           ;        ||
+    out pins, 1       side 0b01
+    jmp x-- bitloop1  side 0b11
+    out pins, 1       side 0b00
+    set x, 14         side 0b10
+                               
+bitloop0:                      
+    out pins, 1       side 0b00
+    jmp x-- bitloop0  side 0b10
+    out pins, 1       side 0b01
+public entry_point:            
+    set x, 14         side 0b11
+
+% c-sdk {
+
+static inline void audio_i2s_program_init(PIO pio, uint sm, uint offset, uint data_pin, uint clock_pin_base) {
+    pio_sm_config sm_config = audio_i2s_program_get_default_config(offset);
+    
+    sm_config_set_out_pins(&sm_config, data_pin, 1);
+    sm_config_set_sideset_pins(&sm_config, clock_pin_base);
+    sm_config_set_out_shift(&sm_config, false, true, 32);
+    sm_config_set_fifo_join(&sm_config, PIO_FIFO_JOIN_TX);
+
+    pio_sm_init(pio, sm, offset, &sm_config);
+
+#if PICO_PIO_USE_GPIO_BASE
+    uint64_t pin_mask = (1ull << data_pin) | (3ull << clock_pin_base);
+    pio_sm_set_pindirs_with_mask64(pio, sm, pin_mask, pin_mask);
+#else
+    uint32_t pin_mask = (1u << data_pin) | (3u << clock_pin_base);
+    pio_sm_set_pindirs_with_mask(pio, sm, pin_mask, pin_mask);
+#endif
+    pio_sm_set_pins(pio, sm, 0); // clear pins
+
+    pio_sm_exec(pio, sm, pio_encode_jmp(offset + audio_i2s_offset_entry_point));
+}
+
+%}

--- a/drivers/pico_audio_i2s_pe/audio_i2s_adapter.c
+++ b/drivers/pico_audio_i2s_pe/audio_i2s_adapter.c
@@ -1,0 +1,234 @@
+/*
+ *  audio_i2s_adapter.c
+ *
+ *  Implements the legacy custom-driver API (audio_i2s_setup,
+ *  audio_i2s_enqueue_sample, ...) on top of the pico-extras audio_buffer_pool
+ *  driver. Callers see the same symbols as before, so no code outside this
+ *  directory changes when USE_PICO_EXTRAS_I2S is on.
+ *
+ *  Per-sample writes go into a producer pool; when a buffer fills it is given
+ *  to the consumer (the I2S DMA) and a fresh buffer is taken. Buffer drops on
+ *  overflow match the legacy "ring full → drop sample" behaviour.
+ */
+
+#include "tlv320dac3100.h"
+
+#include "pico/stdlib.h"
+#include "pico/audio.h"
+#include "hardware/dma.h"
+#include "hardware/pio.h"
+#include "hardware/clocks.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#define ADAPTER_AUDIO_PIO __CONCAT(pio, PICO_AUDIO_I2S_PIO)
+
+/* Rename the colliding symbol BEFORE pulling in the upstream header. The same
+ * rename is applied to pico_extras/audio_i2s.c via pe_audio_i2s_wrapper.c, so
+ * upstream's public entry point appears under `pe_audio_i2s_setup` and we are
+ * free to define our own `audio_i2s_setup` with the legacy signature. */
+#define audio_i2s_setup pe_audio_i2s_setup
+#include "pico/audio_i2s.h"
+#undef audio_i2s_setup
+
+#include "audio_i2s.h"
+
+static audio_buffer_pool_t *s_producer_pool = NULL;
+static audio_buffer_t *s_current_buffer = NULL;
+static uint32_t s_current_offset = 0;
+static int s_driver = PICO_AUDIO_I2S_DRIVER_NONE;
+static int s_dma_chan = -1;
+static int s_pio_sm = -1;
+
+static audio_format_t s_audio_format = {
+    .sample_freq = 44100,
+    .format = AUDIO_BUFFER_FORMAT_PCM_S16,
+    .channel_count = 2,
+};
+
+static audio_buffer_format_t s_producer_format = {
+    .format = &s_audio_format,
+    .sample_stride = 4, /* stereo S16 */
+};
+
+static audio_i2s_hw_t s_hw = { .sm = -1, .pio = NULL, .dma_chan = -1 };
+
+audio_i2s_hw_t *audio_i2s_setup(int driver, int freqHZ, int dmachan)
+{
+    s_driver = driver;
+    if (driver == PICO_AUDIO_I2S_DRIVER_NONE) {
+        printf("No I2S driver selected, skipping audio setup.\n");
+        return NULL;
+    }
+
+    if (driver == PICO_AUDIO_I2S_DRIVER_TLV320) {
+        tlv320_init();
+    }
+
+    if (freqHZ > 0) s_audio_format.sample_freq = (uint32_t)freqHZ;
+
+    /* If the caller asked us to pick a DMA channel, find one. Upstream's
+     * pe_audio_i2s_setup will claim it via dma_channel_claim(), so make sure
+     * it is not claimed yet at the moment we pass it in. */
+    if (dmachan < 0) {
+        int chan = dma_claim_unused_channel(true);
+        dma_channel_unclaim(chan); /* unclaim so upstream can re-claim */
+        dmachan = chan;
+    }
+    s_dma_chan = dmachan;
+
+    /* Allocate the producer pool. The buffer pool replaces the legacy
+     * ring buffer; total memory is COUNT * SAMPLES * 4 bytes (= 4096 bytes
+     * with the defaults, matching the 1024-sample legacy ring). */
+    s_producer_pool = audio_new_producer_pool(&s_producer_format,
+                                              PICO_AUDIO_I2S_PE_BUFFER_COUNT,
+                                              PICO_AUDIO_I2S_PE_BUFFER_SAMPLES);
+    if (!s_producer_pool) {
+        printf("audio_new_producer_pool failed\n");
+        return NULL;
+    }
+
+    /* Pick a free state machine on the target PIO. Upstream's pe_audio_i2s_setup
+     * calls pio_sm_claim() which panics if the SM is already taken; HW_CONFIG=1
+     * (Pimoroni Pico DV) for example reserves PIO1 SM0 for the NES controller.
+     * Mirror the DMA dance: claim to discover a free one, then immediately
+     * unclaim so upstream can re-claim. */
+    int free_sm = pio_claim_unused_sm(ADAPTER_AUDIO_PIO, true);
+    pio_sm_unclaim(ADAPTER_AUDIO_PIO, free_sm);
+
+    audio_i2s_config_t cfg = {
+        .data_pin = PICO_AUDIO_I2S_DATA_PIN,
+        .clock_pin_base = PICO_AUDIO_I2S_CLOCK_PIN_BASE,
+        .dma_channel = (uint8_t)dmachan,
+        .pio_sm = (uint8_t)free_sm,
+    };
+    s_pio_sm = free_sm;
+
+    const audio_format_t *got = pe_audio_i2s_setup(&s_audio_format, &cfg);
+    if (!got) {
+        printf("pe_audio_i2s_setup failed\n");
+        return NULL;
+    }
+
+    if (!audio_i2s_connect(s_producer_pool)) {
+        printf("audio_i2s_connect failed\n");
+        return NULL;
+    }
+
+    audio_i2s_set_enabled(true);
+
+    s_hw.dma_chan = dmachan;
+    s_hw.sm = s_pio_sm;
+    s_hw.pio = NULL; /* PIO instance not exposed by upstream API */
+    return &s_hw;
+}
+
+/* The upstream driver re-computes the PIO divider whenever the producer-pool
+ * sample_freq changes (see wrap_consumer_take in pico_extras/audio_i2s.c).
+ * Simply updating the format struct is enough. */
+void audio_i2s_update_pio_frequency(uint32_t sample_freq)
+{
+    s_audio_format.sample_freq = sample_freq;
+}
+
+void audio_i2s_out_32(uint32_t sample32)
+{
+    /* Compatibility no-op-ish: feed it through the normal path. */
+    audio_i2s_enqueue_sample(sample32);
+}
+
+#if I2S_AUDIO_COMPENSATE_DC_OFFSET
+static int32_t dc_avg_l = 0;
+static int32_t dc_avg_r = 0;
+
+static inline uint32_t __not_in_flash_func(dc_block_sample)(uint32_t sample32)
+{
+    int32_t l = (int16_t)(sample32 >> 16);
+    int32_t r = (int16_t)(sample32 & 0xFFFF);
+    dc_avg_l += (l - dc_avg_l) >> I2S_DC_FILTER_SHIFT;
+    dc_avg_r += (r - dc_avg_r) >> I2S_DC_FILTER_SHIFT;
+    l -= dc_avg_l;
+    r -= dc_avg_r;
+    if (l > 32767) l = 32767; else if (l < -32768) l = -32768;
+    if (r > 32767) r = 32767; else if (r < -32768) r = -32768;
+    return ((uint32_t)(uint16_t)l << 16) | (uint16_t)r;
+}
+#endif
+
+void __not_in_flash_func(audio_i2s_enqueue_sample)(uint32_t sample32)
+{
+    if (!s_producer_pool) return;
+
+    if (!s_current_buffer) {
+        s_current_buffer = take_audio_buffer(s_producer_pool, false /* non-blocking */);
+        if (!s_current_buffer) return; /* pool full → drop sample */
+        s_current_offset = 0;
+    }
+#if I2S_AUDIO_COMPENSATE_DC_OFFSET
+    //if (s_driver == PICO_AUDIO_I2S_DRIVER_PCM5000A)
+        sample32 = dc_block_sample(sample32);
+#endif
+    int16_t *out = (int16_t *)s_current_buffer->buffer->bytes;
+    out[s_current_offset * 2 + 0] = (int16_t)(sample32 >> 16);
+    out[s_current_offset * 2 + 1] = (int16_t)(sample32 & 0xffff);
+    s_current_offset++;
+
+    if (s_current_offset >= s_current_buffer->max_sample_count) {
+        s_current_buffer->sample_count = s_current_offset;
+        give_audio_buffer(s_producer_pool, s_current_buffer);
+        s_current_buffer = NULL;
+        s_current_offset = 0;
+    }
+}
+
+/* Approximate free space in samples. Walks the producer pool's free-list to
+ * count buffers that are currently available to be filled, plus space
+ * remaining in the currently-open buffer. Cheap because the free list is
+ * short (PICO_AUDIO_I2S_PE_BUFFER_COUNT entries). */
+int audio_i2s_get_freebuffer_size(void)
+{
+    if (!s_producer_pool) return 0;
+
+    uint32_t save = save_and_disable_interrupts();
+    uint32_t free_buffers = 0;
+    audio_buffer_t *b = s_producer_pool->free_list;
+    while (b) { free_buffers++; b = b->next; }
+    restore_interrupts(save);
+
+    uint32_t free_samples = free_buffers * PICO_AUDIO_I2S_PE_BUFFER_SAMPLES;
+    if (s_current_buffer) {
+        free_samples += (s_current_buffer->max_sample_count - s_current_offset);
+    }
+    return (int)free_samples;
+}
+
+void audio_i2s_disable(void)
+{
+    printf("Disabling I2S audio (pico-extras driver)\n");
+    audio_i2s_set_enabled(false);
+    /* Note: pico-extras does not provide a teardown for the producer pool;
+     * we leak it on purpose. This matches the existing usage pattern where
+     * audio_i2s_disable is only called from menu transitions that are
+     * followed by power-off or a fresh setup. */
+}
+
+bool audio_i2s_dacError(void)
+{
+    return tlv320_dac_error();
+}
+
+void audio_i2s_setVolume(int8_t level)
+{
+    tlv320_set_volume(level);
+}
+
+void audio_i2s_muteInternalSpeaker(bool mute)
+{
+    tlv320_mute_speaker(mute);
+}
+
+enum headphone_toggle_t audio_i2s_poll_headphone_status(void)
+{
+    return tlv320_poll_headphone();
+}

--- a/drivers/pico_audio_i2s_pe/pe_audio_i2s_wrapper.c
+++ b/drivers/pico_audio_i2s_pe/pe_audio_i2s_wrapper.c
@@ -1,0 +1,15 @@
+/*
+ *  pe_audio_i2s_wrapper.c
+ *
+ *  Compile wrapper for pico_extras/audio_i2s.c. The upstream file is kept
+ *  byte-for-byte identical to the pico-extras tree; this wrapper renames the
+ *  upstream's `audio_i2s_setup` symbol to `pe_audio_i2s_setup` so it doesn't
+ *  collide with the legacy-shaped `audio_i2s_setup` that audio_i2s_adapter.c
+ *  exports to the rest of the codebase.
+ *
+ *  Only this wrapper is added to target_sources; pico_extras/audio_i2s.c is
+ *  pulled in by inclusion.
+ */
+
+#define audio_i2s_setup pe_audio_i2s_setup
+#include "pico_extras/audio_i2s.c"

--- a/drivers/pico_audio_i2s_pe/pico_extras/README.md
+++ b/drivers/pico_audio_i2s_pe/pico_extras/README.md
@@ -1,0 +1,24 @@
+# pico-extras vendored sources
+
+These files are copied verbatim from
+[raspberrypi/pico-extras](https://github.com/raspberrypi/pico-extras) so the
+build does not depend on having that repo checked out.
+
+Upstream commit: `eb071cd88a8d7f6227ae55413e773454d1455168` (2025-08-12).
+
+| File | Upstream path |
+|---|---|
+| `audio_i2s.c` | `src/rp2_common/pico_audio_i2s/audio_i2s.c` |
+| `audio.cpp` | `src/common/pico_audio/audio.cpp` |
+| `buffer.c` | `src/common/pico_util_buffer/buffer.c` |
+| `include/pico/audio_i2s.h` | `src/rp2_common/pico_audio_i2s/include/pico/audio_i2s.h` |
+| `include/pico/audio.h` | `src/common/pico_audio/include/pico/audio.h` |
+| `include/pico/sample_conversion.h` | `src/common/pico_audio/include/pico/sample_conversion.h` |
+| `include/pico/util/buffer.h` | `src/common/pico_util_buffer/include/pico/util/buffer.h` |
+
+The `audio_i2s.pio` file (one level up) is also from
+`src/rp2_common/pico_audio_i2s/audio_i2s.pio` and is byte-identical to the
+copy the legacy driver already used.
+
+To re-sync from upstream: re-run the curl commands in the project README, or
+manually replace the files above and update this commit hash.

--- a/drivers/pico_audio_i2s_pe/pico_extras/audio.cpp
+++ b/drivers/pico_audio_i2s_pe/pico_extras/audio.cpp
@@ -1,0 +1,254 @@
+/*
+ * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <cstring>
+#include "pico/audio.h"
+#include "pico/sample_conversion.h"
+
+// ======================
+// == DEBUGGING =========
+
+#define ENABLE_AUDIO_ASSERTIONS
+
+#ifdef ENABLE_AUDIO_ASSERTIONS
+#define audio_assert(x) assert(x)
+#else
+#define audio_assert(x) (void)0
+#endif
+
+inline static audio_buffer_t *list_remove_head(audio_buffer_t **phead) {
+    audio_buffer_t *ab = *phead;
+
+    if (ab) {
+        *phead = ab->next;
+        ab->next = NULL;
+    }
+
+    return ab;
+}
+
+inline static audio_buffer_t *list_remove_head_with_tail(audio_buffer_t **phead,
+                                                              audio_buffer_t **ptail) {
+    audio_buffer_t *ab = *phead;
+
+    if (ab) {
+        *phead = ab->next;
+
+        if (!ab->next) {
+            audio_assert(*ptail == ab);
+            *ptail = NULL;
+        } else {
+            ab->next = NULL;
+        }
+    }
+
+    return ab;
+}
+
+inline static void list_prepend(audio_buffer_t **phead, audio_buffer_t *ab) {
+    audio_assert(ab->next == NULL);
+    audio_assert(ab != *phead);
+    ab->next = *phead;
+    *phead = ab;
+}
+
+// todo add a tail for these already sorted lists as we generally insert on the end
+inline static void list_append_with_tail(audio_buffer_t **phead, audio_buffer_t **ptail,
+                                         audio_buffer_t *ab) {
+    audio_assert(ab->next == NULL);
+    audio_assert(ab != *phead);
+    audio_assert(ab != *ptail);
+
+    if (!*phead) {
+        audio_assert(!*ptail);
+        *ptail = ab;
+        // insert at the beginning
+        list_prepend(phead, ab);
+    } else {
+        // insert at end
+        (*ptail)->next = ab;
+        *ptail = ab;
+    }
+}
+
+audio_buffer_t *get_free_audio_buffer(audio_buffer_pool_t *context, bool block) {
+    audio_buffer_t *ab;
+
+    do {
+        uint32_t save = spin_lock_blocking(context->free_list_spin_lock);
+        ab = list_remove_head(&context->free_list);
+        spin_unlock(context->free_list_spin_lock, save);
+        if (ab || !block) break;
+        __wfe();
+    } while (true);
+    return ab;
+}
+
+void queue_free_audio_buffer(audio_buffer_pool_t *context, audio_buffer_t *ab) {
+    assert(!ab->next);
+    uint32_t save = spin_lock_blocking(context->free_list_spin_lock);
+    list_prepend(&context->free_list, ab);
+    spin_unlock(context->free_list_spin_lock, save);
+    __sev();
+}
+
+audio_buffer_t *get_full_audio_buffer(audio_buffer_pool_t *context, bool block) {
+    audio_buffer_t *ab;
+
+    do {
+        uint32_t save = spin_lock_blocking(context->prepared_list_spin_lock);
+        ab = list_remove_head_with_tail(&context->prepared_list, &context->prepared_list_tail);
+        spin_unlock(context->prepared_list_spin_lock, save);
+        if (ab || !block) break;
+        __wfe();
+    } while (true);
+    return ab;
+}
+
+void queue_full_audio_buffer(audio_buffer_pool_t *context, audio_buffer_t *ab) {
+    assert(!ab->next);
+    uint32_t save = spin_lock_blocking(context->prepared_list_spin_lock);
+    list_append_with_tail(&context->prepared_list, &context->prepared_list_tail, ab);
+    spin_unlock(context->prepared_list_spin_lock, save);
+    __sev();
+}
+
+void producer_pool_give_buffer_default(audio_connection_t *connection, audio_buffer_t *buffer) {
+    queue_full_audio_buffer(connection->producer_pool, buffer);
+}
+
+audio_buffer_t *producer_pool_take_buffer_default(audio_connection_t *connection, bool block) {
+    return get_free_audio_buffer(connection->producer_pool, block);
+}
+
+void consumer_pool_give_buffer_default(audio_connection_t *connection, audio_buffer_t *buffer) {
+    queue_free_audio_buffer(connection->consumer_pool, buffer);
+}
+
+audio_buffer_t *consumer_pool_take_buffer_default(audio_connection_t *connection, bool block) {
+    return get_full_audio_buffer(connection->consumer_pool, block);
+}
+
+static audio_connection_t connection_default = {
+        .producer_pool_take = producer_pool_take_buffer_default,
+        .producer_pool_give = producer_pool_give_buffer_default,
+        .consumer_pool_take = consumer_pool_take_buffer_default,
+        .consumer_pool_give = consumer_pool_give_buffer_default,
+};
+
+audio_buffer_t *audio_new_buffer(audio_buffer_format_t *format, int buffer_sample_count) {
+    audio_buffer_t *buffer = (audio_buffer_t *) calloc(1, sizeof(audio_buffer_t));
+    audio_init_buffer(buffer, format, buffer_sample_count);
+    return buffer;
+}
+
+void audio_init_buffer(audio_buffer_t *audio_buffer, audio_buffer_format_t *format, int buffer_sample_count) {
+    audio_buffer->format = format;
+    audio_buffer->buffer = pico_buffer_alloc(buffer_sample_count * format->sample_stride);
+    audio_buffer->max_sample_count = buffer_sample_count;
+    audio_buffer->sample_count = 0;
+}
+
+audio_buffer_pool_t *
+audio_new_buffer_pool(audio_buffer_format_t *format, int buffer_count, int buffer_sample_count) {
+    audio_buffer_pool_t *ac = (audio_buffer_pool_t *) calloc(1, sizeof(audio_buffer_pool_t));
+    audio_buffer_t *audio_buffers = buffer_count ? (audio_buffer_t *) calloc(buffer_count,
+                                                                                       sizeof(audio_buffer_t)) : 0;
+    ac->format = format->format;
+    for (int i = 0; i < buffer_count; i++) {
+        audio_init_buffer(audio_buffers + i, format, buffer_sample_count);
+        audio_buffers[i].next = i != buffer_count - 1 ? &audio_buffers[i + 1] : NULL;
+    }
+    // todo one per channel?
+    ac->free_list_spin_lock = spin_lock_init(SPINLOCK_ID_AUDIO_FREE_LIST_LOCK);
+    ac->free_list = audio_buffers;
+    ac->prepared_list_spin_lock = spin_lock_init(SPINLOCK_ID_AUDIO_PREPARED_LISTS_LOCK);
+    ac->prepared_list = NULL;
+    ac->prepared_list_tail = NULL;
+    ac->connection = &connection_default;
+    return ac;
+}
+
+audio_buffer_t *audio_new_wrapping_buffer(audio_buffer_format_t *format, mem_buffer_t *buffer) {
+    audio_buffer_t *audio_buffer = (audio_buffer_t *) calloc(1, sizeof(audio_buffer_t));
+    if (audio_buffer) {
+        audio_buffer->format = format;
+        audio_buffer->buffer = buffer;
+        audio_buffer->max_sample_count = buffer->size / format->sample_stride;
+        audio_buffer->sample_count = 0;
+        audio_buffer->next = 0;
+    }
+    return audio_buffer;
+
+}
+
+audio_buffer_pool_t *
+audio_new_producer_pool(audio_buffer_format_t *format, int buffer_count, int buffer_sample_count) {
+    audio_buffer_pool_t *ac = audio_new_buffer_pool(format, buffer_count, buffer_sample_count);
+    ac->type = audio_buffer_pool::ac_producer;
+    return ac;
+}
+
+audio_buffer_pool_t *
+audio_new_consumer_pool(audio_buffer_format_t *format, int buffer_count, int buffer_sample_count) {
+    audio_buffer_pool_t *ac = audio_new_buffer_pool(format, buffer_count, buffer_sample_count);
+    ac->type = audio_buffer_pool::ac_consumer;
+    return ac;
+}
+
+void audio_complete_connection(audio_connection_t *connection, audio_buffer_pool_t *producer_pool,
+                               audio_buffer_pool_t *consumer_pool) {
+    assert(producer_pool->type == audio_buffer_pool::ac_producer);
+    assert(consumer_pool->type == audio_buffer_pool::ac_consumer);
+    producer_pool->connection = connection;
+    consumer_pool->connection = connection;
+    connection->producer_pool = producer_pool;
+    connection->consumer_pool = consumer_pool;
+}
+
+void give_audio_buffer(audio_buffer_pool_t *ac, audio_buffer_t *buffer) {
+    buffer->user_data = 0;
+    assert(ac->connection);
+    if (ac->type == audio_buffer_pool::ac_producer)
+        ac->connection->producer_pool_give(ac->connection, buffer);
+    else
+        ac->connection->consumer_pool_give(ac->connection, buffer);
+}
+
+audio_buffer_t *take_audio_buffer(audio_buffer_pool_t *ac, bool block) {
+    assert(ac->connection);
+    if (ac->type == audio_buffer_pool::ac_producer)
+        return ac->connection->producer_pool_take(ac->connection, block);
+    else
+        return ac->connection->consumer_pool_take(ac->connection, block);
+}
+
+// todo rename this - this is s16 to s16
+audio_buffer_t *mono_to_mono_consumer_take(audio_connection_t *connection, bool block) {
+    return consumer_pool_take<Mono<FmtS16>, Mono<FmtS16>>(connection, block);
+}
+
+// todo rename this - this is s16 to s16
+audio_buffer_t *stereo_to_stereo_consumer_take(audio_connection_t *connection, bool block) {
+    return consumer_pool_take<Stereo<FmtS16>, Stereo<FmtS16>>(connection, block);
+}
+
+// todo rename this - this is s16 to s16
+audio_buffer_t *mono_to_stereo_consumer_take(audio_connection_t *connection, bool block) {
+    return consumer_pool_take<Stereo<FmtS16>, Mono<FmtS16>>(connection, block);
+}
+
+audio_buffer_t *mono_s8_to_mono_consumer_take(audio_connection_t *connection, bool block) {
+    return consumer_pool_take<Mono<FmtS16>, Mono<FmtS8>>(connection, block);
+}
+
+audio_buffer_t *mono_s8_to_stereo_consumer_take(audio_connection_t *connection, bool block) {
+    return consumer_pool_take<Stereo<FmtS16>, Mono<FmtS8>>(connection, block);
+}
+
+void stereo_to_stereo_producer_give(audio_connection_t *connection, audio_buffer_t *buffer) {
+    return producer_pool_blocking_give<Stereo<FmtS16>, Stereo<FmtS16>>(connection, buffer);
+}

--- a/drivers/pico_audio_i2s_pe/pico_extras/audio_i2s.c
+++ b/drivers/pico_audio_i2s_pe/pico_extras/audio_i2s.c
@@ -1,0 +1,398 @@
+/*
+ * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <stdio.h>
+
+#include "pico/audio_i2s.h"
+#include "audio_i2s.pio.h"
+#include "hardware/pio.h"
+#include "hardware/gpio.h"
+#include "hardware/dma.h"
+#include "hardware/irq.h"
+#include "hardware/clocks.h"
+
+
+CU_REGISTER_DEBUG_PINS(audio_timing)
+
+// ---- select at most one ---
+//CU_SELECT_DEBUG_PINS(audio_timing)
+
+
+#if PICO_AUDIO_I2S_MONO_OUTPUT
+#define i2s_dma_configure_size DMA_SIZE_16
+#else
+#define i2s_dma_configure_size DMA_SIZE_32
+#endif
+
+#define audio_pio __CONCAT(pio, PICO_AUDIO_I2S_PIO)
+#define GPIO_FUNC_PIOx __CONCAT(GPIO_FUNC_PIO, PICO_AUDIO_I2S_PIO)
+#define DREQ_PIOx_TX0 __CONCAT(__CONCAT(DREQ_PIO, PICO_AUDIO_I2S_PIO), _TX0)
+
+struct {
+    audio_buffer_t *playing_buffer;
+    uint32_t freq;
+    uint8_t pio_sm;
+    uint8_t dma_channel;
+} shared_state;
+
+audio_format_t pio_i2s_consumer_format;
+audio_buffer_format_t pio_i2s_consumer_buffer_format = {
+        .format = &pio_i2s_consumer_format,
+};
+
+static void __isr __time_critical_func(audio_i2s_dma_irq_handler)();
+
+const audio_format_t *audio_i2s_setup(const audio_format_t *intended_audio_format,
+                                               const audio_i2s_config_t *config) {
+    printf("Setting up pico_extras I2S audio with data pin %d, clock pin base %d, PIO state machine %d, DMA channel %d\n",
+           config->data_pin, config->clock_pin_base, config->pio_sm, config->dma_channel);
+    uint func = GPIO_FUNC_PIOx;
+    gpio_set_function(config->data_pin, func);
+    gpio_set_function(config->clock_pin_base, func);
+    gpio_set_function(config->clock_pin_base + 1, func);
+
+#if PICO_PIO_USE_GPIO_BASE
+    if(config->data_pin >= 32 || config->clock_pin_base + 1 >= 32) {
+        assert(config->data_pin >= 16 && config->clock_pin_base >= 16);
+        pio_set_gpio_base(audio_pio, 16);
+    }
+#endif
+    uint8_t sm = shared_state.pio_sm = config->pio_sm;
+    pio_sm_claim(audio_pio, sm);
+
+
+    const struct pio_program *program =
+#if PICO_AUDIO_I2S_CLOCK_PINS_SWAPPED
+        &audio_i2s_swapped_program
+#else
+        &audio_i2s_program
+#endif
+        ;
+    uint offset = pio_add_program(audio_pio, program);
+
+    audio_i2s_program_init(audio_pio, sm, offset, config->data_pin, config->clock_pin_base);
+
+    __mem_fence_release();
+    uint8_t dma_channel = config->dma_channel;
+    dma_channel_claim(dma_channel);
+
+    shared_state.dma_channel = dma_channel;
+
+    dma_channel_config dma_config = dma_channel_get_default_config(dma_channel);
+
+    channel_config_set_dreq(&dma_config,
+                            DREQ_PIOx_TX0 + sm
+    );
+    channel_config_set_transfer_data_size(&dma_config, i2s_dma_configure_size);
+    dma_channel_configure(dma_channel,
+                          &dma_config,
+                          &audio_pio->txf[sm],  // dest
+                          NULL, // src
+                          0, // count
+                          false // trigger
+    );
+
+    irq_add_shared_handler(DMA_IRQ_0 + PICO_AUDIO_I2S_DMA_IRQ, audio_i2s_dma_irq_handler, PICO_SHARED_IRQ_HANDLER_DEFAULT_ORDER_PRIORITY);
+    dma_irqn_set_channel_enabled(PICO_AUDIO_I2S_DMA_IRQ, dma_channel, 1);
+    return intended_audio_format;
+}
+
+static audio_buffer_pool_t *audio_i2s_consumer;
+
+static void update_pio_frequency(uint32_t sample_freq) {
+    uint32_t system_clock_frequency = clock_get_hz(clk_sys);
+    assert(system_clock_frequency < 0x40000000);
+    uint32_t divider = system_clock_frequency * 4 / sample_freq; // avoid arithmetic overflow
+    assert(divider < 0x1000000);
+    pio_sm_set_clkdiv_int_frac(audio_pio, shared_state.pio_sm, divider >> 8u, divider & 0xffu);
+    shared_state.freq = sample_freq;
+}
+
+static audio_buffer_t *wrap_consumer_take(audio_connection_t *connection, bool block) {
+    // support dynamic frequency shifting
+    if (connection->producer_pool->format->sample_freq != shared_state.freq) {
+        update_pio_frequency(connection->producer_pool->format->sample_freq);
+    }
+#if PICO_AUDIO_I2S_MONO_INPUT
+#if PICO_AUDIO_I2S_MONO_OUTPUT
+    return mono_to_mono_consumer_take(connection, block);
+#else
+    return mono_to_stereo_consumer_take(connection, block);
+#endif
+#else
+#if PICO_AUDIO_I2S_MONO_OUTPUT
+    unsupported;
+#else
+    return stereo_to_stereo_consumer_take(connection, block);
+#endif
+#endif
+}
+
+static void wrap_producer_give(audio_connection_t *connection, audio_buffer_t *buffer) {
+    // support dynamic frequency shifting
+    if (connection->producer_pool->format->sample_freq != shared_state.freq) {
+        update_pio_frequency(connection->producer_pool->format->sample_freq);
+    }
+#if PICO_AUDIO_I2S_MONO_INPUT
+#if PICO_AUDIO_I2S_MONO_OUTPUT
+    assert(false);
+//    return mono_to_mono_producer_give(connection, block);
+#else
+    assert(false);
+    //return mono_to_stereo_producer_give(connection, buffer);
+#endif
+#else
+#if PICO_AUDIO_I2S_MONO_OUTPUT
+    unsupported;
+#else
+    return stereo_to_stereo_producer_give(connection, buffer);
+#endif
+#endif
+}
+
+static struct buffer_copying_on_consumer_take_connection m2s_audio_i2s_ct_connection = {
+        .core = {
+                .consumer_pool_take = wrap_consumer_take,
+                .consumer_pool_give = consumer_pool_give_buffer_default,
+                .producer_pool_take = producer_pool_take_buffer_default,
+                .producer_pool_give = producer_pool_give_buffer_default,
+        }
+};
+
+static struct producer_pool_blocking_give_connection m2s_audio_i2s_pg_connection = {
+        .core = {
+                .consumer_pool_take = consumer_pool_take_buffer_default,
+                .consumer_pool_give = consumer_pool_give_buffer_default,
+                .producer_pool_take = producer_pool_take_buffer_default,
+                .producer_pool_give = wrap_producer_give,
+        }
+};
+
+static void pass_thru_producer_give(audio_connection_t *connection, audio_buffer_t *buffer) {
+    queue_full_audio_buffer(connection->consumer_pool, buffer);
+}
+
+static void pass_thru_consumer_give(audio_connection_t *connection, audio_buffer_t *buffer) {
+    queue_free_audio_buffer(connection->producer_pool, buffer);
+}
+
+static struct producer_pool_blocking_give_connection audio_i2s_pass_thru_connection = {
+        .core = {
+                .consumer_pool_take = consumer_pool_take_buffer_default,
+                .consumer_pool_give = pass_thru_consumer_give,
+                .producer_pool_take = producer_pool_take_buffer_default,
+                .producer_pool_give = pass_thru_producer_give,
+        }
+};
+
+bool audio_i2s_connect_thru(audio_buffer_pool_t *producer, audio_connection_t *connection) {
+    return audio_i2s_connect_extra(producer, false, 2, 256, connection);
+}
+
+bool audio_i2s_connect(audio_buffer_pool_t *producer) {
+    return audio_i2s_connect_thru(producer, NULL);
+}
+
+bool audio_i2s_connect_extra(audio_buffer_pool_t *producer, bool buffer_on_give, uint buffer_count,
+                                 uint samples_per_buffer, audio_connection_t *connection) {
+    printf("Connecting PIO I2S audio\n");
+
+    // todo we need to pick a connection based on the frequency - e.g. 22050 can be more simply upsampled to 44100
+    assert(producer->format->format == AUDIO_BUFFER_FORMAT_PCM_S16);
+    pio_i2s_consumer_format.format = AUDIO_BUFFER_FORMAT_PCM_S16;
+    // todo we could do mono
+    // todo we can't match exact, so we should return what we can do
+    pio_i2s_consumer_format.sample_freq = producer->format->sample_freq;
+#if PICO_AUDIO_I2S_MONO_OUTPUT
+    pio_i2s_consumer_format.channel_count = 1;
+    pio_i2s_consumer_buffer_format.sample_stride = 2;
+#else
+    pio_i2s_consumer_format.channel_count = 2;
+    pio_i2s_consumer_buffer_format.sample_stride = 4;
+#endif
+
+    audio_i2s_consumer = audio_new_consumer_pool(&pio_i2s_consumer_buffer_format, buffer_count, samples_per_buffer);
+
+    update_pio_frequency(producer->format->sample_freq);
+
+    // todo cleanup threading
+    __mem_fence_release();
+
+    if (!connection) {
+        if (producer->format->channel_count == 2) {
+#if PICO_AUDIO_I2S_MONO_INPUT
+            panic("need to merge channels down\n");
+#else
+#if PICO_AUDIO_I2S_MONO_OUTPUT
+            panic("trying to play stereo thru mono not yet supported");
+#else
+            printf("Copying stereo to stereo at %d Hz\n", (int) producer->format->sample_freq);
+#endif
+#endif
+        } else {
+#if PICO_AUDIO_I2S_MONO_OUTPUT
+            printf("Copying mono to mono at %d Hz\n", (int) producer->format->sample_freq);
+#else
+            printf("Converting mono to stereo at %d Hz\n", (int) producer->format->sample_freq);
+#endif
+        }
+        if (!buffer_count)
+            connection = &audio_i2s_pass_thru_connection.core;
+        else
+            connection = buffer_on_give ? &m2s_audio_i2s_pg_connection.core : &m2s_audio_i2s_ct_connection.core;
+    }
+    audio_complete_connection(connection, producer, audio_i2s_consumer);
+    return true;
+}
+
+static struct buffer_copying_on_consumer_take_connection m2s_audio_i2s_connection_s8 = {
+        .core = {
+#if PICO_AUDIO_I2S_MONO_OUTPUT
+                .consumer_pool_take = mono_s8_to_mono_consumer_take,
+#else
+                .consumer_pool_take = mono_s8_to_stereo_consumer_take,
+#endif
+                .consumer_pool_give = consumer_pool_give_buffer_default,
+                .producer_pool_take = producer_pool_take_buffer_default,
+                .producer_pool_give = producer_pool_give_buffer_default,
+        }
+};
+
+bool audio_i2s_connect_s8(audio_buffer_pool_t *producer) {
+    printf("Connecting PIO I2S audio (U8)\n");
+
+    // todo we need to pick a connection based on the frequency - e.g. 22050 can be more simply upsampled to 44100
+    assert(producer->format->format == AUDIO_BUFFER_FORMAT_PCM_S8);
+    pio_i2s_consumer_format.format = AUDIO_BUFFER_FORMAT_PCM_S16;
+    // todo we could do mono
+    // todo we can't match exact, so we should return what we can do
+    pio_i2s_consumer_format.sample_freq = producer->format->sample_freq;
+#if PICO_AUDIO_I2S_MONO_OUTPUT
+    pio_i2s_consumer_format.channel_count = 1;
+    pio_i2s_consumer_buffer_format.sample_stride = 2;
+#else
+    pio_i2s_consumer_format.channel_count = 2;
+    pio_i2s_consumer_buffer_format.sample_stride = 4;
+#endif
+
+    // we do this on take so should do it quickly...
+    uint samples_per_buffer = 256;
+    // todo with take we really only need 1 buffer
+    audio_i2s_consumer = audio_new_consumer_pool(&pio_i2s_consumer_buffer_format, 2, samples_per_buffer);
+
+    // todo we need a method to calculate this in clocks
+    uint32_t system_clock_frequency = clock_get_hz(clk_sys);
+//    uint32_t divider = system_clock_frequency * 256 / producer->format->sample_freq * 16 * 4;
+    uint32_t divider = system_clock_frequency * 4 / producer->format->sample_freq; // avoid arithmetic overflow
+    pio_sm_set_clkdiv_int_frac(audio_pio, shared_state.pio_sm, divider >> 8u, divider & 0xffu);
+
+    // todo cleanup threading
+    __mem_fence_release();
+
+    audio_connection_t *connection;
+    if (producer->format->channel_count == 2) {
+#if PICO_AUDIO_I2S_MONO_OUTPUT
+        panic("trying to play stereo thru mono not yet supported");
+#endif
+        // todo we should support pass thru option anyway
+        printf("TODO... not completing stereo audio connection properly!\n");
+        connection = &m2s_audio_i2s_connection_s8.core;
+    } else {
+#if PICO_AUDIO_I2S_MONO_OUTPUT
+        printf("Copying mono to mono at %d Hz\n", (int) producer->format->sample_freq);
+#else
+        printf("Converting mono to stereo at %d Hz\n", (int) producer->format->sample_freq);
+#endif
+        connection = &m2s_audio_i2s_connection_s8.core;
+    }
+    audio_complete_connection(connection, producer, audio_i2s_consumer);
+    return true;
+}
+
+static inline void audio_start_dma_transfer() {
+    assert(!shared_state.playing_buffer);
+    audio_buffer_t *ab = take_audio_buffer(audio_i2s_consumer, false);
+
+    shared_state.playing_buffer = ab;
+    if (!ab) {
+        DEBUG_PINS_XOR(audio_timing, 1);
+        DEBUG_PINS_XOR(audio_timing, 2);
+        DEBUG_PINS_XOR(audio_timing, 1);
+        //DEBUG_PINS_XOR(audio_timing, 2);
+        // just play some silence
+        static uint32_t zero;
+        dma_channel_config c = dma_get_channel_config(shared_state.dma_channel);
+        channel_config_set_read_increment(&c, false);
+        dma_channel_set_config(shared_state.dma_channel, &c, false);
+        dma_channel_transfer_from_buffer_now(shared_state.dma_channel, &zero, PICO_AUDIO_I2S_SILENCE_BUFFER_SAMPLE_LENGTH);
+        return;
+    }
+    assert(ab->sample_count);
+    // todo better naming of format->format->format!!
+    assert(ab->format->format->format == AUDIO_BUFFER_FORMAT_PCM_S16);
+#if PICO_AUDIO_I2S_MONO_OUTPUT
+    assert(ab->format->format->channel_count == 1);
+    assert(ab->format->sample_stride == 2);
+#else
+    assert(ab->format->format->channel_count == 2);
+    assert(ab->format->sample_stride == 4);
+#endif
+    dma_channel_config c = dma_get_channel_config(shared_state.dma_channel);
+    channel_config_set_read_increment(&c, true);
+    dma_channel_set_config(shared_state.dma_channel, &c, false);
+    dma_channel_transfer_from_buffer_now(shared_state.dma_channel, ab->buffer->bytes, ab->sample_count);
+}
+
+// irq handler for DMA
+void __isr __time_critical_func(audio_i2s_dma_irq_handler)() {
+#if PICO_AUDIO_I2S_NOOP
+    assert(false);
+#else
+    uint dma_channel = shared_state.dma_channel;
+    if (dma_irqn_get_channel_status(PICO_AUDIO_I2S_DMA_IRQ, dma_channel)) {
+        dma_irqn_acknowledge_channel(PICO_AUDIO_I2S_DMA_IRQ, dma_channel);
+        DEBUG_PINS_SET(audio_timing, 4);
+        // free the buffer we just finished
+        if (shared_state.playing_buffer) {
+            give_audio_buffer(audio_i2s_consumer, shared_state.playing_buffer);
+#ifndef NDEBUG
+            shared_state.playing_buffer = NULL;
+#endif
+        }
+        audio_start_dma_transfer();
+        DEBUG_PINS_CLR(audio_timing, 4);
+    }
+#endif
+}
+
+static bool audio_enabled;
+
+void audio_i2s_set_enabled(bool enabled) {
+    if (enabled != audio_enabled) {
+#ifndef NDEBUG
+        if (enabled)
+        {
+            puts("Enabling PIO I2S audio\n");
+            printf("(on core %d\n", get_core_num());
+        }
+#endif
+        irq_set_enabled(DMA_IRQ_0 + PICO_AUDIO_I2S_DMA_IRQ, enabled);
+
+        if (enabled) {
+            audio_start_dma_transfer();
+        } else {
+            // if there was a buffer in flight, it will not be freed by DMA IRQ, let's do it manually
+            if (shared_state.playing_buffer) {
+                give_audio_buffer(audio_i2s_consumer, shared_state.playing_buffer);
+                shared_state.playing_buffer = NULL;
+            }
+        }
+
+        pio_sm_set_enabled(audio_pio, shared_state.pio_sm, enabled);
+
+        audio_enabled = enabled;
+    }
+}

--- a/drivers/pico_audio_i2s_pe/pico_extras/buffer.c
+++ b/drivers/pico_audio_i2s_pe/pico_extras/buffer.c
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "pico/util/buffer.h"
+
+#ifdef PICO_BUFFER_USB_ALLOC_HACK
+#include <string.h>
+
+uint8_t *usb_ram_alloc_ptr = (uint8_t *)(USBCTRL_DPRAM_BASE + USB_DPRAM_MAX);
+
+static void __attribute__((constructor)) _clear_usb_ram() {
+    memset(usb_ram_alloc_ptr, 0, USB_DPRAM_SIZE - USB_DPRAM_MAX);
+}
+#endif

--- a/drivers/pico_audio_i2s_pe/pico_extras/include/pico/audio.h
+++ b/drivers/pico_audio_i2s_pe/pico_extras/include/pico/audio.h
@@ -1,0 +1,308 @@
+/*
+ * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef _PICO_AUDIO_H
+#define _PICO_AUDIO_H
+
+#include "pico.h"
+#include "pico/util/buffer.h"
+#include "hardware/sync.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** \file audio.h
+*  \defgroup pico_audio pico_audio
+ *
+ * Common API for audio output
+ *
+ */
+
+// PICO_CONFIG: SPINLOCK_ID_AUDIO_FREE_LIST_LOCK, Spinlock number for the audio free list, min=0, max=31, default=6, group=audio
+#ifndef SPINLOCK_ID_AUDIO_FREE_LIST_LOCK
+#define SPINLOCK_ID_AUDIO_FREE_LIST_LOCK 6
+#endif
+
+// PICO_CONFIG: SPINLOCK_ID_AUDIO_PREPARED_LISTS_LOCK, Spinlock number for the audio prepared list, min=0, max=31, default=7, group=audio
+#ifndef SPINLOCK_ID_AUDIO_PREPARED_LISTS_LOCK
+#define SPINLOCK_ID_AUDIO_PREPARED_LISTS_LOCK 7
+#endif
+
+// PICO_CONFIG: PICO_AUDIO_NOOP, Enable/disable audio by forcing NOOPS, type=bool, default=0, group=audio
+#ifndef PICO_AUDIO_NOOP
+#define PICO_AUDIO_NOOP 0
+#endif
+
+
+#define AUDIO_BUFFER_FORMAT_PCM_S16 1          ///< signed 16bit PCM
+#define AUDIO_BUFFER_FORMAT_PCM_S8 2           ///< signed 8bit PCM
+#define AUDIO_BUFFER_FORMAT_PCM_U16 3          ///< unsigned 16bit PCM
+#define AUDIO_BUFFER_FORMAT_PCM_U8 4           ///< unsigned 8bit PCM
+
+/** \brief Audio format definition
+ */
+typedef struct audio_format {
+    uint32_t sample_freq;      ///< Sample frequency in Hz
+    uint16_t format;           ///< Audio format \ref audio_formats
+    uint16_t channel_count;    ///< Number of channels
+} audio_format_t;
+
+/** \brief Audio buffer format definition
+ */
+typedef struct audio_buffer_format {
+    const audio_format_t *format;      ///< Audio format
+    uint16_t sample_stride;                 ///< Sample stride
+} audio_buffer_format_t;
+
+/** \brief Audio buffer definition
+ */
+typedef struct audio_buffer {
+    mem_buffer_t *buffer;
+    const audio_buffer_format_t *format;
+    uint32_t sample_count;
+    uint32_t max_sample_count;
+    uint32_t user_data; // only valid while the user has the buffer
+    // private - todo make an internal version
+    struct audio_buffer *next;
+} audio_buffer_t;
+
+typedef struct audio_connection audio_connection_t;
+
+typedef struct audio_buffer_pool {
+    enum {
+        ac_producer, ac_consumer
+    } type;
+    const audio_format_t *format;
+    // private
+    audio_connection_t *connection;
+    spin_lock_t *free_list_spin_lock;
+    // ----- begin protected by free_list_spin_lock -----
+    audio_buffer_t *free_list;
+    spin_lock_t *prepared_list_spin_lock;
+    audio_buffer_t *prepared_list;
+    audio_buffer_t *prepared_list_tail;
+} audio_buffer_pool_t;
+
+typedef struct audio_connection audio_connection_t;
+
+struct audio_connection {
+    audio_buffer_t *(*producer_pool_take)(audio_connection_t *connection, bool block);
+
+    void (*producer_pool_give)(audio_connection_t *connection, audio_buffer_t *buffer);
+
+    audio_buffer_t *(*consumer_pool_take)(audio_connection_t *connection, bool block);
+
+    void (*consumer_pool_give)(audio_connection_t *connection, audio_buffer_t *buffer);
+
+    audio_buffer_pool_t *producer_pool;
+    audio_buffer_pool_t *consumer_pool;
+};
+
+/*! \brief Allocate and initialise an audio producer pool
+ *  \ingroup pico_audio
+ *
+ * \param format Format of the audio buffer
+ * \param buffer_count \todo
+ * \param buffer_sample_count \todo
+ * \return Pointer to an audio_buffer_pool
+ */
+audio_buffer_pool_t *audio_new_producer_pool(audio_buffer_format_t *format, int buffer_count,
+                                                         int buffer_sample_count);
+
+/*! \brief Allocate and initialise an audio consumer pool
+ *  \ingroup pico_audio
+ *
+ * \param format Format of the audio buffer
+ * \param buffer_count
+ * \param buffer_sample_count
+ * \return Pointer to an audio_buffer_pool
+ */
+audio_buffer_pool_t *audio_new_consumer_pool(audio_buffer_format_t *format, int buffer_count,
+                                                         int buffer_sample_count);
+
+/*! \brief Allocate and initialise an audio wrapping buffer
+ *  \ingroup pico_audio
+ *
+ * \param format Format of the audio buffer
+ * \param buffer \todo
+ * \return Pointer to an audio_buffer
+ */
+audio_buffer_t *audio_new_wrapping_buffer(audio_buffer_format_t *format, mem_buffer_t *buffer);
+
+/*! \brief Allocate and initialise an new audio buffer
+ *  \ingroup pico_audio
+ *
+ * \param format Format of the audio buffer
+ * \param buffer_sample_count \todo
+ * \return Pointer to an audio_buffer
+ */
+audio_buffer_t *audio_new_buffer(audio_buffer_format_t *format, int buffer_sample_count);
+
+/*! \brief Initialise an audio buffer
+ *  \ingroup pico_audio
+ *
+ * \param audio_buffer Pointer to an audio_buffer
+ * \param format Format of the audio buffer
+ * \param buffer_sample_count \todo
+ */
+void audio_init_buffer(audio_buffer_t *audio_buffer, audio_buffer_format_t *format, int buffer_sample_count);
+
+/*! \brief \todo
+ *  \ingroup pico_audio
+ *
+ * \param ac \todo
+ * \param buffer \todo
+ * \return Pointer to an audio_buffer
+ */
+void give_audio_buffer(audio_buffer_pool_t *ac, audio_buffer_t *buffer);
+
+/*! \brief \todo
+ *  \ingroup pico_audio
+ *
+ * \return Pointer to an audio_buffer
+ */
+audio_buffer_t *take_audio_buffer(audio_buffer_pool_t *ac, bool block);
+
+/*! \brief \todo
+ *  \ingroup pico_audio
+ *
+ */
+static inline void release_audio_buffer(audio_buffer_pool_t *ac, audio_buffer_t *buffer) {
+    buffer->sample_count = 0;
+    give_audio_buffer(ac, buffer);
+}
+
+/*! \brief \todo
+ *  \ingroup pico_audio
+ *
+ * todo we are currently limited to 4095+1 input samples
+ * step is fraction of an input sample per output sample * 0x1000 and should be < 0x1000 i.e. we we are up-sampling (otherwise results are undefined)
+ */
+void audio_upsample(int16_t *input, int16_t *output, uint output_count, uint32_t step);
+
+/*! \brief \todo
+ *  \ingroup pico_audio
+ * similar but the output buffer is word aligned, and we output an even number of samples.. this is slightly faster than the above
+ * todo we are currently limited to 4095+1 input samples
+ * step is fraction of an input sample per output sample * 0x1000 and should be < 0x1000 i.e. we we are up-sampling (otherwise results are undefined)
+ */
+void audio_upsample_words(int16_t *input, int16_t *output_aligned, uint output_word_count, uint32_t step);
+
+/*! \brief \todo
+ *  \ingroup pico_audio
+ */
+void audio_upsample_double(int16_t *input, int16_t *output, uint output_count, uint32_t step);
+
+/*! \brief \todo
+ *  \ingroup pico_audio
+ */
+void audio_complete_connection(audio_connection_t *connection, audio_buffer_pool_t *producer,
+                                      audio_buffer_pool_t *consumer);
+
+/*! \brief \todo
+ *  \ingroup pico_audio
+ */
+audio_buffer_t *get_free_audio_buffer(audio_buffer_pool_t *context, bool block);
+
+/*! \brief \todo
+ *  \ingroup pico_audio
+ */
+void queue_free_audio_buffer(audio_buffer_pool_t *context, audio_buffer_t *ab);
+
+/*! \brief \todo
+ *  \ingroup pico_audio
+ */
+audio_buffer_t *get_full_audio_buffer(audio_buffer_pool_t *context, bool block);
+
+/*! \brief \todo
+ *  \ingroup pico_audio
+ */
+void queue_full_audio_buffer(audio_buffer_pool_t *context, audio_buffer_t *ab);
+
+/*! \brief \todo
+ *  \ingroup pico_audio
+ *
+ * generally an pico_audio connection uses 3 of the defaults and does the hard work in one of them
+ */
+void consumer_pool_give_buffer_default(audio_connection_t *connection, audio_buffer_t *buffer);
+
+/*! \brief \todo
+ *  \ingroup pico_audio
+ */
+audio_buffer_t *consumer_pool_take_buffer_default(audio_connection_t *connection, bool block);
+
+/*! \brief \todo
+ *  \ingroup pico_audio
+ */
+void producer_pool_give_buffer_default(audio_connection_t *connection, audio_buffer_t *buffer);
+
+/*! \brief \todo
+ *  \ingroup pico_audio
+ */
+audio_buffer_t *producer_pool_take_buffer_default(audio_connection_t *connection, bool block);
+
+enum audio_correction_mode {
+    none,
+    fixed_dither,
+    dither,
+    noise_shaped_dither,
+};
+
+struct buffer_copying_on_consumer_take_connection {
+    struct audio_connection core;
+    audio_buffer_t *current_producer_buffer;
+    uint32_t current_producer_buffer_pos;
+};
+
+struct producer_pool_blocking_give_connection {
+    audio_connection_t core;
+    audio_buffer_t *current_consumer_buffer;
+    uint32_t current_consumer_buffer_pos;
+};
+
+/*! \brief \todo
+ *  \ingroup pico_audio
+ */
+audio_buffer_t *mono_to_mono_consumer_take(audio_connection_t *connection, bool block);
+
+/*! \brief \todo
+ *  \ingroup pico_audio
+ */
+audio_buffer_t *mono_s8_to_mono_consumer_take(audio_connection_t *connection, bool block);
+
+/*! \brief \todo
+ *  \ingroup pico_audio
+ */
+audio_buffer_t *stereo_to_stereo_consumer_take(audio_connection_t *connection, bool block);
+
+/*! \brief \todo
+ *  \ingroup pico_audio
+ */
+audio_buffer_t *mono_to_stereo_consumer_take(audio_connection_t *connection, bool block);
+
+/*! \brief \todo
+ *  \ingroup pico_audio
+ */
+audio_buffer_t *mono_s8_to_stereo_consumer_take(audio_connection_t *connection, bool block);
+
+/*! \brief \todo
+ *  \ingroup pico_audio
+ */
+void stereo_to_stereo_producer_give(audio_connection_t *connection, audio_buffer_t *buffer);
+
+// not worth a separate header for now
+typedef struct __packed pio_audio_channel_config {
+    uint8_t base_pin;
+    uint8_t dma_channel;
+    uint8_t pio_sm;
+} pio_audio_channel_config_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif //_AUDIO_H

--- a/drivers/pico_audio_i2s_pe/pico_extras/include/pico/audio_i2s.h
+++ b/drivers/pico_audio_i2s_pe/pico_extras/include/pico/audio_i2s.h
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef _PICO_AUDIO_I2S_H
+#define _PICO_AUDIO_I2S_H
+
+#include "pico/audio.h"
+
+/** \file audio_i2s.h
+ *  \defgroup pico_audio_i2s pico_audio_i2s
+ *  I2S audio output using the PIO
+ *
+ * This library uses the \ref hardware_pio system to implement a I2S audio interface
+ *
+ * \todo Must be more we need to say here.
+ * \todo certainly need an example
+ *
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef PICO_AUDIO_I2S_DMA_IRQ
+#ifdef PICO_AUDIO_DMA_IRQ
+#define PICO_AUDIO_I2S_DMA_IRQ PICO_AUDIO_DMA_IRQ
+#else
+#define PICO_AUDIO_I2S_DMA_IRQ 0
+#endif
+#endif
+
+#ifndef PICO_AUDIO_I2S_PIO
+#ifdef PICO_AUDIO_PIO
+#define PICO_AUDIO_I2S_PIO PICO_AUDIO_PIO
+#else
+#define PICO_AUDIO_I2S_PIO 0
+#endif
+#endif
+
+#if !(PICO_AUDIO_I2S_DMA_IRQ == 0 || PICO_AUDIO_I2S_DMA_IRQ == 1)
+#error PICO_AUDIO_I2S_DMA_IRQ must be 0 or 1
+#endif
+
+#if !(PICO_AUDIO_I2S_PIO == 0 || PICO_AUDIO_I2S_PIO == 1)
+#error PICO_AUDIO_I2S_PIO ust be 0 or 1
+#endif
+
+#ifndef PICO_AUDIO_I2S_MAX_CHANNELS
+#ifdef PICO_AUDIO_MAX_CHANNELS
+#define PICO_AUDIO_I2S_MAX_CHANNELS PICO_AUDIO_MAX_CHANNELS
+#else
+#define PICO_AUDIO_I2S_MAX_CHANNELS 2u
+#endif
+#endif
+
+#ifndef PICO_AUDIO_I2S_BUFFERS_PER_CHANNEL
+#ifdef PICO_AUDIO_BUFFERS_PER_CHANNEL
+#define PICO_AUDIO_I2S_BUFFERS_PER_CHANNEL PICO_AUDIO_BUFFERS_PER_CHANNEL
+#else
+#define PICO_AUDIO_I2S_BUFFERS_PER_CHANNEL 3u
+#endif
+#endif
+
+#ifndef PICO_AUDIO_I2S_BUFFER_SAMPLE_LENGTH
+#ifdef PICO_AUDIO_BUFFER_SAMPLE_LENGTH
+#define PICO_AUDIO_I2S_BUFFER_SAMPLE_LENGTH PICO_AUDIO_BUFFER_SAMPLE_LENGTH
+#else
+#define PICO_AUDIO_I2S_BUFFER_SAMPLE_LENGTH 576u
+#endif
+#endif
+
+#ifndef PICO_AUDIO_I2S_SILENCE_BUFFER_SAMPLE_LENGTH
+#ifdef PICO_AUDIO_I2S_SILENCE_BUFFER_SAMPLE_LENGTH
+#define PICO_AUDIO_I2S_SILENCE_BUFFER_SAMPLE_LENGTH PICO_AUDIO_SILENCE_BUFFER_SAMPLE_LENGTH
+#else
+#define PICO_AUDIO_I2S_SILENCE_BUFFER_SAMPLE_LENGTH 256u
+#endif
+#endif
+
+// Allow use of pico_audio driver without actually doing anything much
+#ifndef PICO_AUDIO_I2S_NOOP
+#ifdef PICO_AUDIO_NOOP
+#define PICO_AUDIO_I2S_NOOP PICO_AUDIO_NOOP
+#else
+#define PICO_AUDIO_I2S_NOOP 0
+#endif
+#endif
+
+#ifndef PICO_AUDIO_I2S_MONO_INPUT
+#define PICO_AUDIO_I2S_MONO_INPUT 0
+#endif
+#ifndef PICO_AUDIO_I2S_MONO_OUTPUT
+#define PICO_AUDIO_I2S_MONO_OUTPUT 0
+#endif
+
+#ifndef PICO_AUDIO_I2S_DATA_PIN
+//#warning PICO_AUDIO_I2S_DATA_PIN should be defined when using AUDIO_I2S
+#define PICO_AUDIO_I2S_DATA_PIN 28
+#endif
+
+#ifndef PICO_AUDIO_I2S_CLOCK_PIN_BASE
+//#warning PICO_AUDIO_I2S_CLOCK_PIN_BASE should be defined when using AUDIO_I2S
+#define PICO_AUDIO_I2S_CLOCK_PIN_BASE 26
+#endif
+
+// The default order is CLOCK_PIN_BASE=LRCLK, CLOCK_PIN_BASE+1=BCLK
+// The swapped order is CLOCK_PIN_BASE=BCLK,  CLOCK_PIN_BASE+1=LRCLK
+#ifndef PICO_AUDIO_I2S_CLOCK_PINS_SWAPPED
+#define PICO_AUDIO_I2S_CLOCK_PINS_SWAPPED 0
+#endif
+
+// todo this needs to come from a build config
+/** \brief Base configuration structure used when setting up
+ * \ingroup pico_audio_i2s
+ */
+typedef struct audio_i2s_config {
+    uint8_t data_pin;
+    uint8_t clock_pin_base;
+    uint8_t dma_channel;
+    uint8_t pio_sm;
+} audio_i2s_config_t;
+
+/** \brief Set up system to output I2S audio
+ * \ingroup pico_audio_i2s
+ *
+ * \param intended_audio_format \todo
+ * \param config The configuration to apply.
+ */
+const audio_format_t *audio_i2s_setup(const audio_format_t *intended_audio_format,
+                                               const audio_i2s_config_t *config);
+
+
+/** \brief \todo
+ * \ingroup pico_audio_i2s
+ *
+ * \param producer
+ * \param connection
+ */
+bool audio_i2s_connect_thru(audio_buffer_pool_t *producer, audio_connection_t *connection);
+
+
+/** \brief \todo
+ * \ingroup pico_audio_i2s
+ *
+ * \param producer
+ *
+ *  todo make a common version (or a macro) .. we don't want to pull in unnecessary code by default
+ */
+bool audio_i2s_connect(audio_buffer_pool_t *producer);
+
+
+/** \brief \todo
+ * \ingroup pico_audio_i2s
+ *
+ * \param producer
+ */
+bool audio_i2s_connect_s8(audio_buffer_pool_t *producer);
+
+/** \brief \todo
+ * \ingroup pico_audio_i2s
+ *
+ * \param producer
+ * \param buffer_on_give
+ * \param buffer_count
+ * \param samples_per_buffer
+ * \param connection
+ * \return
+ */
+bool audio_i2s_connect_extra(audio_buffer_pool_t *producer, bool buffer_on_give, uint buffer_count,
+                                 uint samples_per_buffer, audio_connection_t *connection);
+
+
+/** \brief Set up system to output I2S audio
+ * \ingroup pico_audio_i2s
+ *
+ * \param enable true to enable I2S audio, false to disable.
+ */
+void audio_i2s_set_enabled(bool enabled);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif //_AUDIO_I2S_H

--- a/drivers/pico_audio_i2s_pe/pico_extras/include/pico/sample_conversion.h
+++ b/drivers/pico_audio_i2s_pe/pico_extras/include/pico/sample_conversion.h
@@ -1,0 +1,287 @@
+/*
+ * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef SOFTWARE_SAMPLE_CONVERSION_H
+#define SOFTWARE_SAMPLE_CONVERSION_H
+
+#include <algorithm>
+#include <cstring>
+#include "pico/audio.h"
+#include "pico/util/buffer.h"
+
+template<typename _sample_t>
+struct FmtDetails {
+public:
+    static const uint channel_count = 1;
+    static const uint frame_stride = channel_count * sizeof(_sample_t);
+    typedef _sample_t sample_t;
+};
+
+struct FmtU8 : public FmtDetails<uint8_t> {
+};
+
+struct FmtS8 : public FmtDetails<int8_t> {
+};
+
+struct FmtU16 : public FmtDetails<uint16_t> {
+};
+
+struct FmtS16 : public FmtDetails<int16_t> {
+};
+
+// Multi-channel is just N samples back to back
+template<typename Fmt, uint ChannelCount>
+struct MultiChannelFmt {
+    static const uint channel_count = ChannelCount;
+    static const uint frame_stride = ChannelCount * Fmt::frame_stride;
+    typedef typename Fmt::sample_t sample_t;
+};
+
+// define Mono<X> details as one channel
+template<typename Fmt> using Mono = MultiChannelFmt<Fmt, 1>;
+
+// define Stereo<X> details as two channels
+template<typename Fmt> using Stereo = MultiChannelFmt<Fmt, 2>;
+
+template<typename ToFmt, typename FromFmt>
+struct sample_converter {
+    static typename ToFmt::sample_t convert_sample(const typename FromFmt::sample_t &sample);
+};
+
+// noop conversion
+
+template<typename Fmt>
+struct sample_converter<Fmt, Fmt> {
+    static typename Fmt::sample_t convert_sample(const typename Fmt::sample_t &sample) {
+        return sample;
+    }
+};
+
+// converters to S16
+template<>
+struct sample_converter<FmtS16, FmtU16> {
+    static int16_t convert_sample(const uint16_t &sample) {
+        return sample ^ 0x8000u;
+    }
+};
+
+template<>
+struct sample_converter<FmtS16, FmtS8> {
+    static int16_t convert_sample(const int8_t &sample) {
+        return sample << 8u;
+    }
+};
+
+template<>
+struct sample_converter<FmtS16, FmtU8> {
+    static int16_t convert_sample(const uint8_t &sample) {
+        return (sample << 8u) ^ 0x8000u;
+    }
+};
+
+// converters to U16
+
+template<>
+struct sample_converter<FmtU16, FmtS8> {
+    static uint16_t convert_sample(const int8_t &sample) {
+        return (sample << 8u) ^ 0x8000u;
+    }
+};
+
+template<>
+struct sample_converter<FmtU16, FmtU8> {
+    static uint16_t convert_sample(const uint8_t &sample) {
+        return sample << 8u;
+    }
+};
+
+template<>
+struct sample_converter<FmtU16, FmtS16> {
+    static uint16_t convert_sample(const int16_t &sample) {
+        return sample ^ 0x8000u;
+    }
+};
+
+// converters to S8
+
+template<>
+struct sample_converter<FmtS8, FmtU16> {
+    static int8_t convert_sample(const uint16_t &sample) {
+        return (sample ^ 0x8000u) >> 8u;
+    }
+};
+
+template<>
+struct sample_converter<FmtS8, FmtU8> {
+    static int8_t convert_sample(const uint8_t &sample) {
+        return sample ^ 0x80;
+    }
+};
+
+template<>
+struct sample_converter<FmtS8, FmtS16> {
+    static int8_t convert_sample(const int16_t &sample) {
+        return sample >> 8u;
+    }
+};
+
+// converters to U8
+
+template<>
+struct sample_converter<FmtU8, FmtU16> {
+    static uint8_t convert_sample(const uint16_t &sample) {
+        return sample >> 8u;
+    }
+};
+
+template<>
+struct sample_converter<FmtU8, FmtS8> {
+    static uint8_t convert_sample(const int8_t &sample) {
+        return sample ^ 0x80;
+    }
+};
+
+template<>
+struct sample_converter<FmtU8, FmtS16> {
+    static uint8_t convert_sample(const int16_t &sample) {
+        return (sample ^ 0x8000u) >> 8u;
+    }
+};
+
+// template type for doing sample conversion
+template<typename ToFmt, typename FromFmt>
+struct converting_copy {
+    static void copy(typename ToFmt::sample_t *dest, const typename FromFmt::sample_t *src, uint sample_count);
+};
+
+// Efficient copies of same sample type
+
+template<class Fmt, uint ChannelCount>
+struct converting_copy<MultiChannelFmt<Fmt, ChannelCount>, MultiChannelFmt<Fmt, ChannelCount>> {
+    static void copy(typename MultiChannelFmt<Fmt, ChannelCount>::sample_t *dest,
+                     const typename MultiChannelFmt<Fmt, ChannelCount>::sample_t *src,
+                     uint sample_count) {
+        memcpy((void *) dest, (const void *) src, sample_count * MultiChannelFmt<Fmt, ChannelCount>::frame_stride);
+    }
+};
+
+// N channel to N channel
+template<typename ToFmt, typename FromFmt, uint NumChannels>
+struct converting_copy<MultiChannelFmt<ToFmt, NumChannels>, MultiChannelFmt<FromFmt, NumChannels>> {
+    static void copy(typename ToFmt::sample_t *dest, const typename FromFmt::sample_t *src, uint sample_count) {
+        for (uint i = 0; i < sample_count * NumChannels; i++) {
+            *dest++ = sample_converter<ToFmt, FromFmt>::convert_sample(*src++);
+        }
+    }
+};
+
+
+// mono->stereo conversion
+template<typename ToFmt, typename FromFmt>
+struct converting_copy<Stereo<ToFmt>, Mono<FromFmt>> {
+    static void copy(typename ToFmt::sample_t *dest, const typename FromFmt::sample_t *src, uint sample_count) {
+        for (; sample_count; sample_count--) {
+            typename ToFmt::sample_t mono_sample = sample_converter<ToFmt, FromFmt>::convert_sample(*src++);
+            *dest++ = mono_sample;
+            *dest++ = mono_sample;
+        }
+    }
+};
+
+// stereo->mono conversion
+template<typename ToFmt, typename FromFmt>
+struct converting_copy<Mono<ToFmt>, Stereo<FromFmt>> {
+    static void copy(typename ToFmt::sample_t *dest, const typename FromFmt::sample_t *src, uint sample_count) {
+        for (; sample_count; sample_count--) {
+            // average first in case precision is better in source
+            typename FromFmt::sample_t averaged_sample = (src[0] + src[1]) / 2;
+            src += 2;
+            *dest++ = sample_converter<ToFmt, FromFmt>::convert_sample(averaged_sample);
+        }
+    }
+};
+
+template<typename ToFmt, typename FromFmt>
+audio_buffer_t *consumer_pool_take(audio_connection_t *connection, bool block) {
+    struct buffer_copying_on_consumer_take_connection *cc = (struct buffer_copying_on_consumer_take_connection *) connection;
+    // for now we block until we have all the data in consumer buffers
+    audio_buffer_t *buffer = get_free_audio_buffer(cc->core.consumer_pool, block);
+    if (!buffer) return NULL;
+    assert(buffer->format->sample_stride == ToFmt::frame_stride);
+
+    uint32_t pos = 0;
+    while (pos < buffer->max_sample_count) {
+        if (!cc->current_producer_buffer) {
+            cc->current_producer_buffer = get_full_audio_buffer(cc->core.producer_pool, block);
+            if (!cc->current_producer_buffer) {
+                assert(!block);
+                if (!pos) {
+                    queue_free_audio_buffer(cc->core.consumer_pool, buffer);
+                    return NULL;
+                }
+                break;
+            }
+            assert(cc->current_producer_buffer->format->format->channel_count == FromFmt::channel_count);
+            assert(cc->current_producer_buffer->format->sample_stride == FromFmt::frame_stride);
+            cc->current_producer_buffer_pos = 0;
+        }
+        uint sample_count = std::min(buffer->max_sample_count - pos,
+                                     cc->current_producer_buffer->sample_count - cc->current_producer_buffer_pos);
+        converting_copy<ToFmt, FromFmt>::copy(
+                ((typename ToFmt::sample_t *) buffer->buffer->bytes) + pos * ToFmt::channel_count,
+                ((typename FromFmt::sample_t *) cc->current_producer_buffer->buffer->bytes) +
+                cc->current_producer_buffer_pos * FromFmt::channel_count,
+                sample_count);
+        pos += sample_count;
+        cc->current_producer_buffer_pos += sample_count;
+        if (cc->current_producer_buffer_pos == cc->current_producer_buffer->sample_count) {
+            queue_free_audio_buffer(cc->core.producer_pool, cc->current_producer_buffer);
+            cc->current_producer_buffer = NULL;
+        }
+    }
+    buffer->sample_count = pos;
+    return buffer;
+}
+
+template<typename ToFmt, typename FromFmt>
+void producer_pool_blocking_give(audio_connection_t *connection, audio_buffer_t *buffer) {
+    struct producer_pool_blocking_give_connection *pbc = (struct producer_pool_blocking_give_connection *) connection;
+    // for now we block until we have all the data in consumer buffers
+    uint32_t pos = 0;
+    while (pos < buffer->sample_count) {
+        if (!pbc->current_consumer_buffer) {
+            pbc->current_consumer_buffer = get_free_audio_buffer(pbc->core.consumer_pool, true);
+            pbc->current_consumer_buffer_pos = 0;
+        }
+        uint sample_count = std::min(buffer->sample_count - pos,
+                                     pbc->current_consumer_buffer->max_sample_count - pbc->current_consumer_buffer_pos);
+        assert(buffer->format->sample_stride == FromFmt::frame_stride);
+        assert(buffer->format->format->channel_count == FromFmt::channel_count);
+        converting_copy<ToFmt, FromFmt>::copy(
+                ((typename ToFmt::sample_t *) pbc->current_consumer_buffer->buffer->bytes) +
+                pbc->current_consumer_buffer_pos * ToFmt::channel_count,
+                ((typename FromFmt::sample_t *) buffer->buffer->bytes) + pos * FromFmt::channel_count, sample_count);
+        pos += sample_count;
+        pbc->current_consumer_buffer_pos += sample_count;
+        if (pbc->current_consumer_buffer_pos == pbc->current_consumer_buffer->max_sample_count) {
+            pbc->current_consumer_buffer->sample_count = pbc->current_consumer_buffer->max_sample_count;
+            queue_full_audio_buffer(pbc->core.consumer_pool, pbc->current_consumer_buffer);
+            pbc->current_consumer_buffer = NULL;
+        }
+    }
+    // todo this should be a connection configuration (or a seaparate connection type)
+#ifdef BLOCKING_GIVE_SYNCHRONIZE_BUFFERS
+    if (pbc->current_consumer_buffer) {
+        pbc->current_consumer_buffer->sample_count = pbc->current_consumer_buffer_pos;
+        queue_full_audio_buffer(pbc->core.consumer_pool, pbc->current_consumer_buffer);
+        pbc->current_consumer_buffer = NULL;
+    }
+#endif
+    assert(pos == buffer->sample_count);
+    queue_free_audio_buffer(pbc->core.producer_pool, buffer);
+}
+
+#endif //SOFTWARE_SAMPLE_CONVERSION_H

--- a/drivers/pico_audio_i2s_pe/pico_extras/include/pico/util/buffer.h
+++ b/drivers/pico_audio_i2s_pe/pico_extras/include/pico/util/buffer.h
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef _PICO_UTIL_BUFFER_H
+#define _PICO_UTIL_BUFFER_H
+
+#include "pico/types.h"
+
+/** \file buffer.h
+ * \defgroup util_buffer buffer
+ * \brief Buffer management
+ * \ingroup pico_util
+ */
+
+#ifdef PICO_BUFFER_USB_ALLOC_HACK
+#include "hardware/address_mapped.h"
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef DEBUG_MALLOC
+#include <stdio.h>
+#endif
+
+#include <stdlib.h>
+
+/** \struct mem_buffer
+ *  \ingroup util_buffer
+ *  \brief Wrapper structure around a memory buffer
+ * 
+ *   Wrapper could be around static or allocated memory
+ * 
+ * \todo This module needs to be checked - think there are issues with the free function
+ */
+typedef struct mem_buffer {
+    size_t size;
+    uint8_t *bytes;
+    uint8_t flags;
+} mem_buffer_t;
+
+#ifdef PICO_BUFFER_USB_ALLOC_HACK
+#if !defined(USB_DPRAM_MAX) || (USB_DPRAM_MAX > 0)
+#include "hardware/structs/usb.h"
+#else
+#define USB_DPRAM_SIZE 4096
+#endif
+#endif
+
+inline static bool pico_buffer_alloc_in_place(mem_buffer_t *buffer, size_t size) {
+#ifdef PICO_BUFFER_USB_ALLOC_HACK
+    extern uint8_t *usb_ram_alloc_ptr;
+    if ((usb_ram_alloc_ptr + size) <= (uint8_t *)USBCTRL_DPRAM_BASE + USB_DPRAM_SIZE) {
+        buffer->bytes = usb_ram_alloc_ptr;
+        buffer->size = size;
+#ifdef DEBUG_MALLOC
+        printf("balloc %d %p->%p\n", size, buffer->bytes, ((uint8_t *)buffer->bytes) + size);
+#endif
+        usb_ram_alloc_ptr += size;
+        return true;
+    }
+#endif    // inline for now
+    buffer->bytes = (uint8_t *) calloc(1, size);
+    if (buffer->bytes) {
+        buffer->size = size;
+        return true;
+    }
+    buffer->size = 0;
+    return false;
+}
+
+inline static mem_buffer_t *pico_buffer_wrap(uint8_t *bytes, size_t size) {
+    mem_buffer_t *buffer = (mem_buffer_t *) malloc(sizeof(mem_buffer_t));
+    if (buffer) {
+        buffer->bytes = bytes;
+        buffer->size = size;
+    }
+    return buffer;
+}
+
+inline static mem_buffer_t *pico_buffer_alloc(size_t size) {
+    mem_buffer_t *b = (mem_buffer_t *) malloc(sizeof(mem_buffer_t));
+    if (b) {
+        if (!pico_buffer_alloc_in_place(b, size)) {
+            free(b);
+            b = NULL;
+        }
+    }
+    return b;
+}
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/drivers/pico_hdmi/hstx.c
+++ b/drivers/pico_hdmi/hstx.c
@@ -263,7 +263,7 @@ void __not_in_flash_func(hstx_push_audio_sample)(const int left, const int right
         acc_count = 0;
     }
 }
-
+static uint32_t core1_stack[1024] __attribute__((aligned(8)));
 void hstx_init(bool dviOnly)
 {
     video_output_set_dvi_mode(dviOnly);
@@ -272,7 +272,7 @@ void hstx_init(bool dviOnly)
     video_output_init(640, 480);
     pico_hdmi_set_audio_sample_rate(44100);
     video_output_set_scanline_callback(scanline_callbackfunc);
-    multicore_launch_core1(video_output_core1_run);
+    multicore_launch_core1_with_stack(video_output_core1_run, core1_stack, sizeof(core1_stack));
     printf("Pico HDMI initialized.\n");
 }
 #endif

--- a/drivers/pico_hdmi/hstx.c
+++ b/drivers/pico_hdmi/hstx.c
@@ -264,15 +264,50 @@ void __not_in_flash_func(hstx_push_audio_sample)(const int left, const int right
     }
 }
 static uint32_t core1_stack[1024] __attribute__((aligned(8)));
+static bool s_hstx_dvi_mode = false;
+
+void *hstx_default_core1_stack(size_t *out_bytes)
+{
+    if (out_bytes) *out_bytes = sizeof(core1_stack);
+    return core1_stack;
+}
+
 void hstx_init(bool dviOnly)
 {
+    s_hstx_dvi_mode = dviOnly;
     video_output_set_dvi_mode(dviOnly);
     hstx_di_queue_init();
-    video_output_set_vsync_callback(hstx_vsync_callbackfunc);   
+    video_output_set_vsync_callback(hstx_vsync_callbackfunc);
     video_output_init(640, 480);
     pico_hdmi_set_audio_sample_rate(44100);
     video_output_set_scanline_callback(scanline_callbackfunc);
     multicore_launch_core1_with_stack(video_output_core1_run, core1_stack, sizeof(core1_stack));
     printf("Pico HDMI initialized.\n");
+}
+
+// Tear HSTX + core1 down and relaunch core1 with a different stack buffer.
+// Used by pico-pcePlus to grow core1's stack to ~8 KB only when a CHD CD
+// game is mounted — libchdr's chd_read uses ~6-10 KB and overflows the
+// default 4 KB into adjacent SRAM otherwise. The caller owns new_stack
+// (must be 8-byte aligned) and is responsible for freeing it once hstx is
+// restarted onto a different stack again. Passing the pointer returned by
+// hstx_default_core1_stack() restores the boot-time stack.
+void hstx_restart_core1(uint32_t *new_stack, size_t new_stack_bytes)
+{
+    video_output_stop();
+    multicore_reset_core1();
+
+    // Repeat the init steps that video_output_stop undid. The scanline /
+    // vsync callbacks set via the setters are not cleared by stop, but
+    // hstx_di_queue / video_output_init reprogram the parts that were
+    // physically torn down.
+    video_output_set_dvi_mode(s_hstx_dvi_mode);
+    hstx_di_queue_init();
+    video_output_set_vsync_callback(hstx_vsync_callbackfunc);
+    video_output_init(640, 480);
+    pico_hdmi_set_audio_sample_rate(44100);
+    video_output_set_scanline_callback(scanline_callbackfunc);
+
+    multicore_launch_core1_with_stack(video_output_core1_run, new_stack, new_stack_bytes);
 }
 #endif

--- a/drivers/pico_hdmi/hstx.h
+++ b/drivers/pico_hdmi/hstx.h
@@ -2,6 +2,7 @@
 #if PICO_RP2350
 #include <stdbool.h>
 #include <stdint.h>
+#include <stddef.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -26,6 +27,17 @@ uint16_t *hstx_getlineFromFramebuffer(int scanline);
 void hstx_init(bool dviOnly);
 void video_output_core1_run(void);
 void hstx_push_audio_sample(const int left, const int right);
+
+// Tear HSTX + core1 down and re-launch core1 with the supplied stack
+// buffer. Used by pico-pcePlus to grow core1's stack at runtime when a
+// CHD CD game is mounted (libchdr decompression needs ~8 KB). The caller
+// must keep `new_stack` allocated until the next restart.
+void hstx_restart_core1(uint32_t *new_stack, size_t new_stack_bytes);
+
+// Return the boot-time static core1 stack pointer + size (in bytes via
+// *out_bytes). Pass these back to hstx_restart_core1 to restore the
+// default stack after the CHD game exits.
+void *hstx_default_core1_stack(size_t *out_bytes);
 #ifdef __cplusplus
 }
 #endif

--- a/drivers/pico_hdmi/hstx_data_island_queue.c
+++ b/drivers/pico_hdmi/hstx_data_island_queue.c
@@ -7,8 +7,9 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include "pico.h"
-
+#ifndef DI_RING_BUFFER_SIZE
 #define DI_RING_BUFFER_SIZE 256
+#endif
 static hstx_data_island_t *di_ring_buffer = NULL; // [DI_RING_BUFFER_SIZE];
 static volatile uint32_t di_ring_head = 0;
 static volatile uint32_t di_ring_tail = 0;

--- a/drivers/pico_hdmi/video_output.c
+++ b/drivers/pico_hdmi/video_output.c
@@ -532,6 +532,45 @@ void video_output_init(uint16_t width, uint16_t height)
     memcpy(vblank_di_pong, vblank_di_ping, sizeof(vblank_di_ping));
 }
 
+// Tear-down counterpart to video_output_init / video_output_core1_run.
+// Disables and releases everything those two install so the same hardware
+// can be brought back up by a fresh init pair. Required when the caller
+// wants to reset core1 with a different stack at runtime — the SDK's
+// dma_channel_claim and irq_set_exclusive_handler both panic on the second
+// install if the previous claim / handler wasn't released.
+//
+// Call ordering: caller must already have stopped feeding the audio path
+// (background_task = NULL) and be on core0 — core1 will be reset by the
+// caller after this returns.
+void video_output_stop(void)
+{
+    // Quiet the IRQ first so the DMA abort that follows can't trigger a
+    // half-state in dma_irq_handler.
+    irq_set_enabled(DMA_IRQ_0, false);
+
+    // Disable the DMA channels' EN bit before aborting (matches the safe
+    // pattern used by hstx_resync above).
+    hw_clear_bits(&dma_hw->ch[DMACH_PING].al1_ctrl, DMA_CH0_CTRL_TRIG_EN_BITS);
+    hw_clear_bits(&dma_hw->ch[DMACH_PONG].al1_ctrl, DMA_CH0_CTRL_TRIG_EN_BITS);
+    dma_channel_abort(DMACH_PING);
+    dma_channel_abort(DMACH_PONG);
+    dma_hw->ints0 = (1U << DMACH_PING) | (1U << DMACH_PONG);
+    dma_hw->inte0 &= ~((1U << DMACH_PING) | (1U << DMACH_PONG));
+
+    // Park HSTX. video_output_core1_run will re-program CSR on the re-launch.
+    hstx_ctrl_hw->csr &= ~HSTX_CTRL_CSR_EN_BITS;
+
+    // Hand the channels and IRQ back to the SDK so the next init can
+    // re-claim them without panicking.
+    irq_remove_handler(DMA_IRQ_0, dma_irq_handler);
+    dma_channel_unclaim(DMACH_PING);
+    dma_channel_unclaim(DMACH_PONG);
+
+    // Reset latched state in our own driver layer that the next init may
+    // consult on the way back up.
+    resync_requested = false;
+}
+
 void video_output_set_background_task(video_output_task_fn task)
 {
     background_task = task;

--- a/drivers/pico_hdmi/video_output.h
+++ b/drivers/pico_hdmi/video_output.h
@@ -91,6 +91,14 @@ typedef void (*video_output_scanline_cb_t)(uint32_t v_scanline, uint32_t active_
 void video_output_init(uint16_t width, uint16_t height);
 
 /**
+ * Tear down the HSTX video output. Disables and unclaims the DMA channels
+ * + IRQ that video_output_init / video_output_core1_run installed so a
+ * subsequent re-init can reclaim them. Must be called from core0 only,
+ * after core1's loop has been stopped or is about to be reset.
+ */
+void video_output_stop(void);
+
+/**
  * Register the scanline callback.
  */
 void video_output_set_scanline_callback(video_output_scanline_cb_t cb);

--- a/drivers/tlv320dac3100/CMakeLists.txt
+++ b/drivers/tlv320dac3100/CMakeLists.txt
@@ -1,0 +1,14 @@
+if (NOT TARGET tlv320dac3100)
+    add_library(tlv320dac3100 INTERFACE)
+    target_sources(tlv320dac3100 INTERFACE
+        ${CMAKE_CURRENT_LIST_DIR}/tlv320dac3100.c
+    )
+    target_include_directories(tlv320dac3100 INTERFACE
+        ${CMAKE_CURRENT_LIST_DIR}
+    )
+    target_link_libraries(tlv320dac3100 INTERFACE
+        pico_stdlib
+        hardware_i2c
+        hardware_gpio
+    )
+endif()

--- a/drivers/tlv320dac3100/tlv320dac3100.c
+++ b/drivers/tlv320dac3100/tlv320dac3100.c
@@ -1,0 +1,359 @@
+/*
+ *  tlv320dac3100.c
+ *
+ *  TLV320DAC3100 codec control over I2C. Extracted verbatim (with light
+ *  renaming for module boundary) from the legacy custom pico_audio_i2s driver
+ *  so the same code is reused by the pico-extras based driver.
+ *
+ *  Register-script reference:
+ *    https://github.com/jepler/fruitjam-doom/blob/adafruit-fruitjam/src/i_main.c
+ *  TLV320DAC3100 datasheet:
+ *    https://www.ti.com/lit/ds/symlink/tlv320dac3100.pdf
+ */
+
+#include "tlv320dac3100.h"
+
+#include "pico/stdlib.h"
+#include "hardware/i2c.h"
+#include "hardware/gpio.h"
+
+#include <stdio.h>
+
+/* The I2C bus and SDA/SCL pins are shared with the Wii controller pads.
+ * WIIPAD_I2C / WII_PIN_SDA / WII_PIN_SCL are project-wide macros supplied via
+ * compile definitions (see BoardConfigs.cmake / wiipad.h). */
+#define I2C_PORT       WIIPAD_I2C
+#define PIN_SDA        WII_PIN_SDA
+#define PIN_SCL        WII_PIN_SCL
+#define DAC_I2C_ADDR   0x18
+
+static volatile bool s_dac_error = false;
+static volatile bool s_active = false;
+static volatile bool s_speaker_muted = false;
+static volatile bool s_hp_irq_pending = false;
+static volatile uint32_t s_last_irq_time = 0;
+
+/* ----- low-level register access -------------------------------------- */
+
+static void write_register(uint8_t reg, uint8_t value)
+{
+    uint8_t buf[2] = { reg, value };
+    int res = i2c_write_timeout_us(I2C_PORT, DAC_I2C_ADDR, buf, sizeof(buf),
+                                   /* nostop */ false, 1000);
+    if (res != 2) {
+        printf("!!!WARNING!!!: tlv320 i2c_write_timeout failed: res=%d\n", res);
+        s_dac_error = true;
+    }
+#if PICO_AUDIO_I2S_DEBUG
+    printf("Write Reg: %d = 0x%x\n", reg, value);
+#endif
+}
+
+static uint8_t read_register(uint8_t reg)
+{
+    uint8_t buf[1] = { reg };
+    int res = i2c_write_timeout_us(I2C_PORT, DAC_I2C_ADDR, buf, sizeof(buf),
+                                   /* nostop */ true, 1000);
+    if (res != 1) {
+        printf("!!!WARNING!!!: tlv320 i2c_write_timeout failed: res=%d\n", res);
+        s_dac_error = true;
+    }
+    res = i2c_read_timeout_us(I2C_PORT, DAC_I2C_ADDR, buf, sizeof(buf),
+                              /* nostop */ false, 1000);
+    if (res != 1) {
+        printf("!!!WARNING!!!: tlv320 i2c_read_timeout failed: res=%d\n", res);
+        s_dac_error = true;
+    }
+#if PICO_AUDIO_I2S_DEBUG
+    printf("Read Reg: %d = 0x%x\n", reg, buf[0]);
+#endif
+    return buf[0];
+}
+
+static void modify_register(uint8_t reg, uint8_t mask, uint8_t value)
+{
+    uint8_t current = read_register(reg);
+    uint8_t new_value = (current & ~mask) | (value & mask);
+    write_register(reg, new_value);
+}
+
+static void set_page(uint8_t page)
+{
+    write_register(0x00, page);
+}
+
+/* ----- hardware reset ------------------------------------------------- */
+
+static void tlv320_hardware_reset(void)
+{
+    assert(PICO_AUDIO_I2S_RESET_PIN >= 0 && PICO_AUDIO_I2S_RESET_PIN < NUM_BANK0_GPIOS);
+    printf("Performing TLV320 hardware reset...\n");
+    gpio_put(PICO_AUDIO_I2S_RESET_PIN, 0);
+    gpio_set_dir(PICO_AUDIO_I2S_RESET_PIN, GPIO_OUT);
+    gpio_set_function(PICO_AUDIO_I2S_RESET_PIN, GPIO_FUNC_SIO);
+    sleep_us(20);
+    gpio_put(PICO_AUDIO_I2S_RESET_PIN, 1);
+    gpio_set_dir(PICO_AUDIO_I2S_RESET_PIN, GPIO_OUT);
+    gpio_set_function(PICO_AUDIO_I2S_RESET_PIN, GPIO_FUNC_SIO);
+    sleep_ms(10);
+    printf("TLV320 hardware reset complete\n");
+}
+
+/* ----- speaker mute helpers ------------------------------------------- */
+
+#define MASK_SPK_UNMUTE     (1 << 2)
+
+/* HP analog volume (Page 1 / Reg 0x24-0x25): each LSB = -0.5 dB. The speaker
+ * is louder than the HP at the same dB; HP gets ~20 dB extra attenuation. */
+#define HP_ANALOG_VOL_SPEAKER 0x0A  /* -5 dB */
+#define HP_ANALOG_VOL_HP      0x34  /* -25 dB */
+
+static void speaker_mute_internal(void)
+{
+    set_page(0x01);
+    modify_register(0x2A, MASK_SPK_UNMUTE, 0x00);
+}
+
+static void speaker_unmute_internal(void)
+{
+    set_page(0x01);
+    modify_register(0x2A, MASK_SPK_UNMUTE, MASK_SPK_UNMUTE);
+}
+
+/* ----- headphone detection IRQ callbacks ------------------------------ */
+
+static void gpio_callback(uint gpio, uint32_t events)
+{
+    (void)gpio;
+    uint32_t now = to_ms_since_boot(get_absolute_time());
+    if (now - s_last_irq_time < 50) return;
+    s_last_irq_time = now;
+    if (events & GPIO_IRQ_EDGE_RISE) {
+        s_speaker_muted = !s_speaker_muted;
+        if (s_speaker_muted) speaker_mute_internal();
+        else                 speaker_unmute_internal();
+    }
+}
+
+static void hp_int1_callback(uint gpio, uint32_t events)
+{
+    (void)gpio;
+    uint32_t now = to_ms_since_boot(get_absolute_time());
+    if (now - s_last_irq_time < 200) return;
+    s_last_irq_time = now;
+    if (events & GPIO_IRQ_EDGE_RISE) {
+        s_hp_irq_pending = true;
+    }
+}
+
+static enum headphone_toggle_t handle_headphone_event(void)
+{
+    set_page(0);
+    uint8_t sticky = read_register(0x2C);     /* clear sticky flag */
+    uint8_t flags  = read_register(0x2E);
+    bool hp_inserted = (flags & 0x10) != 0;
+
+    uint8_t hsdet  = read_register(0x43);
+    uint8_t hstype = (hsdet >> 5) & 0x03;
+
+    printf("Headphone event: %s (type=%d, sticky=0x%02X, flags=0x%02X)\n",
+           hp_inserted ? "inserted" : "removed", hstype, sticky, flags);
+
+    if (hp_inserted) {
+        speaker_mute_internal();
+        write_register(0x24, HP_ANALOG_VOL_HP);
+        write_register(0x25, HP_ANALOG_VOL_HP);
+    } else {
+        speaker_unmute_internal();
+        write_register(0x24, HP_ANALOG_VOL_SPEAKER);
+        write_register(0x25, HP_ANALOG_VOL_SPEAKER);
+    }
+    set_page(0);
+    s_speaker_muted = hp_inserted;
+    return hp_inserted ? HP_TOGGLE_CONNECT : HP_TOGGLE_DISCONNECT;
+}
+
+static void setup_headphone_detection_interrupt(int gpio, bool gpio_is_button)
+{
+    s_speaker_muted = false;
+    printf("Setting up headphone detection on GPIO %d, is_button=%d\n", gpio, gpio_is_button);
+    if (gpio_is_button) {
+        gpio_init(gpio);
+        gpio_set_dir(gpio, GPIO_IN);
+        gpio_pull_down(gpio);
+        gpio_set_irq_enabled_with_callback(gpio, GPIO_IRQ_EDGE_RISE | GPIO_IRQ_EDGE_FALL,
+                                           true, &gpio_callback);
+    } else {
+        gpio_init(gpio);
+        gpio_set_dir(gpio, GPIO_IN);
+        gpio_pull_down(gpio);
+        gpio_set_irq_enabled_with_callback(gpio, GPIO_IRQ_EDGE_RISE,
+                                           true, &hp_int1_callback);
+        /* Check initial state (outside ISR context) */
+        handle_headphone_event();
+    }
+}
+
+/* ----- codec register program ----------------------------------------- */
+
+/* Programs the TLV320DAC3100 for I2S, 16-bit, fS = 44.1 kHz from BCLK via PLL.
+ * Adapted from the fruitjam-doom register script. */
+static void tlv320_program_registers(void)
+{
+    printf("Initializing TLV320AIC3204 audio DAC...\n");
+    i2c_init(I2C_PORT, 400 * 1000);
+    sleep_ms(10);
+    gpio_set_function(PIN_SDA, GPIO_FUNC_I2C);
+    gpio_set_function(PIN_SCL, GPIO_FUNC_I2C);
+    gpio_pull_up(PIN_SDA);
+    gpio_pull_up(PIN_SCL);
+
+    /* Software reset */
+    write_register(0x01, 0x01);
+    sleep_ms(10);
+
+    /* Interface Control 1: I²S, 16-bit, no offset */
+    write_register(0x1B, 0x00);
+    write_register(0x1C, 0x00);
+
+    /* Clock MUX / PLL */
+    modify_register(0x04, 0x03, 0x03);
+    modify_register(0x04, 0x0C, 0x04);
+    write_register(0x06, 0x20);
+    write_register(0x08, 0x00);
+    write_register(0x07, 0x00);
+    modify_register(0x05, 0x0F, 0x02);
+    modify_register(0x05, 0x70, 0x10);
+
+    /* DAC/ADC dividers */
+    modify_register(0x0B, 0x7F, 0x08); modify_register(0x0B, 0x80, 0x80); /* NDAC */
+    modify_register(0x0C, 0x7F, 0x02); modify_register(0x0C, 0x80, 0x80); /* MDAC */
+    modify_register(0x12, 0x7F, 0x08); modify_register(0x12, 0x80, 0x80); /* NADC */
+    modify_register(0x13, 0x7F, 0x02); modify_register(0x13, 0x80, 0x80); /* MADC */
+
+    /* PLL Power Up */
+    modify_register(0x05, 0x80, 0x80);
+
+    /* Headset / GPIO config (page 1) */
+    set_page(1);
+    modify_register(0x2e, 0xFF, 0x0b);
+    set_page(0);
+
+    /* Timer clock = internal oscillator (page 3 / reg 0x10 D7=0). MCLK isn't
+     * connected on these boards (PLL_CLKIN = BCLK), so the debounce clock
+     * needs a source for headset detection to work. */
+    set_page(3);
+    modify_register(0x10, 0x80, 0x00);
+    set_page(0);
+
+    /* Headset detect enable, 64ms debounce */
+    modify_register(0x43, 0x9C, 0x88);
+    modify_register(0x30, 0x81, 0x81); /* INT1 = headset detect, multi-pulse */
+    modify_register(0x33, 0x3C, 0x14); /* GPIO1 = INT1 output */
+
+    modify_register(0x3F, 0xC0, 0xC0); /* DAC setup */
+
+    /* DAC routing (page 1) */
+    set_page(1);
+    modify_register(0x23, 0xC0, 0x40);
+    modify_register(0x23, 0x0C, 0x04);
+
+    /* DAC digital volume (page 0) */
+    set_page(0);
+    modify_register(0x40, 0x0C, 0x00);
+    write_register(0x41, 0x0A); /* +5 dB L */
+    write_register(0x42, 0x0A); /* +5 dB R */
+
+    /* ADC setup */
+    modify_register(0x51, 0x80, 0x80);
+    modify_register(0x52, 0x80, 0x00);
+    write_register(0x53, 0x68);
+
+    /* HP & Speaker (page 1) */
+    set_page(1);
+    modify_register(0x1F, 0xC0, 0xC0);
+    modify_register(0x28, 0x04, 0x04);
+    modify_register(0x29, 0x04, 0x04);
+    write_register(0x24, 0x0A);
+    write_register(0x25, 0x0A);
+    modify_register(0x28, 0x78, 0x40);
+    modify_register(0x29, 0x78, 0x40);
+
+    modify_register(0x20, 0x80, 0x80);
+    modify_register(0x2A, 0x04, 0x04);
+    modify_register(0x2A, 0x18, 0x08);
+    write_register(0x26, 0x0A);
+
+    set_page(0);
+
+#if PICO_AUDIO_I2S_INTERRUPT_PIN != -1
+    if (!s_dac_error) {
+        printf("setup headphone detection interrupt.\n");
+        setup_headphone_detection_interrupt(PICO_AUDIO_I2S_INTERRUPT_PIN,
+                                            PICO_AUDIO_I2S_INTERRUPT_IS_BUTTON);
+    }
+#endif
+    printf("TLV320AIC3204 Initialization complete!\n");
+    sleep_ms(100);
+}
+
+/* ----- public API ----------------------------------------------------- */
+
+bool tlv320_init(void)
+{
+    s_active = false;
+    int retries = 0;
+    printf("Init TLV320 DAC, max 5 retries...\n");
+    do {
+        s_dac_error = false;
+        tlv320_hardware_reset();
+        tlv320_program_registers();
+        if (!s_dac_error) {
+            s_active = true;
+            return true;
+        }
+        printf("TLV320 init failed, retrying (%d/5)...\n", retries + 1);
+        sleep_ms(500);
+    } while (s_dac_error && ++retries < 5);
+    printf("TLV320 initialization failed after 5 attempts.\n");
+    return false;
+}
+
+void tlv320_set_volume(int8_t level)
+{
+    if (!s_active) return;
+    if (level < -63 || level > 23) {
+        printf("Volume level %d out of range (-63 to 23)\n", level);
+        return;
+    }
+    printf("Setting TLV320 volume to level %d\n", level);
+    set_page(0);
+    modify_register(0x40, 0x0C, 0x00);
+    write_register(0x41, level << 1);
+    write_register(0x42, level << 1);
+}
+
+void tlv320_mute_speaker(bool mute)
+{
+    if (!s_active) return;
+    s_speaker_muted = mute;
+    if (mute) speaker_mute_internal();
+    else      speaker_unmute_internal();
+}
+
+enum headphone_toggle_t tlv320_poll_headphone(void)
+{
+    if (!s_active || !s_hp_irq_pending) return HP_TOGGLE_NONE;
+    s_hp_irq_pending = false;
+    return handle_headphone_event();
+}
+
+bool tlv320_dac_error(void)
+{
+    return s_dac_error;
+}
+
+bool tlv320_is_active(void)
+{
+    return s_active;
+}

--- a/drivers/tlv320dac3100/tlv320dac3100.h
+++ b/drivers/tlv320dac3100/tlv320dac3100.h
@@ -1,0 +1,76 @@
+/*
+ *  tlv320dac3100.h
+ *
+ *  TLV320DAC3100 I2C codec control, factored out of the I2S driver so it can
+ *  be shared between the legacy custom driver and the pico-extras based one.
+ *
+ *  Configuration is supplied as compile definitions (see board configs):
+ *    PICO_AUDIO_I2S_RESET_PIN            GPIO connected to the codec /RST pin
+ *    PICO_AUDIO_I2S_INTERRUPT_PIN        GPIO connected to headphone-detect
+ *                                        signal (DAC INT1 or button); -1 = none
+ *    PICO_AUDIO_I2S_INTERRUPT_IS_BUTTON  1 = the GPIO is a push-button that
+ *                                        toggles speaker mute; 0 = the GPIO is
+ *                                        driven by the DAC's INT1 output.
+ *
+ *  The I2C bus shared with the Wii controller pads (WIIPAD_I2C / WII_PIN_SDA /
+ *  WII_PIN_SCL) is used to talk to the codec at 0x18.
+ */
+
+#ifndef _TLV320DAC3100_H_
+#define _TLV320DAC3100_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef PICO_AUDIO_I2S_RESET_PIN
+#define PICO_AUDIO_I2S_RESET_PIN 7
+#endif
+
+#ifndef PICO_AUDIO_I2S_INTERRUPT_PIN
+#define PICO_AUDIO_I2S_INTERRUPT_PIN -1
+#endif
+
+#ifndef PICO_AUDIO_I2S_INTERRUPT_IS_BUTTON
+#define PICO_AUDIO_I2S_INTERRUPT_IS_BUTTON 0
+#endif
+
+#ifndef PICO_AUDIO_I2S_DEBUG
+#define PICO_AUDIO_I2S_DEBUG 0
+#endif
+
+enum headphone_toggle_t {
+    HP_TOGGLE_NONE = 0,
+    HP_TOGGLE_CONNECT = 1,
+    HP_TOGGLE_DISCONNECT = 2
+};
+
+/// Hardware reset, I2C bus setup, codec register programming, and (if
+/// PICO_AUDIO_I2S_INTERRUPT_PIN >= 0) headphone-detect interrupt installation.
+/// Retries up to 5 times on I2C failure. Returns true on success.
+bool tlv320_init(void);
+
+/// Set DAC digital volume. level is in -63..+23 (units of 0.5 dB? — see driver).
+void tlv320_set_volume(int8_t level);
+
+/// Mute or unmute the speaker amplifier path. No-op if codec inactive.
+void tlv320_mute_speaker(bool mute);
+
+/// Returns a pending headphone-insertion / -removal event if one was latched
+/// in the GPIO IRQ, otherwise HP_TOGGLE_NONE. Safe to call every frame.
+enum headphone_toggle_t tlv320_poll_headphone(void);
+
+/// True if the last I2C transaction (anywhere in this module) failed.
+bool tlv320_dac_error(void);
+
+/// True after tlv320_init() returned true.
+bool tlv320_is_active(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // _TLV320DAC3100_H_

--- a/external_audio.h
+++ b/external_audio.h
@@ -10,6 +10,12 @@
 #define USE_SPI_AUDIO 0
 #endif
 
+// Driver selection between the legacy custom I2S driver and the pico-extras
+// based one. Set via -DUSE_PICO_EXTRAS_I2S=ON when configuring; default off.
+#ifndef USE_PICO_EXTRAS_I2S
+#define USE_PICO_EXTRAS_I2S 0
+#endif
+
 // generete a compiler error if both USE_I2S_AUDIO and USE_SPI_AUDIO are defined
 #if USE_I2S_AUDIO > 0 && USE_SPI_AUDIO == 1
 #error "Both USE_I2S_AUDIO and USE_SPI_AUDIO cannot be defined at the same time. Please define only one."

--- a/gamepad.cpp
+++ b/gamepad.cpp
@@ -12,11 +12,17 @@ namespace io
     namespace
     {
         GamePadState currentGamePad_[2];
+        KeyboardState currentKeyboard_ = {};
     }
 
     GamePadState &getCurrentGamePadState(int i)
     {
         return currentGamePad_[i];
+    }
+
+    const KeyboardState &getCurrentKeyboardState()
+    {
+        return currentKeyboard_;
     }
 
     void

--- a/gamepad.h
+++ b/gamepad.h
@@ -58,6 +58,18 @@ namespace io
     };
 
     GamePadState &getCurrentGamePadState(int i);
+
+    // Raw HID keyboard state. Populated by hid_app.cpp from the most recent
+    // boot-protocol keyboard report. modifier matches HID_KEYBOARD_MODIFIER_*
+    // and keycode[] holds the up to 6 currently-pressed HID usage codes
+    // (HID_KEY_*). Emulators that emulate a real keyboard (e.g. O2 / G7400)
+    // should read this in addition to the GamePadState mapping.
+    struct KeyboardState
+    {
+        uint8_t modifier;
+        uint8_t keycode[6];
+    };
+    const KeyboardState &getCurrentKeyboardState();
 }
 
 #endif /* _510036F3_0134_6411_4376_A918ACA8AC4C */

--- a/hid_app.cpp
+++ b/hid_app.cpp
@@ -818,6 +818,12 @@ extern "C"
                 case HID_USAGE_DESKTOP_KEYBOARD:
                 {
                     auto r = reinterpret_cast<const hid_keyboard_report_t *>(report);
+                    // Expose the raw HID report for emulators that emulate a
+                    // real keyboard (e.g. O2 / G7400). The gamepad mapping
+                    // below stays in place for joystick-style use.
+                    auto &kb = const_cast<io::KeyboardState &>(io::getCurrentKeyboardState());
+                    kb.modifier = r->modifier;
+                    memcpy(kb.keycode, r->keycode, sizeof(kb.keycode));
                     auto &gp = io::getCurrentGamePadState(player);
                     gp.GamePadName = "Keyboard";
                     gp.GamePadShortName = "KB";

--- a/menu.cpp
+++ b/menu.cpp
@@ -202,6 +202,9 @@ static bool isArtWorkEnabled()
     case FrensSettings::emulators::GAMEBOY:
         snprintf(PATH, sizeof(PATH), "/Metadata/%s/Images/160/0/00A9001E.444", emulator);
         break;
+    case FrensSettings::emulators::PCE:
+        snprintf(PATH, sizeof(PATH), "/Metadata/%s/Images/160/5/599EAD9B.444", emulator);
+        break;
     default:
         return false;
     }

--- a/menu.cpp
+++ b/menu.cpp
@@ -647,7 +647,11 @@ void DrawScreen(int selectedRow, int w = 0, int h = 0, uint16_t *imagebuffer = n
             }
         }
         putText(SCREEN_COLS / 2 - strlen(tmpstr) / 2, SCREEN_ROWS - 1, tmpstr, CBLUE, CWHITE);
-        snprintf(s, sizeof(s), "%c%dK %c", Frens::isPsramEnabled() ? 'P' : 'F', maxRomSize / 1024, WIIPAD_IS_CONNECTED() ? 'W' : ' ');
+        snprintf(s, sizeof(s), "%c%dK %c%c",
+                 Frens::isPsramEnabled() ? 'P' : 'F',
+                 maxRomSize / 1024,
+                 WIIPAD_IS_CONNECTED() ? 'W' : ' ',
+                 EXT_AUDIO_IS_ENABLED ? (USE_PICO_EXTRAS_I2S ? 'E' : 'L') : ' ');
         putText(1, SCREEN_ROWS - 1, s, settings.fgcolor, settings.bgcolor);
         snprintf(s, sizeof(s), "%s:Open %s:Back", buttonLabel1, buttonLabel2);
 

--- a/menu.cpp
+++ b/menu.cpp
@@ -222,7 +222,7 @@ static bool isArtWorkEnabled()
 int Menu_LoadFrame()
 {
     //Frens::waitForVSync();
-    Frens::PaceFrames60fps(false);
+    Frens::PaceFrames60fps(false, true);
 #if NES_PIN_CLK != -1
     nespad_read_start();
 #endif
@@ -2193,7 +2193,7 @@ bool showSaveStateMenu(int (*savestatefunc)(const char *path), int (*loadstatefu
         dvi_->getBlankSettings().bottom = marginbottom;
     }
 #endif
-    Frens::PaceFrames60fps(true);
+    Frens::PaceFrames60fps(true, true);
     //Frens::waitForVSync();
     printf("Exiting save state menu.\n");
     Frens::f_free(screenBuffer);
@@ -3205,7 +3205,7 @@ int showSettingsMenu(bool calledFromGame)
         // Speaker can be muted/unmuted from settings menu
         //EXT_AUDIO_MUTE_INTERNAL_SPEAKER(settings.flags.fruitJamEnableInternalSpeaker == 0);
         EXT_AUDIO_SETVOLUME(settings.fruitjamVolumeLevel);
-        Frens::PaceFrames60fps(true);
+        Frens::PaceFrames60fps(true, true);
         //Frens::waitForVSync();
     }
 #if USE_I2S_AUDIO == PICO_AUDIO_I2S_DRIVER_TLV320
@@ -3250,7 +3250,7 @@ void menu(const char *title, char *errorMessage, bool isFatal, bool showSplash, 
 #endif
     scaleMode8_7_ = Frens::applyScreenMode(ScreenMode::NOSCANLINE_1_1);
     abSwapped = 1; // Swap A and B buttons, so menu is consistent across different emulators
-    Frens::PaceFrames60fps(true);
+    Frens::PaceFrames60fps(true, true);
     //Frens::waitForVSync();
     //
     menutitle = (char *)title;
@@ -3822,6 +3822,6 @@ void menu(const char *title, char *errorMessage, bool isFatal, bool showSplash, 
         // Never return
     }
     Frens::restoreScanlines();
-    Frens::PaceFrames60fps(true); // reset frame pacing
+    Frens::PaceFrames60fps(true, true); // reset frame pacing
     //Frens::waitForVSync();
 }

--- a/menu.cpp
+++ b/menu.cpp
@@ -3786,9 +3786,10 @@ void menu(const char *title, char *errorMessage, bool isFatal, bool showSplash, 
     // Frens::f_free(buffer);
 
     FrensSettings::savesettings();
-#if !HSTX
+     // Reset the screen mode to the original settings
     scaleMode8_7_ = Frens::applyScreenMode(settings.screenMode);
-    // Reset the screen mode to the original settings
+#if !HSTX
+   
     // Do not reset the margins when framebuffer is used, this will lock up the display driver
     // Margins will be handled by the framebuffer.
     if (!Frens::isFrameBufferUsed())

--- a/menu.cpp
+++ b/menu.cpp
@@ -3320,6 +3320,43 @@ void menu(const char *title, char *errorMessage, bool isFatal, bool showSplash, 
             isWav = false;
         }
 #endif
+// SGX auto-clock-switch is only safe on builds using PIO-USB. On
+// TinyUSB-native-USB builds PLL_USB must stay at 48 MHz, so we can't decouple
+// clk_hstx from clk_sys at 378 MHz — running there would produce visible TMDS
+// artifacts. Skip the auto-switch in that case; the .sgx ROM still loads and
+// runs at the build's default 252 MHz (slower on the heavier titles but clean).
+#if (HSTX && SGX && CFG_TUH_RPI_PIO_USB)
+        if (selectedRomOrFolder && entries[index].IsDirectory == false && oldIndex != index)
+        {        
+            oldIndex = index;
+            if ( strncasecmp(fileExt, ".sgx", 4) == 0)
+            {
+                if (clockFreq != FLASHPARAM_MAX_FREQ_KHZ)
+                {
+                    char message[40];
+                    snprintf(message, sizeof(message), "Setting clock to  %dMHZ for SGX", FLASHPARAM_MAX_FREQ_KHZ /1000);
+                    showLoadingScreen(message, 60);
+                    FrensSettings::savesettings(); // save current settings before changing clock
+                    if (Frens::writeFlashParamsToFlash(FLASHPARAM_MAX_FREQ_KHZ, FLASHPARAM_MAX_VOLTAGE) == false)
+                    {
+                        printf("Failed to write flash params for high clock\n");
+                    }
+                }
+            } else {
+                if (clockFreq != FLASHPARAM_MIN_FREQ_KHZ)
+                {
+                    char message[40];
+                    snprintf(message, sizeof(message), "Setting clock to  %dMHZ", FLASHPARAM_MIN_FREQ_KHZ /1000);
+                    showLoadingScreen(message, 60);
+                    FrensSettings::savesettings(); // save current settings before changing clock
+                    if (Frens::writeFlashParamsToFlash(FLASHPARAM_MIN_FREQ_KHZ, FLASHPARAM_MIN_VOLTAGE) == false)
+                    {
+                        printf("Failed to write flash params for low clock\n");
+                    }
+                }
+            }
+        }
+#endif
 #if RETROJAM
         // retroJam: adjust clock speed and crc offset based on selected ROM type
         if (selectedRomOrFolder && entries[index].IsDirectory == false && oldIndex != index)

--- a/menu.cpp
+++ b/menu.cpp
@@ -191,7 +191,7 @@ static bool isArtWorkEnabled()
     {
     case FrensSettings::emulators::NES:
 
-        snprintf(PATH, sizeof(PATH), "/Metadata/%s/Images/320/D/D0E96F6B.444", emulator);
+        snprintf(PATH, sizeof(PATH), "/Metadata/%s/Images/160/D/D0E96F6B.444", emulator);
         break;
     case FrensSettings::emulators::SMS:
         snprintf(PATH, sizeof(PATH), "/Metadata/%s/Images/160/6/6A5A1E39.444", emulator);

--- a/settings.cpp
+++ b/settings.cpp
@@ -7,7 +7,7 @@ struct settings settings;
 namespace FrensSettings
 {
     #define SETTINGSFILE "/settings_%s.dat" // File to store settings
-    static const char *emulatorstrings[5] = { "NES", "SMS", "GB", "MD", "MUL" };
+    static const char *emulatorstrings[6] = { "NES", "SMS", "GB", "MD", "MUL", "PCE" };
     static char settingsFileName[21] = {};
     static emulators emulatorTypeForSettings = emulators::MULTI;
     char *getSettingsFileName()
@@ -46,6 +46,12 @@ namespace FrensSettings
             if ( emulatorType == emulators::GAMEBOY ) return;
             emulatorType = emulators::GAMEBOY;
             g_settings_visibility = g_settings_visibility_gb;
+        }
+        else if (strcasecmp(fileextension, ".pce") == 0)
+        {
+            if ( emulatorType == emulators::PCE ) return;
+            emulatorType = emulators::PCE;
+            g_settings_visibility = g_settings_visibility_pce;
         }
         else if (strcasecmp(fileextension, ".gen") == 0 || strcasecmp(fileextension, ".md") == 0|| strcasecmp(fileextension, ".bin") == 0)
         {

--- a/settings.cpp
+++ b/settings.cpp
@@ -7,7 +7,7 @@ struct settings settings;
 namespace FrensSettings
 {
     #define SETTINGSFILE "/settings_%s.dat" // File to store settings
-    static const char *emulatorstrings[6] = { "NES", "SMS", "GB", "MD", "MUL", "PCE" };
+    static const char *emulatorstrings[7] = { "NES", "SMS", "GB", "MD", "MUL", "PCE", "O2E" };
     static char settingsFileName[21] = {};
     static emulators emulatorTypeForSettings = emulators::MULTI;
     char *getSettingsFileName()
@@ -133,14 +133,19 @@ namespace FrensSettings
     void savesettings()
     {
         // Save settings to file
-        FIL fil;
+        // FIL is ~600 bytes - allocate on heap to avoid stack overflow
+        FIL *fil = (FIL *)Frens::f_malloc(sizeof(FIL));
+        if (!fil) {
+            printf("savesettings: failed to allocate FIL\n");
+            return;
+        }
         UINT bw;
         FRESULT fr;
         printf("Saving settings to %s\n", getSettingsFileName());
-        fr = f_open(&fil, getSettingsFileName(), FA_WRITE | FA_CREATE_ALWAYS);
+        fr = f_open(fil, getSettingsFileName(), FA_WRITE | FA_CREATE_ALWAYS);
         if (fr == FR_OK)
         {
-            fr = f_write(&fil, &settings, sizeof(settings), &bw);
+            fr = f_write(fil, &settings, sizeof(settings), &bw);
             if (fr)
             {
                 printf("Error writing %s: %d\n", getSettingsFileName(), fr);
@@ -149,12 +154,13 @@ namespace FrensSettings
             {
                 printf("Wrote %d bytes to %s\n", bw, getSettingsFileName());
             }
-            f_close(&fil);
+            f_close(fil);
         }
         else
         {
             printf("Error opening %s: %d\n", getSettingsFileName(), fr);
         }
+        Frens::f_free(fil);
         printsettings();
 #if HSTX
         printf("Setting HDMI DVI mode to %d\n", settings.flags.useDVIModeForHDMI);
@@ -165,19 +171,28 @@ namespace FrensSettings
 
     void loadsettings()
     {
-        FIL fil;
+        // FIL ~600 bytes, DIR ~80 bytes, FILINFO ~280 bytes - put on heap
+        FIL *fil = (FIL *)Frens::f_malloc(sizeof(FIL));
+        DIR *dir = (DIR *)Frens::f_malloc(sizeof(DIR));
+        FILINFO *fno = (FILINFO *)Frens::f_malloc(sizeof(FILINFO));
+        if (!fil || !dir || !fno) {
+            printf("loadsettings: failed to allocate FatFS structs\n");
+            if (fil) Frens::f_free(fil);
+            if (dir) Frens::f_free(dir);
+            if (fno) Frens::f_free(fno);
+            resetsettings();
+            return;
+        }
         UINT br;
         FRESULT fr;
-        DIR dir;
-        FILINFO fno;
         // Load settings from file
         printf("Loading settings\n");
         // determine size of settings file
-        fr = f_stat(getSettingsFileName(), &fno);
+        fr = f_stat(getSettingsFileName(), fno);
         if (fr == FR_OK)
         {
-            printf("Size of %s: %lu bytes\n", getSettingsFileName(), fno.fsize);
-            if (fno.fsize != sizeof(settings))
+            printf("Size of %s: %lu bytes\n", getSettingsFileName(), fno->fsize);
+            if (fno->fsize != sizeof(settings))
             {
                 printf("Size of %s is not %d bytes, resetting settings\n", getSettingsFileName(), sizeof(settings));
                 resetsettings();
@@ -185,10 +200,10 @@ namespace FrensSettings
             }
             else
             {
-                fr = f_open(&fil, getSettingsFileName(), FA_READ);
+                fr = f_open(fil, getSettingsFileName(), FA_READ);
                 if (fr == FR_OK)
                 {
-                    fr = f_read(&fil, &settings, sizeof(settings), &br);
+                    fr = f_read(fil, &settings, sizeof(settings), &br);
                     if (fr)
                     {
                         printf("Error reading %s: %d\n", getSettingsFileName(), fr);
@@ -212,7 +227,7 @@ namespace FrensSettings
                             printf("Read %d bytes from %s\n", br, getSettingsFileName());
                         }
                     }
-                    f_close(&fil);
+                    f_close(fil);
                 }
                 else
                 {
@@ -229,7 +244,7 @@ namespace FrensSettings
                 }
 
                 // if settings.currentDir is no valid directory, reset settings to default
-                if (f_opendir(&dir, settings.currentDir) != FR_OK)
+                if (f_opendir(dir, settings.currentDir) != FR_OK)
                 {
                     printf("Directory %s does not exist\n", settings.currentDir);
                     resetsettings();
@@ -241,6 +256,9 @@ namespace FrensSettings
             printf("Settings file not found %s: %d\n", getSettingsFileName(), fr);
             resetsettings();
         }
+        Frens::f_free(fil);
+        Frens::f_free(dir);
+        Frens::f_free(fno);
         printsettings();
     }
     // Get the current emulator type, this may be different from emulatorTypeForSettings when in multi-emulator mode

--- a/settings.h
+++ b/settings.h
@@ -57,7 +57,8 @@ namespace FrensSettings
         SMS = 1,
         GAMEBOY = 2,
         GENESIS = 3,
-        MULTI = 4
+        MULTI = 4,
+        PCE = 5
     } emulators;
     static emulators emulatorType = NES;
     void initSettings(emulators emu) ;
@@ -77,5 +78,6 @@ extern int8_t g_settings_visibility_nes[];
 extern const int8_t g_settings_visibility_gb[];
 extern const int8_t g_settings_visibility_sms[];
 extern const int8_t g_settings_visibility_md[];
+extern const int8_t g_settings_visibility_pce[];
 extern const int8_t g_settings_visibility_main[];
 #endif

--- a/settings.h
+++ b/settings.h
@@ -58,7 +58,8 @@ namespace FrensSettings
         GAMEBOY = 2,
         GENESIS = 3,
         MULTI = 4,
-        PCE = 5
+        PCE = 5,
+        O2EM = 6
     } emulators;
     static emulators emulatorType = NES;
     void initSettings(emulators emu) ;
@@ -79,5 +80,6 @@ extern const int8_t g_settings_visibility_gb[];
 extern const int8_t g_settings_visibility_sms[];
 extern const int8_t g_settings_visibility_md[];
 extern const int8_t g_settings_visibility_pce[];
+extern const int8_t g_settings_visibility_o2em[];
 extern const int8_t g_settings_visibility_main[];
 #endif


### PR DESCRIPTION
This pull request introduces several improvements and fixes across the codebase, focusing on better memory management, enhanced frame pacing and audio synchronization, improved ROM listing logic, and more robust hardware configuration handling. The changes are grouped below by theme:

**Frame Pacing and Audio Synchronization:**

* Refactored `PaceFrames60fps` in `FrensHelpers.cpp` to support audio-clock pacing, allowing the frame rate to lock to the audio consumption rate for smoother emulation and reduced audio artifacts. Added support for a customizable vsync wait task and audio fill query, and updated the function signature in both implementation and header. [[1]](diffhunk://#diff-47e62d520f7eae50d3519dbc612bbebcb49fef07fc4079a79b177921ac064db8R48-R53) [[2]](diffhunk://#diff-47e62d520f7eae50d3519dbc612bbebcb49fef07fc4079a79b177921ac064db8L179-R197) [[3]](diffhunk://#diff-47e62d520f7eae50d3519dbc612bbebcb49fef07fc4079a79b177921ac064db8L199-R298) [[4]](diffhunk://#diff-5f5975e512c19f502d53f7be6bdadfa01cafa61f5514a26e7a13870fd871080bL141-R157)
* Improved multicore launching by specifying a dedicated stack for core1, enhancing stability when running framebuffer or non-framebuffer renderers.

**Memory Management and Debugging:**

* Enhanced memory allocation functions (`f_malloc`, `f_free`, `f_realloc`) with debug logging controlled by the `F_MALLOC_DEBUG` macro, and added a C-friendly `frens_f_realloc` wrapper for standard realloc semantics. [[1]](diffhunk://#diff-47e62d520f7eae50d3519dbc612bbebcb49fef07fc4079a79b177921ac064db8R760-R770) [[2]](diffhunk://#diff-47e62d520f7eae50d3519dbc612bbebcb49fef07fc4079a79b177921ac064db8R787-R799) [[3]](diffhunk://#diff-47e62d520f7eae50d3519dbc612bbebcb49fef07fc4079a79b177921ac064db8R820-R830) [[4]](diffhunk://#diff-47e62d520f7eae50d3519dbc612bbebcb49fef07fc4079a79b177921ac064db8R1929-R1938) [[5]](diffhunk://#diff-5f5975e512c19f502d53f7be6bdadfa01cafa61f5514a26e7a13870fd871080bL78-R83)

**ROM Listing and CD Handling:**

* Updated `RomLister.cpp` to allow `.cue` and `.chd` files (streamed CD images) to bypass the PSRAM size check, ensuring large disc images are not excluded from the menu.
* Added logic to hide `.pce` files and `cd_bios.rom` in folders containing CD images, preventing BIOS files from being shown as selectable games in the menu.
* Excluded the `BIOS` directory from ROM listings to avoid clutter.

**Large File Handling:**

* Modified `flashromtoPsram` to detect when a file is too large to preload into PSRAM, reading only the first 4 KB to compute a CRC and returning without allocating memory, which prevents stack overflows and improves reliability with large CD images.

**Build System and Hardware Configuration:**

* Added new CMake options to select between the legacy and `pico-extras` I2S audio drivers, propagating the choice as a compile definition. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR25-R34) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR46)
* Improved clock configuration comments and logic for SGX/HDMI output, clarifying when to force PLL_USB for cleaner video output and avoiding clock-related artifacts on certain hardware.
* Updated build script usage documentation to reflect new options.