### PR TITLE
Enhance settings menu with scrollable options and Overclock toggle

### DIFF
--- a/menu.cpp
+++ b/menu.cpp
@@ -2311,6 +2311,9 @@ int showSettingsMenu(bool calledFromGame)
     for (int i = 0; i < MOPT_COUNT; ++i)
     {
         if (i == MOPT_FDS_DISK_SWAP) continue; // already handled above
+        // Overclock is reachable only from the file-browser menu — applying it
+        // mid-game would reboot the box and drop unsaved emulator state.
+        if (i == MOPT_OVERCLOCK && calledFromGame) continue;
         // -1 is always hidden
         if (g_settings_visibility[i] >= 0)
         {

--- a/menu.cpp
+++ b/menu.cpp
@@ -2320,24 +2320,31 @@ int showSettingsMenu(bool calledFromGame)
             }
         }
     }
-    // Layout rows:
-    // 0: title
-    // 1: blank spacer after title
-    // 2 .. 2+visibleCount-1 : options
-    // spacerAfterOptionsRow (blank)
-    // paletteStartRow .. paletteStartRow+3 : 4 rows of 16 color blocks (64 colors total)
-    // paletteInfoRow: textual FG/BG info using working colors
-    // SAVE
-    // CANCEL
-    // DEFAULT
-    const int rowStartOptions = 2;
-    const int spacerAfterOptionsRow = rowStartOptions + visibleCount; // first spacer (blank)
-    const int actionRowScreen = spacerAfterOptionsRow + 1;         // single row for SAVE / CANCEL / DEFAULT
-    const int paletteStartRow = actionRowScreen + 2;              // +2 = blank spacer between action row and palette
-    const int paletteRowCount = 4;                                // 4 x 16 = 64
-    const int helpRowScreen = paletteStartRow + paletteRowCount + 1; // extra spacer before help line
-    int selectedRowLocal = rowStartOptions;         // first selectable option row
-    int actionSubSelect = 0;                        // 0=SAVE, 1=CANCEL, 2=DEFAULT
+    // Layout rows (option list is a scrollable window of optionWindowSize rows):
+    //   title, blank,
+    //   upIndicatorRow,
+    //   rowStartOptions .. rowStartOptions+optionWindowSize-1 (option slots),
+    //   downIndicatorRow,
+    //   blank,
+    //   actionRowScreen (SAVE / CANCEL / DEFAULT, fixed),
+    //   blank,
+    //   paletteStartRow .. paletteStartRow+3 (4x16 palette),
+    //   blank,
+    //   helpRowScreen (option description),
+    //   ... free ...,
+    //   bottom-anchored hint lines at SCREEN_ROWS-3 .. SCREEN_ROWS-1.
+    const int optionWindowSize  = 10;
+    const int rowStartOptions   = 3;
+    const int upIndicatorRow    = rowStartOptions - 1;
+    const int downIndicatorRow  = rowStartOptions + optionWindowSize;
+    const int actionRowScreen   = downIndicatorRow + 2;
+    const int paletteStartRow   = actionRowScreen + 2;
+    const int paletteRowCount   = 4;
+    const int helpRowScreen     = paletteStartRow + paletteRowCount + 1;
+    int  selectedOptionIndex = 0;                   // logical 0..visibleCount-1
+    int  firstVisibleOption  = 0;                   // scroll offset
+    bool onActionRow         = (visibleCount == 0); // no options -> start on action row
+    int  actionSubSelect     = 0;                   // 0=SAVE, 1=CANCEL, 2=DEFAULT
     exitMenu = false;
     bool applySettings = false; // true when SAVE, false when CANCEL
     // lambda to redraw the entire menu
@@ -2356,8 +2363,15 @@ int showSettingsMenu(bool calledFromGame)
         putText(titleCol, row++, "-- Settings --", CBLACK, CWHITE);
         // Blank spacer line
         putText(0, row++, "", CBLACK, CWHITE);
