### PR TITLE
Optimize IRQ and audio paths, fix pacing and DVI output issues

### DIFF
--- a/FrensHelpers.cpp
+++ b/FrensHelpers.cpp
@@ -51,6 +51,16 @@ static void (*vsyncWaitTask)(void) = nullptr;
 // i.e. to the audio-consumption clock. nullptr → fall back to timer pacing.
 static int (*audioFillQuery)(void) = nullptr;
 static bool paceTimerInited = false;
+// Opt-in line-stream mode (see FrensHelpers.h). When lineStreamFill_ is set,
+// core1 reads each line via the callback into lineStreamScratch_ and streams it
+// to the DMA instead of consuming the validLineQueue. lineStreamActive_ lets
+// the producer know core1 is in the callback loop before it tears down the
+// source buffer. Default null → unchanged queue behaviour (menu, other ports).
+// The scratch line is allocated on demand by setLineStreamFill() so projects
+// that never use line-streaming pay no SRAM for it.
+static volatile Frens::LineStreamFillFn lineStreamFill_ = nullptr;
+static volatile bool lineStreamActive_ = false;
+static uint16_t *lineStreamScratch_ = nullptr;
 #endif
 char ErrorMessage[ERRORMESSAGESIZE];
 bool scaleMode8_7_ = true;
@@ -198,7 +208,9 @@ namespace Frens
     void waitForVSync()
     {
 #if !HSTX
-        if (Frens::isFrameBufferUsed())
+        // Framebuffer path and line-stream path both drive `vsync` from core1
+        // at frame boundaries; wait for it so core0 stays frame-locked.
+        if (Frens::isFrameBufferUsed() || lineStreamActive_)
         {
             while (vsync == false)
             {
@@ -1173,13 +1185,36 @@ namespace Frens
         while (true)
         {
             dvi_->registerIRQThisCore();
-            dvi_->waitForValidLine();
+            // Line-stream mode has no producer queue to wait on; only the
+            // default queue model needs a first valid line before starting.
+            if (!lineStreamFill_)
+                dvi_->waitForValidLine();
 
             dvi_->start();
             while (!exclProc_.isExist())
             {
-                if (scaleMode8_7_)
+                Frens::LineStreamFillFn fn = lineStreamFill_;
+                if (fn)
                 {
+                    // Line-stream mode: read each line via the callback into the
+                    // scratch buffer and stream it straight to the DMA. The
+                    // convertScanBuffer12bpp(line,...) call blocks on the free
+                    // TMDS queue, so this loop is paced to the DMA's 60Hz.
+                    // Raise vsync at frame start so the producer (core0) can
+                    // phase-lock its render to this read pass (waitForVSync) and
+                    // stay ahead of the read -> no crawling tear seam.
+                    lineStreamActive_ = true;
+                    vsync = false;
+                    for (int line = 0; line < SCREENHEIGHT; ++line)
+                    {
+                        fn(line, lineStreamScratch_);
+                        dvi_->convertScanBuffer12bpp(line, lineStreamScratch_, 640);
+                    }
+                    vsync = true;
+                }
+                else if (scaleMode8_7_)
+                {
+                    lineStreamActive_ = false;
                     // Default
                     dvi_->convertScanBuffer12bppScaled16_7(34, 32, 288 * 2);
                     // dvi_->convertScanBuffer12bppScaled16_7(0,0 , 320 * 2);
@@ -1188,6 +1223,7 @@ namespace Frens
                 }
                 else
                 {
+                    lineStreamActive_ = false;
                     //
                     dvi_->convertScanBuffer12bpp();
                 }
@@ -1198,6 +1234,25 @@ namespace Frens
 
             exclProc_.processOrWaitIfExist();
         }
+    }
+
+    void setLineStreamFill(LineStreamFillFn fn)
+    {
+        if (fn && !lineStreamScratch_)
+        {
+            // Allocate the per-line scratch (SRAM, for fast core1 reads) on
+            // first use. Kept allocated and reused across games — not freed on
+            // unregister, which would race core1 still finishing a frame.
+            lineStreamScratch_ = (uint16_t *)malloc(640 * sizeof(uint16_t));
+        }
+        if (fn && !lineStreamScratch_)
+            return; // allocation failed: stay in queue mode rather than deref null
+        lineStreamFill_ = fn;
+    }
+
+    bool lineStreamActive()
+    {
+        return lineStreamActive_;
     }
 
     static WORD *buffer;

--- a/FrensHelpers.cpp
+++ b/FrensHelpers.cpp
@@ -262,14 +262,15 @@ namespace Frens
                 // stream to lock onto). Resync on overrun so a slow frame can't
                 // harmonic-lock the loop to 30fps.
                 static absolute_time_t next_frame;
+                // True PCE NTSC frame period: 1/59.826 ≈ 16715 µs (not 60 Hz).
                 if (init || !paceTimerInited)
                 {
-                    next_frame = make_timeout_time_us(16667); // 1/60s
+                    next_frame = make_timeout_time_us(16715);
                     paceTimerInited = true;
                 }
                 if (time_reached(next_frame))
                 {
-                    next_frame = make_timeout_time_us(16667);
+                    next_frame = make_timeout_time_us(16715);
                 }
                 else
                 {
@@ -280,7 +281,7 @@ namespace Frens
                         else
                             tight_loop_contents();
                     }
-                    next_frame = delayed_by_us(next_frame, 16667);
+                    next_frame = delayed_by_us(next_frame, 16715);
                 }
             }
         }

