### PR TITLE
pico_hdmi: IEC 60958 channel status, DI push barrier, fixed-address ring

### DIFF
--- a/drivers/pico_hdmi/hstx.c
+++ b/drivers/pico_hdmi/hstx.c
@@ -286,7 +286,11 @@ void __not_in_flash_func(hstx_push_audio_sample)(const int left, const int right
             return;
         }
         hstx_packet_t packet;
-        g_hdmi_audio_frame_counter = hstx_packet_set_audio_samples(&packet, acc_buf, 4, g_hdmi_audio_frame_counter);
+        // _cs variant: carries IEC 60958 channel status with a valid
+        // sample-frequency code. Strict HDMI sinks mute all-zero channel
+        // status even with a correct Audio InfoFrame; lax sinks (capture
+        // cards) decode it but with glitches.
+        g_hdmi_audio_frame_counter = hstx_packet_set_audio_samples_cs(&packet, acc_buf, 4, g_hdmi_audio_frame_counter);
 
         hstx_data_island_t island;
         hstx_encode_data_island(&island, &packet, false, true);

--- a/drivers/pico_hdmi/hstx_data_island_queue.c
+++ b/drivers/pico_hdmi/hstx_data_island_queue.c
@@ -7,10 +7,20 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include "pico.h"
+#include "hardware/sync.h"  // __dmb
 #ifndef DI_RING_BUFFER_SIZE
 #define DI_RING_BUFFER_SIZE 256
 #endif
-static hstx_data_island_t *di_ring_buffer = NULL; // [DI_RING_BUFFER_SIZE];
+// HSTX_DI_RING_ADDRESS lets the caller point the ring at a specific static
+// SRAM address. fruitjam-doom uses this to place the ring above the top of
+// its shortptr zone (SHORTPTR_BASE + 0x40000 = 0x20076000), reclaiming the
+// 36 KB the malloc path would otherwise steal from Doom's heap. When unset,
+// the driver falls back to its historical malloc-on-first-init behaviour.
+#ifdef HSTX_DI_RING_ADDRESS
+static hstx_data_island_t *const di_ring_buffer = (hstx_data_island_t *)(HSTX_DI_RING_ADDRESS);
+#else
+static hstx_data_island_t *di_ring_buffer = NULL; // [DI_RING_BUFFER_SIZE]
+#endif
 static volatile uint32_t di_ring_head = 0;
 static volatile uint32_t di_ring_tail = 0;
 
@@ -34,15 +44,24 @@ void hstx_di_queue_init(void)
     di_ring_head = 0;
     di_ring_tail = 0;
     audio_sample_accum = 0;
-    // Allocate memory for the ring buffer
+    // Allocate memory for the ring buffer (skipped when the address was
+    // pinned at compile time via HSTX_DI_RING_ADDRESS).
+#ifdef HSTX_DI_RING_ADDRESS
+    printf("HSTX DI ring buffer at fixed %p (%u bytes)\n",
+           (void *)di_ring_buffer,
+           (unsigned)(DI_RING_BUFFER_SIZE * sizeof(hstx_data_island_t)));
+#else
     if (di_ring_buffer == NULL) {
         printf("Allocating memory for HSTX DI ring buffer: %d bytes\n", DI_RING_BUFFER_SIZE * sizeof(hstx_data_island_t));
         di_ring_buffer = (hstx_data_island_t *)malloc(DI_RING_BUFFER_SIZE * sizeof(hstx_data_island_t));
     }
-    // Build a single silent audio packet with fixed B-frame flags.
+#endif
+    // Build a single silent audio packet. frame_count=4 (NOT 0): frame 0
+    // would set the IEC 60958 block-start B flag, so every underrun
+    // insertion would reset the sink's channel-status block sync mid-stream.
     hstx_packet_t packet;
     audio_sample_t samples[4] = {0};
-    (void)hstx_packet_set_audio_samples(&packet, samples, 4, 0);
+    (void)hstx_packet_set_audio_samples(&packet, samples, 4, 4);
     hstx_encode_data_island(&silence_packet, &packet, false, true);
 }
 
@@ -64,6 +83,9 @@ bool __not_in_flash_func(hstx_di_queue_push)(const hstx_data_island_t *island)
     const uint32_t *src = island->words;
     for (size_t i = 0; i < count_of(island->words); i++)
         dst[i] = src[i];
+    // Publish payload before head: the consumer (DMA IRQ on the other core)
+    // must never observe the head advance ahead of the payload words.
+    __dmb();
     di_ring_head = next_head;
     return true;
 }