-        // Render each visible option
-        for (int vi = 0; vi < visibleCount; ++vi)
+        // Up-scroll indicator (centered): shown when there are options above the window
+        putText(SCREEN_COLS / 2, upIndicatorRow,
+                (firstVisibleOption > 0) ? "^" : " ", CBLACK, CWHITE);
+        // Render the visible option window (up to optionWindowSize entries)
+        row = rowStartOptions;
+        const int lastVi = (firstVisibleOption + optionWindowSize < visibleCount)
+                               ? firstVisibleOption + optionWindowSize
+                               : visibleCount;
+        for (int vi = firstVisibleOption; vi < lastVi; ++vi)
         {
             int optIndex = visibleIndices[vi];
             const char *label = "";
@@ -2646,9 +2660,11 @@ int showSettingsMenu(bool calledFromGame)
             snprintf(line, sizeof(line), "%s%s%s", label, (optIndex == MOPT_EXIT_GAME || optIndex == MOPT_SAVE_RESTORE_STATE || optIndex == MOPT_ENTER_BOOTSEL_MODE || optIndex == MOPT_RESET_GAME) ? "" : ": ", value);
             putText(0, row++, line, CBLACK, CWHITE);
         }
-        // Blank spacer after last option
-        putText(0, row++, "", CBLACK, CWHITE);
-        // Render SAVE / CANCEL / DEFAULT on a single row with per-word highlighting
+        // Down-scroll indicator (centered): shown when there are options below the window
+        putText(SCREEN_COLS / 2, downIndicatorRow,
+                (firstVisibleOption + optionWindowSize < visibleCount) ? "v" : " ", CBLACK, CWHITE);
+        // Render SAVE / CANCEL / DEFAULT at a fixed row, with per-word highlighting
+        row = actionRowScreen;
         {
             const char *saveLabel  = settingsChanged ? "SAVE*" : "SAVE";
             const char *labels[3]  = { saveLabel, "CANCEL", "DEFAULT" };
@@ -2658,7 +2674,6 @@ int showSettingsMenu(bool calledFromGame)
             int startCol           = (SCREEN_COLS - totalLen) / 2;
             if (startCol < 0) startCol = 0;
             int col3 = startCol;
-            bool onActionRow = (selectedRowLocal == actionRowScreen);
             for (int ai = 0; ai < 3; ++ai)
             {
                 int fg = (onActionRow && actionSubSelect == ai) ? CWHITE : CBLACK;
@@ -2668,9 +2683,8 @@ int showSettingsMenu(bool calledFromGame)
             }
             row++;
         }
-        // Blank spacer after action row
-        putText(0, row++, "", CBLACK, CWHITE);
         // 64-color palette grid (4 rows x 16 columns). Each block is a space with fg=bg=colorIndex
+        row = paletteStartRow;
         int blocksPerRow = 16;
         int blockRows = paletteRowCount;
         int gridWidth = blocksPerRow; // one char per block
@@ -2706,12 +2720,13 @@ int showSettingsMenu(bool calledFromGame)
         }
         // Help text (dynamic button labels)
 