--- a/FrensHelpers.h
+++ b/FrensHelpers.h
@@ -123,6 +123,16 @@ namespace Frens
     bool screenMode(int incr);
     void flashrom(char *selectedRom);
     void __not_in_flash_func(core1_main)();
+    // Opt-in line-stream mode for core1 (RP2040 DVI, no framebuffer). When a
+    // fill callback is registered, core1 continuously reads a source one line
+    // at a time via the callback (filling dst with RGB565) and streams it to
+    // the DMA, instead of consuming the validLineQueue. Pass nullptr to return
+    // to the default queue model. lineStreamActive() reports whether core1 is
+    // currently running the callback loop — used to safely tear down the source
+    // buffer before freeing it.
+    typedef void (*LineStreamFillFn)(int line, uint16_t *dst);
+    void setLineStreamFill(LineStreamFillFn fn);
+    bool lineStreamActive();
     int initLed();
     void initVintageControllers(uint32_t CPUFreqKHz);
     void initDVandAudio(int marginTop, int marginBottom);

--- a/drivers/pico_hdmi/hstx.c
+++ b/drivers/pico_hdmi/hstx.c
@@ -45,7 +45,9 @@ void hstx_paceFrame(bool init)
     uint32_t current = video_frame_count;
     if ((int32_t)(current - target_frame) < 0)
     {
-        while (video_frame_count != target_frame)
+        // Signed comparison, not !=: robust even if the counter ever steps
+        // past target_frame between checks (a != loop would spin until wrap).
+        while ((int32_t)(video_frame_count - target_frame) < 0)
         {
             tight_loop_contents();
         }
@@ -155,9 +157,15 @@ void __not_in_flash_func(scanline_callbackfunc)(uint32_t v_scanline, uint32_t ac
         const uint16_t *sp = (const uint16_t *)&DisplayBuf[Line_dup * MODE_H_ACTIVE_PIXELS] + 34;
         uint32_t *dp = buff;
 
-        // 32 px left black border (16 uint32_t words)
+        // 32 px left black border (16 uint32_t words). Volatile stores so GCC
+        // cannot replace the loop with a call to flash-resident memset: this
+        // runs in the scanline DMA IRQ, and a flash fetch here can stall
+        // behind QMI traffic (e.g. a CHD hunk decompress hammering PSRAM),
+        // blowing the line-fill deadline and scanning out a corrupt line.
+        volatile uint32_t *bp = dp;
         for (int i = 0; i < 16; i++)
-            *dp++ = 0;
+            bp[i] = 0;
+        dp += 16;
 
         if (stype == 1) {
             for (int g = 0; g < 36; g++) {
@@ -194,9 +202,11 @@ void __not_in_flash_func(scanline_callbackfunc)(uint32_t v_scanline, uint32_t ac
             }
         }
 
-        // 32 px right black border
+        // 32 px right black border (volatile: see left border above)
+        bp = dp;
         for (int i = 0; i < 16; i++)
-            *dp++ = 0;
+            bp[i] = 0;
+        dp += 16;
     } else {
         const uint32_t *src = (const uint32_t *)&DisplayBuf[Line_dup * MODE_H_ACTIVE_PIXELS];
         uint32_t *dst = buff;

--- a/drivers/pico_hdmi/hstx.c
+++ b/drivers/pico_hdmi/hstx.c
@@ -32,30 +32,51 @@ void hstx_waitForVSync(void)
 
 void hstx_paceFrame(bool init)
 {
-    // Slack-aware 60fps pacing. Waits for the next vsync only if we haven't
-    // already passed our target frame. If the caller overran a frame, resync
-    // to the current counter instead of stalling another ~16.6ms, which would
-    // otherwise harmonic-lock the loop to 30fps.
+    // Slack-aware pacing to true PCE NTSC rate (59.8261 Hz), not the HDMI
+    // signal's 60 Hz. video_frame_count ticks at 60 Hz, so on average we wait
+    // 60/59.8261 ≈ 1.00291 vsyncs per emulator frame: most calls advance by 1,
+    // and roughly once every 344 frames (~5.7s) we advance by 2 — invisible to
+    // the eye but it brings game-side per-vsync logic (music tempo, bullet
+    // velocity) into agreement with native PCE timing.
+    //
+    // If the caller overran a frame, resync to the current counter instead of
+    // stalling, which would otherwise harmonic-lock the loop to 30fps.
     static uint32_t target_frame = 0;
+    static uint32_t pace_accum = 0;   // scaled by 10000
     if (init)
     {
         target_frame = video_frame_count;
+        pace_accum = 0;
     }
-    target_frame++;
-    uint32_t current = video_frame_count;
-    if ((int32_t)(current - target_frame) < 0)
+    // accum += 60.0 / 59.8261, both scaled by 10000.
+    pace_accum += 600000u;
+    uint32_t step = pace_accum / 598261u;   // 1 or 2
+    pace_accum -= step * 598261u;
+    target_frame += step;
+    int32_t lag = (int32_t)(video_frame_count - target_frame);
+    if (lag < 0)
     {
-        // Signed comparison, not !=: robust even if the counter ever steps
-        // past target_frame between checks (a != loop would spin until wrap).
+        // On schedule: wait for the target tick. Signed comparison, not !=:
+        // robust even if the counter ever steps past target_frame between
+        // checks (a != loop would spin until wrap).
         while ((int32_t)(video_frame_count - target_frame) < 0)
         {
             tight_loop_contents();
         }
     }
-    else
+    else if (lag > 0)
     {
-        target_frame = current;
+        // More than one full frame behind: drop the missed frames.
+        target_frame = video_frame_count;
     }
+    // lag == 0 — a vsync tick landed inside this frame's execution. Do NOT
+    // resync: that forgets the tick phase, and in heavy scenes (frame time
+    // close to the tick period) nearly every frame spans a tick, so the
+    // resync path would let the loop free-run at raw emulation speed
+    // (observed: 62/63 fps in Aero Blasters gameplay). Leaving target_frame
+    // alone means this frame consumed exactly its one tick and the next call
+    // waits as usual — overspeed is impossible, and a genuinely slow frame
+    // still passes through without stalling (no 30fps harmonic lock).
 }
 uint8_t *hstx_getframebuffer(void)
 {

--- a/drivers/pico_hdmi/hstx_data_island_queue.c
+++ b/drivers/pico_hdmi/hstx_data_island_queue.c
@@ -49,18 +49,23 @@ void hstx_di_queue_set_sample_rate(uint32_t sample_rate)
     samples_per_line_fp = (samples_per_frame << 16) / MODE_V_TOTAL_LINES;
 }
 
-bool hstx_di_queue_push(const hstx_data_island_t *island)
+bool __not_in_flash_func(hstx_di_queue_push)(const hstx_data_island_t *island)
 {
     uint32_t next_head = (di_ring_head + 1) % DI_RING_BUFFER_SIZE;
     if (next_head == di_ring_tail)
         return false;
 
-    di_ring_buffer[di_ring_head] = *island;
+    // Volatile word copy instead of struct assignment: keeps the copy inline
+    // so this SRAM function never calls the flash-resident libc memcpy.
+    volatile uint32_t *dst = di_ring_buffer[di_ring_head].words;
+    const uint32_t *src = island->words;
+    for (size_t i = 0; i < count_of(island->words); i++)
+        dst[i] = src[i];
     di_ring_head = next_head;
     return true;
 }
 
-uint32_t hstx_di_queue_get_level(void)
+uint32_t __not_in_flash_func(hstx_di_queue_get_level)(void)
 {
     uint32_t head = di_ring_head;
     uint32_t tail = di_ring_tail;

--- a/drivers/pico_hdmi/hstx_packet.c
+++ b/drivers/pico_hdmi/hstx_packet.c
@@ -1,12 +1,19 @@
 #include "hstx_packet.h"
 
 #include <string.h>
+#include "pico.h"
+
+// The per-audio-packet encode path (hstx_packet_set_audio_samples +
+// hstx_encode_data_island and their tables) is kept out of flash: it runs
+// ~46 times per frame on core0, and a flash fetch can stall behind QMI
+// traffic (CHD hunk decompress hammering PSRAM), delaying the audio push
+// long enough to drain the HDMI data-island queue.
 
 // ============================================================================
 // TERC4 Symbol Table (4-bit to 10-bit encoding)
 // ============================================================================
 
-static const uint16_t ter_c4[16] = {
+static const uint16_t __not_in_flash("hstx_packet") ter_c4[16] = {
     0b1010011100, // 0
     0b1001100011, // 1
     0b1011100100, // 2
@@ -31,7 +38,7 @@ static const uint16_t ter_c4[16] = {
 // BCH Encoding
 // ============================================================================
 
-static const uint8_t bch_table[256] = {
+static const uint8_t __not_in_flash("hstx_packet") bch_table[256] = {
     0x00, 0xd9, 0xb5, 0x6c, 0x6d, 0xb4, 0xd8, 0x01, 0xda, 0x03, 0x6f, 0xb6, 0xb7, 0x6e, 0x02, 0xdb, 0xb3, 0x6a, 0x06,
     0xdf, 0xde, 0x07, 0x6b, 0xb2, 0x69, 0xb0, 0xdc, 0x05, 0x04, 0xdd, 0xb1, 0x68, 0x61, 0xb8, 0xd4, 0x0d, 0x0c, 0xd5,
     0xb9, 0x60, 0xbb, 0x62, 0x0e, 0xd7, 0xd6, 0x0f, 0x63, 0xba, 0xd2, 0x0b, 0x67, 0xbe, 0xbf, 0x66, 0x0a, 0xd3, 0x08,
@@ -48,7 +55,7 @@ static const uint8_t bch_table[256] = {
     0x92, 0x49, 0x90, 0xfc, 0x25, 0x24, 0xfd, 0x91, 0x48,
 };
 
-static const uint8_t parity_table[32] = {0x96, 0x69, 0x69, 0x96, 0x69, 0x96, 0x96, 0x69, 0x69, 0x96, 0x96,
+static const uint8_t __not_in_flash("hstx_packet") parity_table[32] = {0x96, 0x69, 0x69, 0x96, 0x69, 0x96, 0x96, 0x69, 0x69, 0x96, 0x96,
                                          0x69, 0x96, 0x69, 0x69, 0x96, 0x69, 0x96, 0x96, 0x69, 0x96, 0x69,
                                          0x69, 0x96, 0x96, 0x69, 0x69, 0x96, 0x69, 0x96, 0x96, 0x69};
 
@@ -62,7 +69,7 @@ static inline bool compute_parity3(uint8_t a, uint8_t b, uint8_t c)
     return compute_parity(a) ^ compute_parity(b) ^ compute_parity(c);
 }
 
-static uint8_t encode_bch_3(const uint8_t *p)
+static uint8_t __not_in_flash_func(encode_bch_3)(const uint8_t *p)
 {
     uint8_t v = bch_table[p[0]];
     v = bch_table[p[1] ^ v];
@@ -70,7 +77,7 @@ static uint8_t encode_bch_3(const uint8_t *p)
     return v;
 }
 
-static uint8_t encode_bch_7(const uint8_t *p)
+static uint8_t __not_in_flash_func(encode_bch_7)(const uint8_t *p)
 {
     uint8_t v = bch_table[p[0]];
     v = bch_table[p[1] ^ v];
@@ -82,12 +89,12 @@ static uint8_t encode_bch_7(const uint8_t *p)
     return v;
 }
 
-static void compute_header_parity(hstx_packet_t *p)
+static void __not_in_flash_func(compute_header_parity)(hstx_packet_t *p)
 {
     p->header[3] = encode_bch_3(p->header);
 }
 
-static void compute_subpacket_parity(hstx_packet_t *p, int idx)
+static void __not_in_flash_func(compute_subpacket_parity)(hstx_packet_t *p, int idx)
 {
     p->subpacket[idx][7] = encode_bch_7(p->subpacket[idx]);
 }
@@ -119,9 +126,13 @@ static void compute_infoframe_checksum(hstx_packet_t *p)
 // Public API
 // ============================================================================
 
-void hstx_packet_init(hstx_packet_t *packet)
+void __not_in_flash_func(hstx_packet_init)(hstx_packet_t *packet)
 {
-    memset(packet, 0, sizeof(hstx_packet_t));
+    // Volatile byte stores instead of memset: keeps the zeroing inline so
+    // this SRAM function never calls the flash-resident libc memset.
+    volatile uint8_t *p = (volatile uint8_t *)packet;
+    for (size_t i = 0; i < sizeof(hstx_packet_t); i++)
+        p[i] = 0;
 }
 
 void hstx_packet_set_null(hstx_packet_t *packet)
@@ -193,7 +204,7 @@ void hstx_packet_set_avi_infoframe(hstx_packet_t *packet, uint8_t vic, uint8_t p
     compute_all_parity(packet);
 }
 
-int hstx_packet_set_audio_samples(hstx_packet_t *packet, const audio_sample_t *samples, int num_samples,
+int __not_in_flash_func(hstx_packet_set_audio_samples)(hstx_packet_t *packet, const audio_sample_t *samples, int num_samples,
                                   int frame_count)
 {
     hstx_packet_init(packet);
@@ -244,7 +255,7 @@ static inline uint32_t make_hstx_word(uint16_t lane0, uint16_t lane1, uint16_t l
     return (lane0 & 0x3FF) | ((lane1 & 0x3FF) << 10) | ((lane2 & 0x3FF) << 20);
 }
 
-static void encode_header_to_lane0(const hstx_packet_t *packet, uint16_t *lane0, int hv, bool first_packet)
+static void __not_in_flash_func(encode_header_to_lane0)(const hstx_packet_t *packet, uint16_t *lane0, int hv, bool first_packet)
 {
     int hv1 = hv | 0x08;
     if (!first_packet)
@@ -265,7 +276,7 @@ static void encode_header_to_lane0(const hstx_packet_t *packet, uint16_t *lane0,
     }
 }
 
-static void encode_subpackets_to_lanes(const hstx_packet_t *packet, uint16_t *lane1, uint16_t *lane2)
+static void __not_in_flash_func(encode_subpackets_to_lanes)(const hstx_packet_t *packet, uint16_t *lane1, uint16_t *lane2)
 {
     for (int i = 0; i < 8; i++) {
         uint32_t v = (packet->subpacket[0][i] << 0) | (packet->subpacket[1][i] << 8) | (packet->subpacket[2][i] << 16) |
@@ -287,7 +298,7 @@ static void encode_subpackets_to_lanes(const hstx_packet_t *packet, uint16_t *la
     }
 }
 
-void hstx_encode_data_island(hstx_data_island_t *out, const hstx_packet_t *packet, bool vsync_active, bool hsync_active)
+void __not_in_flash_func(hstx_encode_data_island)(hstx_data_island_t *out, const hstx_packet_t *packet, bool vsync_active, bool hsync_active)
 {
     // REVERTED: vsync_active/hsync_active indicate pulse region, not signal level
     // For 640x480 (negative polarity), pulse region means signal=0

--- a/drivers/pico_hdmi/video_output.c
+++ b/drivers/pico_hdmi/video_output.c
@@ -203,7 +203,9 @@ static void __not_in_flash_func(hstx_resync)(void)
 // Internal Helpers
 // ============================================================================
 
-static uint32_t build_line_with_di(uint32_t *buf, const uint32_t *di_words, bool vsync, bool active)
+// __not_in_flash_func: called from the scanline DMA IRQ; must not fetch from
+// flash while the QMI may be saturated (CHD decompress, PSRAM traffic).
+static uint32_t __not_in_flash_func(build_line_with_di)(uint32_t *buf, const uint32_t *di_words, bool vsync, bool active)
 {
     uint32_t *p = buf;
     uint32_t sync_h0 = vsync ? SYNC_V0_H0 : SYNC_V1_H0;

--- a/drivers/pico_hdmi/video_output.c
+++ b/drivers/pico_hdmi/video_output.c
@@ -700,8 +700,11 @@ void video_output_core1_run(void)
     }
 
     // Set GPIO 12-19 to HSTX function (function 0 on RP2350)
-    for (int i = 12; i <= 19; ++i)
+    for (int i = 12; i <= 19; ++i) {
         gpio_set_function(i, 0);
+        gpio_set_slew_rate(i, GPIO_SLEW_RATE_FAST);
+        gpio_set_drive_strength(i, GPIO_DRIVE_STRENGTH_12MA);
+    }
 
     // DMA Setup
     dma_channel_config c = dma_channel_get_default_config(DMACH_PING);

--- a/drivers/pico_hdmi/video_output.c
+++ b/drivers/pico_hdmi/video_output.c
@@ -140,6 +140,14 @@ static uint32_t vactive_di_len, vactive_di_null_len;
 static uint32_t vblank_di_ping[128], vblank_di_pong[128], vblank_di_null[128];
 static uint32_t vblank_di_len, vblank_di_null_len;
 
+// DVI-mode null-DI cmdlist for VSYNC-active blanking lines. The other
+// null-DI buffers above are pre-built with vsync=false; we need a vsync=true
+// variant so DVI mode can emit the same HDMI-structured cmdlist (data-island
+// period + video preamble + guard band) on every line of the frame, including
+// the 2-line vertical sync pulse. See video_output_init().
+static uint32_t vblank_di_null_vsync_on[128];
+static uint32_t vblank_di_null_vsync_on_len;
+
 static uint32_t vblank_acr_vsync_on[64], vblank_acr_vsync_on_len;
 static uint32_t vblank_acr_vsync_off[64], vblank_acr_vsync_off_len;
 static uint32_t vblank_infoframe_vsync_on[64], vblank_infoframe_vsync_on_len;
@@ -287,14 +295,20 @@ static inline void __not_in_flash_func(get_scanline_state)(uint32_t v_scanline, 
 static inline void __not_in_flash_func(video_output_handle_vsync)(dma_channel_hw_t *ch, uint32_t v_scanline)
 {
     if (dvi_mode) {
-        // Pure DVI: simple vsync line without Data Islands
-        ch->read_addr = (uintptr_t)vblank_line_vsync_on;
-        ch->transfer_count = count_of(vblank_line_vsync_on);
+        // DVI mode: use the same HDMI-structured cmdlist (data-island period
+        // + video preamble + guard band) as HDMI mode, but with a null DI
+        // packet so no audio / AVI / ACR data is actually transmitted. The
+        // longer cmdlist produces a much richer control-period before each
+        // active region, which several sinks (notably the Murmulator M2's
+        // monitor) need to maintain TMDS lock — the bare 9-word DVI cmdlist
+        // caused frequent lock loss and watchdog resyncs.
+        ch->read_addr = (uintptr_t)vblank_di_null_vsync_on;
+        ch->transfer_count = vblank_di_null_vsync_on_len;
         if (v_scanline == MODE_V_FRONT_PORCH) {
             video_frame_count++;
             if (vsync_callback)
                 vsync_callback();
-        } 
+        }
     } else {
         if (v_scanline == MODE_V_FRONT_PORCH) {
             ch->read_addr = (uintptr_t)vblank_acr_vsync_on;
@@ -317,8 +331,11 @@ static inline void __not_in_flash_func(video_output_handle_active_start)(dma_cha
     //    even if the scanline callback below overruns, the cmdlist chain is
     //    safe and HSTX keeps emitting valid sync.
     if (dvi_mode) {
-        ch->read_addr = (uintptr_t)vactive_line_dvi;
-        ch->transfer_count = count_of(vactive_line_dvi);
+        // DVI mode: share HDMI's active-line cmdlist (with null DI) so the
+        // sink sees the same control-period structure on every line. See
+        // video_output_handle_vsync for rationale.
+        ch->read_addr = (uintptr_t)vactive_di_null;
+        ch->transfer_count = vactive_di_null_len;
     } else {
         uint32_t *buf = dma_pong ? vactive_di_ping : vactive_di_pong;
         const uint32_t *di_words = hstx_di_queue_get_audio_packet();
@@ -357,12 +374,14 @@ static inline void __not_in_flash_func(video_output_handle_active_start)(dma_cha
 static inline void __not_in_flash_func(video_output_handle_blanking)(dma_channel_hw_t *ch, uint32_t v_scanline, bool send_acr, bool dma_pong)
 {
     if (dvi_mode) {
-        // Pure DVI: simple blanking line without Data Islands
+        // DVI mode: HDMI-structured blanking cmdlist with a null DI packet
+        // (no audio / no ACR / no AVI InfoFrame). See video_output_handle_vsync
+        // for why the cmdlist shape is shared with HDMI mode.
         (void)send_acr;
         (void)dma_pong;
         (void)v_scanline;
-        ch->read_addr = (uintptr_t)vblank_line_vsync_off;
-        ch->transfer_count = count_of(vblank_line_vsync_off);
+        ch->read_addr = (uintptr_t)vblank_di_null;
+        ch->transfer_count = vblank_di_null_len;
     } else {
         if (send_acr) {
             ch->read_addr = (uintptr_t)vblank_acr_vsync_off;
@@ -529,6 +548,12 @@ void video_output_init(uint16_t width, uint16_t height)
 
     vblank_di_null_len = build_line_with_di(vblank_di_null, hstx_get_null_data_island(false, true), false, false);
     vactive_di_null_len = build_line_with_di(vactive_di_null, hstx_get_null_data_island(false, true), false, true);
+
+    // Vsync-active variant for DVI mode's two vsync lines (HDMI mode uses
+    // the ACR/InfoFrame cmdlists instead). Built with vsync=true so the sync
+    // symbols carry VSYNC asserted, and the embedded null DI also has its
+    // vsync-active TERC4 encoding.
+    vblank_di_null_vsync_on_len = build_line_with_di(vblank_di_null_vsync_on, hstx_get_null_data_island(true, true), true, false);
 
     vblank_di_len = build_line_with_di(vblank_di_ping, hstx_get_null_data_island(false, true), false, false);
     memcpy(vblank_di_pong, vblank_di_ping, sizeof(vblank_di_ping));

--- a/menu.cpp
+++ b/menu.cpp
@@ -205,6 +205,9 @@ static bool isArtWorkEnabled()
     case FrensSettings::emulators::PCE:
         snprintf(PATH, sizeof(PATH), "/Metadata/%s/Images/160/5/599EAD9B.444", emulator);
         break;
+    case FrensSettings::emulators::O2EM:
+        snprintf(PATH, sizeof(PATH), "/Metadata/%s/Images/160/0/084EE035.444", emulator);
+        break;
     default:
         return false;
     }


### PR DESCRIPTION
This pull request introduces several performance and timing improvements for the RP2040 DVI/HDMI video and audio output code, with a focus on precise frame pacing, robust memory usage, and ensuring all timing-critical routines stay in SRAM to avoid flash stalls. The most significant changes are grouped below.

**Video Output Timing and Frame Pacing Improvements:**
- Adjusted frame pacing to match the true PCE NTSC frame rate (59.826 Hz, 16,715 µs per frame) instead of rounding to 60 Hz, both in the DVI (Frens) and HDMI (hstx) code paths. This ensures that game logic tied to vsync (e.g., music tempo, movement) matches original hardware more closely and avoids harmonic locking at 30fps in slow scenes. [[1]](diffhunk://#diff-47e62d520f7eae50d3519dbc612bbebcb49fef07fc4079a79b177921ac064db8R277-R285) [[2]](diffhunk://#diff-47e62d520f7eae50d3519dbc612bbebcb49fef07fc4079a79b177921ac064db8L283-R296) [[3]](diffhunk://#diff-d241c2856e91356fd96a3df1ad47e0ec41b6eae3d9c1beb76e7f1d99802c4e52L35-R79)

**New Line-Stream Rendering Mode (Frens):**
- Added an opt-in "line-stream" mode for DVI output, where core1 reads each line via a callback and streams it directly to DMA, bypassing the framebuffer/queue. This is memory-efficient for ports that don't need a full framebuffer and ensures phase-locked vsync signaling for the producer. Includes allocation-on-demand for the scratch buffer and APIs to set the callback and query line-stream activity. [[1]](diffhunk://#diff-47e62d520f7eae50d3519dbc612bbebcb49fef07fc4079a79b177921ac064db8R54-R63) [[2]](diffhunk://#diff-47e62d520f7eae50d3519dbc612bbebcb49fef07fc4079a79b177921ac064db8R1188-R1217) [[3]](diffhunk://#diff-47e62d520f7eae50d3519dbc612bbebcb49fef07fc4079a79b177921ac064db8R1226) [[4]](diffhunk://#diff-47e62d520f7eae50d3519dbc612bbebcb49fef07fc4079a79b177921ac064db8R1239-R1257) [[5]](diffhunk://#diff-5f5975e512c19f502d53f7be6bdadfa01cafa61f5514a26e7a13870fd871080bR126-R135)

**SRAM Placement and Flash Stall Avoidance:**
- Moved all timing-critical routines and lookup tables for HDMI packet/audio encoding into SRAM using `__not_in_flash_func` and `__not_in_flash` attributes. This prevents flash stalls during heavy PSRAM/flash traffic (e.g., CHD decompression), which could otherwise cause missed deadlines and visible glitches in audio or video output. [[1]](diffhunk://#diff-c1b518b0c31293fd23694303a09fee45fcf6e829bea9cfee292c8934099f6da3R4-R16) [[2]](diffhunk://#diff-c1b518b0c31293fd23694303a09fee45fcf6e829bea9cfee292c8934099f6da3L34-R41) [[3]](diffhunk://#diff-c1b518b0c31293fd23694303a09fee45fcf6e829bea9cfee292c8934099f6da3L51-R58) [[4]](diffhunk://#diff-c1b518b0c31293fd23694303a09fee45fcf6e829bea9cfee292c8934099f6da3L65-R80) [[5]](diffhunk://#diff-c1b518b0c31293fd23694303a09fee45fcf6e829bea9cfee292c8934099f6da3L85-R97) [[6]](diffhunk://#diff-c1b518b0c31293fd23694303a09fee45fcf6e829bea9cfee292c8934099f6da3L122-R135) [[7]](diffhunk://#diff-c1b518b0c31293fd23694303a09fee45fcf6e829bea9cfee292c8934099f6da3L196-R207) [[8]](diffhunk://#diff-c1b518b0c31293fd23694303a09fee45fcf6e829bea9cfee292c8934099f6da3L247-R258) [[9]](diffhunk://#diff-c1b518b0c31293fd23694303a09fee45fcf6e829bea9cfee292c8934099f6da3L268-R279) [[10]](diffhunk://#diff-c1b518b0c31293fd23694303a09fee45fcf6e829bea9cfee292c8934099f6da3L290-R301) [[11]](diffhunk://#diff-61938ba514ababea9d7ffc2a4c856ef4dd4e198cb67eb1b9597fd00dfc4e6b66L52-R68)

**Memory Handling and Data Integrity:**
- Replaced standard library functions like `memset` and struct assignment with explicit volatile memory operations in timing-critical code, ensuring all operations remain inline in SRAM and are not replaced with flash-resident library calls. This is especially important in IRQ and DMA paths. [[1]](diffhunk://#diff-c1b518b0c31293fd23694303a09fee45fcf6e829bea9cfee292c8934099f6da3L122-R135) [[2]](diffhunk://#diff-61938ba514ababea9d7ffc2a4c856ef4dd4e198cb67eb1b9597fd00dfc4e6b66L52-R68) [[3]](diffhunk://#diff-d241c2856e91356fd96a3df1ad47e0ec41b6eae3d9c1beb76e7f1d99802c4e52L158-R189) [[4]](diffhunk://#diff-d241c2856e91356fd96a3df1ad47e0ec41b6eae3d9c1beb76e7f1d99802c4e52L197-R230)

**Support for DVI-mode VSYNC Null Data Islands:**
- Added a new buffer for DVI-mode null data islands with VSYNC active, allowing the DVI output to emit HDMI-structured command lists on every line, including during the vertical sync pulse.

These changes collectively improve the timing accuracy, robustness, and performance of the video/audio output system, especially under heavy I/O load and in memory-constrained scenarios.This pull request introduces a new opt-in "line-stream" mode for the RP2040 DVI output, improves frame pacing accuracy to match the true PCE NTSC rate, and applies several low-level optimizations to avoid flash stalls during critical real-time routines. The changes also enhance memory management and synchronization between cores, and make the HDMI/DVI data-island and packet encoding paths more robust and deterministic.

**Line-stream mode and synchronization:**

- Added a line-stream mode to `FrensHelpers.cpp`/`.h` allowing core1 to stream lines directly via a callback, bypassing the framebuffer queue. This includes new functions (`setLineStreamFill`, `lineStreamActive`), on-demand allocation of a line scratch buffer, and synchronization logic to ensure safe buffer teardown. (`[[1]](diffhunk://#diff-47e62d520f7eae50d3519dbc612bbebcb49fef07fc4079a79b177921ac064db8R54-R63)`, `[[2]](diffhunk://#diff-47e62d520f7eae50d3519dbc612bbebcb49fef07fc4079a79b177921ac064db8R1188-R1217)`, `[[3]](diffhunk://#diff-47e62d520f7eae50d3519dbc612bbebcb49fef07fc4079a79b177921ac064db8R1226)`, `[[4]](diffhunk://#diff-47e62d520f7eae50d3519dbc612bbebcb49fef07fc4079a79b177921ac064db8R1239-R1257)`, `[[5]](diffhunk://#diff-5f5975e512c19f502d53f7be6bdadfa01cafa61f5514a26e7a13870fd871080bR126-R135)`)
- Modified `waitForVSync` to support both framebuffer and line-stream modes, ensuring core0 remains frame-locked regardless of the rendering path. (`[FrensHelpers.cppL201-R213](diffhunk://#diff-47e62d520f7eae50d3519dbc612bbebcb49fef07fc4079a79b177921ac064db8L201-R213)`)

**Frame pacing and timing accuracy:**

- Updated frame pacing in both DVI and HDMI code paths to use the true PCE NTSC frame period (59.8261 Hz, ≈16715 µs), instead of rounding to 60 Hz, for more accurate emulation timing and improved game compatibility. (`[[1]](diffhunk://#diff-47e62d520f7eae50d3519dbc612bbebcb49fef07fc4079a79b177921ac064db8R277-R285)`, `[[2]](diffhunk://#diff-47e62d520f7eae50d3519dbc612bbebcb49fef07fc4079a79b177921ac064db8L283-R296)`, `[[3]](diffhunk://#diff-d241c2856e91356fd96a3df1ad47e0ec41b6eae3d9c1beb76e7f1d99802c4e52L35-R79)`)

**Performance and real-time safety improvements:**

- Replaced standard memory operations (e.g., `memset`, `memcpy`, struct assignment) with volatile, inline implementations in packet and data-island code to guarantee that critical routines never stall on flash fetches, which could cause missed deadlines during video/audio output. (`[[1]](diffhunk://#diff-c1b518b0c31293fd23694303a09fee45fcf6e829bea9cfee292c8934099f6da3R4-R16)`, `[[2]](diffhunk://#diff-61938ba514ababea9d7ffc2a4c856ef4dd4e198cb67eb1b9597fd00dfc4e6b66L52-R68)`, `[[3]](diffhunk://#diff-c1b518b0c31293fd23694303a09fee45fcf6e829bea9cfee292c8934099f6da3L122-R135)`)
- Marked key functions and tables as `__not_in_flash_func` or `__not_in_flash`, ensuring they're resident in SRAM for deterministic execution. (`[[1]](diffhunk://#diff-c1b518b0c31293fd23694303a09fee45fcf6e829bea9cfee292c8934099f6da3L34-R41)`, `[[2]](diffhunk://#diff-c1b518b0c31293fd23694303a09fee45fcf6e829bea9cfee292c8934099f6da3L51-R58)`, `[[3]](diffhunk://#diff-c1b518b0c31293fd23694303a09fee45fcf6e829bea9cfee292c8934099f6da3L65-R80)`, `[[4]](diffhunk://#diff-c1b518b0c31293fd23694303a09fee45fcf6e829bea9cfee292c8934099f6da3L85-R97)`, `[[5]](diffhunk://#diff-c1b518b0c31293fd23694303a09fee45fcf6e829bea9cfee292c8934099f6da3L196-R207)`, `[[6]](diffhunk://#diff-c1b518b0c31293fd23694303a09fee45fcf6e829bea9cfee292c8934099f6da3L247-R258)`, `[[7]](diffhunk://#diff-c1b518b0c31293fd23694303a09fee45fcf6e829bea9cfee292c8934099f6da3L268-R279)`, `[[8]](diffhunk://#diff-c1b518b0c31293fd23694303a09fee45fcf6e829bea9cfee292c8934099f6da3L290-R301)`)

**DMA and scanline handling:**

- Made scanline border fill routines use volatile stores to prevent GCC from generating flash-resident `memset` calls, which could introduce stalls during DMA IRQs. (`[[1]](diffhunk://#diff-d241c2856e91356fd96a3df1ad47e0ec41b6eae3d9c1beb76e7f1d99802c4e52L158-R189)`, `[[2]](diffhunk://#diff-d241c2856e91356fd96a3df1ad47e0ec41b6eae3d9c1beb76e7f1d99802c4e52L197-R230)`)

**HDMI/DVI data-island and blanking improvements:**

- Added a dedicated DVI-mode null data-island command list for VSYNC-active blanking lines, ensuring correct HDMI-structured output during vertical sync periods. (`[drivers/pico_hdmi/video_output.cR143-R150](diffhunk://#diff-5ff0b7863ef7e043fa0839614797822d0c905021ff637b9bae61e937788d62baR143-R150)`)

These changes collectively improve timing accuracy, reliability, and extensibility of video/audio output on the RP2040 platform, especially for advanced use cases and edge conditions.