--- a/drivers/pico_hdmi/hstx_packet.c
+++ b/drivers/pico_hdmi/hstx_packet.c
@@ -204,6 +204,80 @@ void hstx_packet_set_avi_infoframe(hstx_packet_t *packet, uint8_t vic, uint8_t p
     compute_all_parity(packet);
 }
 
+// IEC 60958-3 channel status bytes, one bit per audio frame across the
+// 192-frame block: byte 0 = 0x04 (consumer, L-PCM, copy permitted), byte 3 =
+// sample-frequency code (bits 24-27). Bytes 5..23 are zero, which IEC 60958
+// treats as valid consumer defaults, so only the first 5 bytes are stored.
+// Mutable so hstx_packet_set_cs_sample_rate can retarget the rate code; lives
+// in .data (RAM), safe to read from the not-in-flash encode path.
+static uint8_t cs_bytes[5] = {0x04, 0x00, 0x00, 0x02 /* 48 kHz */, 0x00};
+
+void hstx_packet_set_cs_sample_rate(uint32_t sample_rate)
+{
+    // Sample-frequency code, IEC 60958-3 bits 24-27 (LSB-first in byte 3):
+    // 44.1 kHz = 0000, 48 kHz = 0100, 32 kHz = 1100.
+    switch (sample_rate) {
+        case 44100: cs_bytes[3] = 0x00; break;
+        case 32000: cs_bytes[3] = 0x03; break;
+        case 48000:
+        default:    cs_bytes[3] = 0x02; break;
+    }
+}
+
+static inline int channel_status_bit(int frame)
+{
+    return frame < 40 ? (cs_bytes[frame >> 3] >> (frame & 7)) & 1 : 0;
+}
+
+int __not_in_flash_func(hstx_packet_set_audio_samples_cs)(hstx_packet_t *packet,
+                                                          const audio_sample_t *samples,
+                                                          int num_samples,
+                                                          int frame_count)
+{
+    hstx_packet_init(packet);
+    if (num_samples < 1) num_samples = 1;
+    if (num_samples > 4) num_samples = 4;
+
+    uint8_t sample_present = (1 << num_samples) - 1;
+    uint8_t b_flags = 0;
+    int temp_frame_count = frame_count;
+    for (int i = 0; i < num_samples; i++) {
+        if (temp_frame_count == 0) b_flags |= (1 << i);
+        temp_frame_count = (temp_frame_count + 1) % 192;
+    }
+
+    packet->header[0] = 0x02;
+    packet->header[1] = sample_present;
+    packet->header[2] = b_flags << 4;
+    compute_header_parity(packet);
+
+    int fc = frame_count;
+    for (int i = 0; i < num_samples; i++) {
+        uint8_t *d = packet->subpacket[i];
+        int16_t left = samples[i].left;
+        int16_t right = samples[i].right;
+        int c = channel_status_bit(fc);
+        fc = (fc + 1) % 192;
+
+        d[0] = 0x00;
+        d[1] = left & 0xFF;
+        d[2] = (left >> 8) & 0xFF;
+        d[3] = 0x00;
+        d[4] = right & 0xFF;
+        d[5] = (right >> 8) & 0xFF;
+
+        // Parity covers the 24-bit sample plus V, U, C bits (V=U=0 here).
+        int p_left = (int)compute_parity3(d[1], d[2], 0) ^ c;
+        int p_right = (int)compute_parity3(d[4], d[5], 0) ^ c;
+
+        // Byte 6 layout: VL UL CL PL VR UR CR PR (bits 0..7).
+        d[6] = (uint8_t)((c << 2) | (p_left << 3) | (c << 6) | (p_right << 7));
+        compute_subpacket_parity(packet, i);
+    }
+
+    return temp_frame_count;
+}
+
 int __not_in_flash_func(hstx_packet_set_audio_samples)(hstx_packet_t *packet, const audio_sample_t *samples, int num_samples,
                                   int frame_count)
 {

--- a/drivers/pico_hdmi/hstx_packet.h
+++ b/drivers/pico_hdmi/hstx_packet.h
@@ -41,6 +41,21 @@ void hstx_packet_set_audio_infoframe(hstx_packet_t *packet, uint32_t sample_rate
 void hstx_packet_set_avi_infoframe(hstx_packet_t *packet, uint8_t vic, uint8_t pixel_repetition);
 int hstx_packet_set_audio_samples(hstx_packet_t *packet, const audio_sample_t *samples, int num_samples,
                                   int frame_count);
+// Same as hstx_packet_set_audio_samples but also writes IEC 60958 channel
+// status bits ("consumer LPCM, copy permitted" + the sample-frequency code
+// set via hstx_packet_set_cs_sample_rate) into the L/R VUCP bytes across the
+// 192-frame block. Strict HDMI receivers (many monitors/TVs) mute streams
+// whose channel status is all-zero — "sample rate not indicated" — even when
+// the Audio InfoFrame is present; lax sinks decode them with glitches.
+// Found the hard way in fruitjam-doom (2026-07); ported from the standalone
+// pico_hdmi upstream, with the sample-frequency code made configurable.
+int hstx_packet_set_audio_samples_cs(hstx_packet_t *packet, const audio_sample_t *samples, int num_samples,
+                                     int frame_count);
+// Set the IEC 60958 channel-status sample-frequency code used by
+// hstx_packet_set_audio_samples_cs. Supported: 32000, 44100, 48000 Hz
+// (anything else falls back to the 48 kHz code). Called automatically by
+// pico_hdmi_set_audio_sample_rate via configure_audio_packets.
+void hstx_packet_set_cs_sample_rate(uint32_t sample_rate);
 void hstx_packet_set_null(hstx_packet_t *packet);
 
 // ============================================================================

--- a/drivers/pico_hdmi/video_output.c
+++ b/drivers/pico_hdmi/video_output.c
@@ -504,6 +504,10 @@ static void configure_audio_packets(uint32_t sample_rate)
 {
     configured_audio_sample_rate = sample_rate;
     hstx_di_queue_set_sample_rate(sample_rate);
+    // Keep the IEC 60958 channel-status sample-frequency code in lockstep
+    // with ACR and the Audio InfoFrame — strict sinks require all three to
+    // agree with the actual stream rate.
+    hstx_packet_set_cs_sample_rate(sample_rate);
 
     hstx_packet_t packet;
     hstx_data_island_t island;
@@ -823,14 +827,16 @@ void __not_in_flash_func(video_output_core1_run)(void)
             uint32_t d_us = now - rate_last_us;
             uint32_t d_frames = current_count - rate_last_frames;
             uint32_t d_irqs = irq_count - rate_last_irqs;
-            printf("video rate: %lu frames/s, %lu irqs/s (dvi=%d) clk_sys=%lu clk_hstx=%lu csr=%08lx resync=%d\n",
+            printf("video rate: %lu frames/s, %lu irqs/s (dvi=%d) clk_sys=%lu clk_hstx=%lu csr=%08lx resync=%d di_lvl=%lu underrun=%lu\n",
                    (unsigned long)((uint64_t)d_frames * 1000000u / d_us),
                    (unsigned long)((uint64_t)d_irqs * 1000000u / d_us),
                    dvi_mode ? 1 : 0,
                    (unsigned long)clock_get_hz(clk_sys),
                    (unsigned long)clock_get_hz(clk_hstx),
                    (unsigned long)hstx_ctrl_hw->csr,
-                   resync_count);
+                   resync_count,
+                   (unsigned long)hstx_di_queue_get_level(),
+                   (unsigned long)hstx_di_queue_get_underrun_count());
             printf("  hstx_div=%08lx exp_sh=%08lx exp_tmds=%08lx ping_ctrl=%08lx pong_ctrl=%08lx\n",
                    (unsigned long)clocks_hw->clk[clk_hstx].div,
                    (unsigned long)hstx_ctrl_hw->expand_shift,


### PR DESCRIPTION
Fixes found while bringing HDMI audio up in fruitjam-doom, mirrored here so all pico_shared consumers benefit:

- hstx_packet_set_audio_samples_cs: audio sample packets now carry IEC 60958 channel status (consumer LPCM + sample-frequency code). Strict HDMI sinks (many monitors/TVs) mute streams with all-zero channel status even when the Audio InfoFrame is correct; lax sinks (capture cards) decode them with glitches. The sample-frequency code follows the configured rate (32/44.1/48 kHz) via hstx_packet_set_cs_sample_rate, wired into configure_audio_packets so ACR, Audio InfoFrame and channel status always agree. hstx_push_audio_sample now uses the _cs variant.

- Silence packet built with frame_count=4 instead of 0: frame 0 sets the IEC block-start B flag, so every underrun insertion reset the sink's channel-status block sync mid-stream.

- __dmb() in hstx_di_queue_push between the payload copy and the head publish: the consumer (DMA IRQ on the other core) must never observe the head advance before the payload words land.

- Optional HSTX_DI_RING_ADDRESS compile definition pins the DI ring at a fixed SRAM address instead of malloc (fruitjam-doom uses this to place the 36 KB ring in the gap above its zone allocator). Unset = the historical malloc-on-first-init behaviour.

- HSTX_DEBUG 1 Hz dump now includes DI queue level and underrun count - the underrun growth rate is the key diagnostic for audio static/tempo problems (fruitjam-doom saw ~2400/s with an 8 ms effective buffer).