-        if (selectedRowLocal < actionRowScreen)
+        if (!onActionRow && visibleCount > 0)
         {
-            if (visibleIndices[selectedRowLocal - rowStartOptions] == MOPT_EXIT_GAME ||
-                visibleIndices[selectedRowLocal - rowStartOptions] == MOPT_SAVE_RESTORE_STATE ||
-                visibleIndices[selectedRowLocal - rowStartOptions] == MOPT_ENTER_BOOTSEL_MODE ||
-                visibleIndices[selectedRowLocal - rowStartOptions] == MOPT_RESET_GAME)
+            int curOpt = visibleIndices[selectedOptionIndex];
+            if (curOpt == MOPT_EXIT_GAME ||
+                curOpt == MOPT_SAVE_RESTORE_STATE ||
+                curOpt == MOPT_ENTER_BOOTSEL_MODE ||
+                curOpt == MOPT_RESET_GAME)
             {
                 snprintf(line, sizeof(line), "UP/DOWN: Move, %s: select", buttonLabel1);
             }
@@ -2733,7 +2748,7 @@ int showSettingsMenu(bool calledFromGame)
         if (col < 0)
             col = 0;
         putText(col, row++, line, CBLACK, CWHITE);
-        if (selectedRowLocal == actionRowScreen)
+        if (onActionRow)
         {
             const char *actionHints[3] = { "Confirm changes", "Discard changes", "Restore defaults" };
             snprintf(line, sizeof(line), "%s: %s", buttonLabel1, actionHints[actionSubSelect]);
@@ -2743,9 +2758,9 @@ int showSettingsMenu(bool calledFromGame)
             strcpy(line, ""); // no second line
         }
         // display helptext
-        if (selectedRowLocal >= rowStartOptions && selectedRowLocal < rowStartOptions + visibleCount)
+        if (!onActionRow && visibleCount > 0)
         {
-            putText(0, helpRowScreen, g_settings_descriptions[visibleIndices[selectedRowLocal - rowStartOptions]], CBLACK, CWHITE);
+            putText(0, helpRowScreen, g_settings_descriptions[visibleIndices[selectedOptionIndex]], CBLACK, CWHITE);
         }
         else
         {
@@ -2770,8 +2785,11 @@ int showSettingsMenu(bool calledFromGame)
         putText(1, helpRowScreen + 4, "SD:", CBLACK, CWHITE);
         putText(5, helpRowScreen + 4, line, CBLACK, CWHITE);
 #endif
-        // Suppress row-level highlight for action row; per-word colors handle it
-        int displayRow = (selectedRowLocal == actionRowScreen) ? -1 : selectedRowLocal;
+        // Suppress row-level highlight for action row; per-word colors handle it.
+        // Selected screen row is derived from the logical option index + scroll offset.
+        int displayRow = onActionRow
+                             ? -1
+                             : rowStartOptions + (selectedOptionIndex - firstVisibleOption);
         drawAllLines(displayRow);
     }; // redraw lambda
     // for volume control option: initialize audio stream
@@ -2812,9 +2830,9 @@ int showSettingsMenu(bool calledFromGame)
         }
         bool pushed = pad != 0;
         int optIndex = -1;
-        if (selectedRowLocal >= rowStartOptions && selectedRowLocal < rowStartOptions + visibleCount)
+        if (!onActionRow && selectedOptionIndex >= 0 && selectedOptionIndex < visibleCount)
         {
-            optIndex = visibleIndices[selectedRowLocal - rowStartOptions]; // map screen row to option index
+            optIndex = visibleIndices[selectedOptionIndex];
         }
 #if USE_I2S_AUDIO == PICO_AUDIO_I2S_DRIVER_TLV320 && PICO_RP2350
         if (optIndex == MOPT_FRUITJAM_VOLUME_CONTROL)
@@ -2843,42 +2861,57 @@ int showSettingsMenu(bool calledFromGame)
 
             if (pad & UP)
             {
-                if (selectedRowLocal > rowStartOptions)
+                const int maxFirst = (visibleCount > optionWindowSize)
+                                         ? visibleCount - optionWindowSize
+                                         : 0;
+                if (onActionRow)
                 {
-                    do
+                    // re-enter list at the bottom; scroll so last option is visible
+                    if (visibleCount > 0)
                     {
-                        selectedRowLocal--;
-                        // printf("Selected row: %d\n", selectedRowLocal);
-                    } while (
-                        selectedRowLocal == spacerAfterOptionsRow ||
-                        (selectedRowLocal >= paletteStartRow && selectedRowLocal < paletteStartRow + paletteRowCount));
+                        onActionRow = false;
+                        selectedOptionIndex = visibleCount - 1;
+                        firstVisibleOption = maxFirst;
+                    }
+                }
+                else if (selectedOptionIndex == 0)
+                {
+                    onActionRow = true; // wrap to action row
                 }
                 else
                 {
-                    selectedRowLocal = actionRowScreen; // wrap
+                    selectedOptionIndex--;
+                    if (selectedOptionIndex < firstVisibleOption)
+                        firstVisibleOption = selectedOptionIndex; // scroll up
                 }
             }
             else if (pad & DOWN)
             {
-                if (selectedRowLocal < actionRowScreen)
+                if (onActionRow)
                 {
-                    do
+                    // re-enter list at the top
+                    if (visibleCount > 0)
                     {
-                        selectedRowLocal++;
-                        // printf("Selected row: %d\n", selectedRowLocal);
-                    } while (
-                        selectedRowLocal == spacerAfterOptionsRow ||
-                        (selectedRowLocal >= paletteStartRow && selectedRowLocal < paletteStartRow + paletteRowCount));
+                        onActionRow = false;
+                        selectedOptionIndex = 0;
+                        firstVisibleOption = 0;
+                    }
+                }
+                else if (selectedOptionIndex == visibleCount - 1)
+                {
+                    onActionRow = true; // wrap to action row
                 }
                 else
                 {
-                    selectedRowLocal = rowStartOptions; // wrap
+                    selectedOptionIndex++;
+                    if (selectedOptionIndex >= firstVisibleOption + optionWindowSize)
+                        firstVisibleOption = selectedOptionIndex - optionWindowSize + 1; // scroll down
                 }
             }
             else if (pad & LEFT || pad & RIGHT || ((pad & A) && (optIndex == MOPT_EXIT_GAME || optIndex == MOPT_SAVE_RESTORE_STATE || optIndex == MOPT_ENTER_BOOTSEL_MODE || optIndex == MOPT_RESET_GAME || optIndex == MOPT_FDS_DISK_SWAP)))
             {
                 // LEFT/RIGHT on the action row cycles sub-selection
-                if (selectedRowLocal == actionRowScreen && (pad & (LEFT | RIGHT)))
+                if (onActionRow && (pad & (LEFT | RIGHT)))
                 {
                     if (pad & RIGHT)
                         actionSubSelect = (actionSubSelect + 1) % 3;
@@ -2891,7 +2924,6 @@ int showSettingsMenu(bool calledFromGame)
                     {
                        reset_usb_boot(0, 0);
                     }
-                    // int optIndex = visibleIndices[selectedRowLocal - rowStartOptions]; // map screen row to option index
                     bool right = pad & RIGHT;
                     switch (optIndex)
                     {
@@ -3140,7 +3172,7 @@ int showSettingsMenu(bool calledFromGame)
             }
             else if (pad & A)
             {
-                if (selectedRowLocal == actionRowScreen)
+                if (onActionRow)
                 {
                     switch (actionSubSelect)
                     {

--- a/menu.cpp
+++ b/menu.cpp
@@ -2333,7 +2333,7 @@ int showSettingsMenu(bool calledFromGame)
     //   helpRowScreen (option description),
     //   ... free ...,
     //   bottom-anchored hint lines at SCREEN_ROWS-3 .. SCREEN_ROWS-1.
-    const int optionWindowSize  = 10;
+    const int optionWindowSize  = 12;
     const int rowStartOptions   = 3;
     const int upIndicatorRow    = rowStartOptions - 1;
     const int downIndicatorRow  = rowStartOptions + optionWindowSize;

--- a/menu.cpp
+++ b/menu.cpp
@@ -2519,6 +2519,12 @@ int showSettingsMenu(bool calledFromGame)
                 value = working.flags.enableVUMeter ? "ON" : "OFF";
                 break;
             }
+            case MenuSettingsIndex::MOPT_OVERCLOCK:
+            {
+                label = "Overclock";
+                value = working.flags.overclock ? "ON" : "OFF";
+                break;
+            }
             // case MenuSettingsIndex::MOPT_FRUITJAM_INTERNAL_SPEAKER:
             // {
             //     label = "Fruit Jam Internal Speaker";
@@ -3048,6 +3054,9 @@ int showSettingsMenu(bool calledFromGame)
                     case MOPT_FRUITJAM_VUMETER:
                         working.flags.enableVUMeter = !working.flags.enableVUMeter;
                         break;
+                    case MOPT_OVERCLOCK:
+                        working.flags.overclock = !working.flags.overclock;
+                        break;
                     case MOPT_DMG_PALETTE:
                     {
                         if (right)
@@ -3215,6 +3224,18 @@ int showSettingsMenu(bool calledFromGame)
         settings = working;
         FrensSettings::savesettings();
         if (rval == 0) rval = 1;
+
+        // If the overclock toggle disagrees with the live clock, rewrite
+        // FlashParams and reboot. writeFlashParamsToFlash arms the watchdog
+        // and never returns.
+        uint32_t liveKHz   = clock_get_hz(clk_sys) / 1000;
+        uint32_t targetKHz = settings.flags.overclock ? FLASHPARAM_MAX_FREQ_KHZ : FLASHPARAM_MIN_FREQ_KHZ;
+        vreg_voltage targetV = settings.flags.overclock ? FLASHPARAM_MAX_VOLTAGE : FLASHPARAM_MIN_VOLTAGE;
+        if (liveKHz != targetKHz)
+        {
+            showLoadingScreen(settings.flags.overclock ? "Enabling overclock" : "Disabling overclock", 60);
+            Frens::writeFlashParamsToFlash(targetKHz, targetV);
+        }
     }
     Frens::f_free(workingDyn);
     // restore contents of swap file back to altScreenbuffer when not nullptr
@@ -3361,8 +3382,10 @@ void menu(const char *title, char *errorMessage, bool isFatal, bool showSplash, 
 // artifacts. Skip the auto-switch in that case; the .sgx ROM still loads and
 // runs at the build's default 252 MHz (slower on the heavier titles but clean).
 #if (HSTX && SGX && CFG_TUH_RPI_PIO_USB)
-        if (selectedRomOrFolder && entries[index].IsDirectory == false && oldIndex != index)
-        {        
+        // Skip per-ROM auto-switch when user explicitly locked overclock on:
+        // the system stays at FLASHPARAM_MAX_FREQ_KHZ for every ROM.
+        if (!settings.flags.overclock && selectedRomOrFolder && entries[index].IsDirectory == false && oldIndex != index)
+        {
             oldIndex = index;
             if ( strncasecmp(fileExt, ".sgx", 4) == 0)
             {
@@ -3408,8 +3431,8 @@ void menu(const char *title, char *errorMessage, bool isFatal, bool showSplash, 
             // printf(" Current clock freq: %d kHz\n", (unsigned int)clockFreq);
             if (FrensSettings::getEmulatorType() == FrensSettings::emulators::GENESIS && !isWav)
             {
-
-                if (clockFreq != FLASHPARAM_MAX_FREQ_KHZ)
+                // Skip clock switch when user locked overclock on (stay at MAX).
+                if (!settings.flags.overclock && clockFreq != FLASHPARAM_MAX_FREQ_KHZ)
                 {
                     char message[40];
                     snprintf(message, sizeof(message), "Setting clock to  %dMHZ", FLASHPARAM_MAX_FREQ_KHZ /1000);
@@ -3423,7 +3446,8 @@ void menu(const char *title, char *errorMessage, bool isFatal, bool showSplash, 
             }
             else
             {
-                if (clockFreq != FLASHPARAM_MIN_FREQ_KHZ)
+                // Skip clock switch when user locked overclock on (stay at MAX).
+                if (!settings.flags.overclock && clockFreq != FLASHPARAM_MIN_FREQ_KHZ)
                 {
                     char message[40];
                     snprintf(message, sizeof(message), "Setting clock to  %dMHZ", FLASHPARAM_MIN_FREQ_KHZ /1000);

--- a/menu_settings.h
+++ b/menu_settings.h
@@ -27,8 +27,9 @@ enum MenuSettingsIndex {
     MOPT_RAPID_FIRE_ON_B,
     MOPT_AUTO_INSERT_FDS_DISK_A, // Auto-insert disk side A at boot (On) or wait for user A press (Off)
     MOPT_AUTO_SWAP_FDS_DISK, // New menu option for automatically swapping FDS disk sides when loading a .fds file
-    MOPT_ENTER_BOOTSEL_MODE,
     MOPT_FDS_DISK_SWAP,
+    MOPT_OVERCLOCK,
+    MOPT_ENTER_BOOTSEL_MODE, // Keep last so BOOTSEL is the final entry in the settings list
     MOPT_COUNT
 };
 // Create and initialize an array which explains each option in a short description of max 40 characters
@@ -55,8 +56,9 @@ const char* const g_settings_descriptions[MOPT_COUNT] = {
     "Enable rapid fire for this button",
     "Insert disk at boot or stay in BIOS",
     "Auto swap disk side when game asks",
-    "Reboot to BOOTSEL mode for flashing",
-    "Eject / insert FDS disk side"
+    "Eject / insert FDS disk side",
+    "Run CPU at high clock (reboots to apply)",
+    "Reboot to BOOTSEL mode for flashing"
 };
 
 extern const int8_t *g_settings_visibility; // Visibility configuration for options menu

--- a/settings.cpp
+++ b/settings.cpp
@@ -96,6 +96,7 @@ namespace FrensSettings
         printf("useDVIModeForHDMI: %d\n", settings.flags.useDVIModeForHDMI);
         printf("autoSwapFDS: %d\n", settings.flags.autoSwapFDS);
         printf("autoInsertDiskA: %d\n", settings.flags.autoInsertDiskA);
+        printf("overclock: %d\n", settings.flags.overclock);
         printf("\n");
     }
     void resetsettings(struct settings *settingsPtr)
@@ -125,8 +126,7 @@ namespace FrensSettings
         settings.version = SETTINGS_VERSION;
         settings.flags.autoSwapFDS = 0;
         settings.flags.autoInsertDiskA = 1; // default: disk side A pre-inserted at boot
-        // clear all the reserved settings
-        settings.flags.reserved = 0;
+        settings.flags.overclock = 0; // default: run at FLASHPARAM_MIN_FREQ_KHZ
         strcpy(settings.currentDir, "/");
     }
 

--- a/settings.h
+++ b/settings.h
@@ -6,7 +6,7 @@
 
 
 extern struct settings settings;
-#define SETTINGS_VERSION 112
+#define SETTINGS_VERSION 113
 
 struct settings
 {
@@ -38,7 +38,7 @@ struct settings
         unsigned short useDVIModeForHDMI : 1;      // 1 = use DVI mode for HDMI output (lower latency, but no audio), 0 = use HDMI mode (required for audio, but slightly higher latency)
         unsigned short autoSwapFDS : 1;      // 1 = automatically swap FDS disk sides when loading a .fds file, 0 = do not auto swap (user must manually select "FDS Disk Swap" in settings menu to swap sides). Default to on, because it's less confusing for users if the correct disk side is automatically loaded.
         unsigned short autoInsertDiskA : 1;  // 1 = disk side A is pre-inserted at boot, 0 = disk starts ejected (user presses A to insert, allowing BIOS Mario/Luigi animation to play)
-        unsigned short reserved : 1;         // keep struct size the same
+        unsigned short overclock : 1;        // 1 = boot/run at FLASHPARAM_MAX_FREQ_KHZ, 0 = FLASHPARAM_MIN_FREQ_KHZ
     } flags; // Total 16 bits
    
 };


### PR DESCRIPTION
This pull request introduces a scrollable window for the settings menu options and adds a new persistent "Overclock" option to the settings, allowing users to toggle CPU overclocking from the menu. The menu navigation logic has been refactored to support scrolling through a larger list of options, and the overclock setting now persists across ROMs and reboots, with safeguards to avoid unintended state loss.

**Settings Menu Usability Improvements:**

* Refactored the settings menu to use a scrollable window for options, supporting up/down indicators and navigation through large option lists; replaced row-based selection logic with logical option indices for improved clarity and maintainability. [[1]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L2323-R2349) [[2]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L2359-R2377) [[3]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L2649-R2676) [[4]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L2709-R2738) [[5]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L2773-R2801) [[6]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L2815-R2844) [[7]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L2846-R2923)
* Updated menu rendering and help text logic to align with the new scrollable option window and logical selection model. [[1]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L2671-R2696) [[2]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L2736-R2760) [[3]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L2746-R2772)

**Overclock Option Addition:**

* Added a new `MOPT_OVERCLOCK` option to the settings menu, allowing users to toggle CPU overclocking; this option is only accessible from the file-browser menu to prevent mid-game state loss. [[1]](diffhunk://#diff-00942d15d2efd75e38630de1594be8470880d55ce6fc00a8315a508a1a832d1eL30-R32) [[2]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79R2314-R2316) [[3]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79R2525-R2530) [[4]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79R3060-R3062) [[5]](diffhunk://#diff-00942d15d2efd75e38630de1594be8470880d55ce6fc00a8315a508a1a832d1eL58-R61)
* When the overclock setting is changed, the system writes new flash parameters and triggers a reboot to apply the change, ensuring the setting is persistent and safe.

**ROM Loading and Clock Management:**

* Modified ROM loading logic to respect the persistent overclock setting: when overclock is locked on, the system skips per-ROM clock switching and always runs at maximum frequency. [[1]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L3332-R3390) [[2]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L3379-R3438) [[3]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L3394-R3453)