### PR TITLE
Enhance bootloader and emulator support with multi-slot features

### DIFF
--- a/BoardConfigs.cmake
+++ b/BoardConfigs.cmake
@@ -40,6 +40,7 @@ set(BOARD pico_sdk)
 if (NOT DEFINED FORCE_DVI)
     set(FORCE_DVI 0 CACHE BOOL "Set to 1 to force DVI output instead of HSTX when available")
 endif()
+list(APPEND PICO_BOARD_HEADER_DIRS ${CMAKE_SOURCE_DIR}/pico_shared/boards)
 if ( HW_CONFIG EQUAL 1 )
 	# This default Config is for Pimoroni Pico DV Demo Base, note uart is disabled because gpio 1 is used for NES controller
 	set(DVICONFIG "dviConfig_PimoroniDemoDVSock" CACHE STRING

--- a/BoardConfigs.cmake
+++ b/BoardConfigs.cmake
@@ -267,6 +267,7 @@ elseif ( HW_CONFIG EQUAL 7 )
     # --------------------------------------------------------------------
 	# WaveShare RP2350-PiZero
 	# --------------------------------------------------------------------
+    set(PICO_BOARD "waveshare_rp2350_pizero" CACHE STRING "Select the board type for TinyUSB")
 	set(DVICONFIG "dviConfig_WaveShareRp2350" CACHE STRING
     "Select a default pin configuration from common_dvi_pin_configs.h")
     set(LED_GPIO_PIN "-1" CACHE STRING "Select the GPIO pin for LED")  

--- a/BoardConfigs.cmake
+++ b/BoardConfigs.cmake
@@ -267,7 +267,7 @@ elseif ( HW_CONFIG EQUAL 7 )
     # --------------------------------------------------------------------
 	# WaveShare RP2350-PiZero
 	# --------------------------------------------------------------------
-    set(PICO_BOARD "waveshare_rp2350_pizero" CACHE STRING "Select the board type for TinyUSB")
+    set(PICO_BOARD "waveshare_rp2350_pizero" CACHE STRING "Select the board type")
 	set(DVICONFIG "dviConfig_WaveShareRp2350" CACHE STRING
     "Select a default pin configuration from common_dvi_pin_configs.h")
     set(LED_GPIO_PIN "-1" CACHE STRING "Select the GPIO pin for LED")  

--- a/BoardConfigs.cmake
+++ b/BoardConfigs.cmake
@@ -108,6 +108,7 @@ elseif ( HW_CONFIG EQUAL 2 )
     set(PICO_AUDIO_I2S_CLOCK_PINS_SWAPPED 0 CACHE STRING "Set to 1 if the I2S clock pins are swapped")
     set(PICO_AUDIO_I2S_RESET_PIN -1 CACHE STRING "Select the GPIO pin for I2S reset")
     # PIO USB settings
+    # set(ENABLE_PIO_USB 1 CACHE BOOL "Enable PIO USB support")
     set(PIO_USB_USE_PIO 2 CACHE BOOL "Select the PIO used for PIO-USB")
     # connect the DP+ pin to GPIO 20, DP- will be GPIO 21
     set(PIO_DP_PLUS_PIN 20 CACHE STRING "PIO USB DP pin.")

--- a/BootPartition.cmake
+++ b/BootPartition.cmake
@@ -15,10 +15,10 @@
 #
 #   0x10000000  +-----------------------------+  <- bootrom always boots this
 #               |   Bootloader (emuLoader)    |     image (the menu/flasher).
-#               |        1 MB                  |
-#   0x10100000  +-----------------------------+  <- FRENS_APP_BASE
+#               |        512 KB               |
+#   0x10080000  +-----------------------------+  <- FRENS_APP_BASE
 #               |   Application partition      |     emulator UF2s land here.
-#               |        15 MB                 |     the bootloader jumps here.
+#               |        15.5 MB              |     the bootloader jumps here.
 #   0x11000000  +-----------------------------+
 #
 # Override on the command line for other boards, e.g.:
@@ -30,7 +30,7 @@ endif()
 set(_FRENS_BOOTPARTITION_INCLUDED 1)
 
 set(FRENS_XIP_BASE        "0x10000000" CACHE STRING "RP2350 XIP flash base")
-set(FRENS_BOOTLOADER_SIZE "0x100000"   CACHE STRING "Bytes reserved for the resident bootloader (1 MB)")
+set(FRENS_BOOTLOADER_SIZE "0x80000"    CACHE STRING "Bytes reserved for the resident bootloader (512 KB)")
 set(FRENS_FLASH_TOTAL     "0x1000000"  CACHE STRING "Total external flash on the board (Fruit Jam = 16 MB)")
 
 # Slot layout for the multi-slot ("hybrid") bootloader. The bootloader scans
@@ -40,7 +40,7 @@ set(FRENS_FLASH_TOTAL     "0x1000000"  CACHE STRING "Total external flash on the
 # partition. Constants here are also passed as compile defs to boot_config.h
 # so the C scanner and the linker agree.
 set(FRENS_SLOT_SIZE  "0x200000" CACHE STRING "Size of each pinned slot (2 MB)")
-set(FRENS_SLOT_COUNT "7"        CACHE STRING "Number of pinned slots (7 fit in 14 MB after 1 MB bootloader; top 1 MB reserved)")
+set(FRENS_SLOT_COUNT "7"        CACHE STRING "Number of pinned slots (7 fit in 14 MB after 512 KB bootloader; top 1.5 MB reserved)")
 
 # Derived addresses.
 math(EXPR FRENS_APP_BASE "${FRENS_XIP_BASE} + ${FRENS_BOOTLOADER_SIZE}" OUTPUT_FORMAT HEXADECIMAL)
@@ -122,7 +122,7 @@ function(frens_link_as_bootloader TARGET)
 endfunction()
 
 # Link an emulator into the application partition (legacy single-partition /
-# slot 0). Same address (FRENS_APP_BASE = 0x10100000); the bootloader writes
+# slot 0). Same address (FRENS_APP_BASE = 0x10080000); the bootloader writes
 # the resulting UF2 verbatim and either flashes-on-launch (legacy boards) or
 # treats it as pinned slot 0 (slot-mode boards).
 function(frens_offset_for_bootloader TARGET)

--- a/BootPartition.cmake
+++ b/BootPartition.cmake
@@ -105,6 +105,15 @@ function(_frens_relink_flash TARGET ORIGIN LENGTH)
     file(WRITE "${_out_ld}" "${_ld_text}")
     message(STATUS "BootPartition: ${TARGET} -> ORIGIN=${ORIGIN} LENGTH=${LENGTH} (from ${_src_ld})")
     pico_set_linker_script(${TARGET} "${_out_ld}")
+
+    # Override the SDK's compile-time flash-size assumption to match the actual
+    # chip. The board header (e.g. adafruit_fruit_jam.h) may set PICO_FLASH_SIZE_BYTES
+    # to a value smaller than the real flash (e.g. 8 MB on a 16 MB board), which
+    # makes hard_assert in flash_range_erase / flash_range_program panic when the
+    # bootloader or an emulator writes at higher offsets (e.g. slot 4 at 9 MB).
+    # FRENS_FLASH_TOTAL is the single source of truth here.
+    target_compile_definitions(${TARGET} PRIVATE
+        PICO_FLASH_SIZE_BYTES=${FRENS_FLASH_TOTAL})
 endfunction()
 
 # Link the bootloader into the reserved boot region at the start of flash.

--- a/BootPartition.cmake
+++ b/BootPartition.cmake
@@ -73,8 +73,19 @@ function(_frens_relink_flash TARGET ORIGIN LENGTH)
     endif()
 
     file(READ "${_src_ld}" _ld_text)
+
+    # Newer SDKs pull the FLASH region in from a generated pico_flash_region.ld
+    # (which carries the board's full flash size). Replace that INCLUDE with an
+    # explicit, capped FLASH region so the bootloader / app partition can never
+    # overlap and the linker errors if an image overflows its slot.
+    string(REPLACE
+        "INCLUDE \"pico_flash_region.ld\""
+        "FLASH(rx) : ORIGIN = ${ORIGIN}, LENGTH = ${LENGTH}"
+        _ld_text "${_ld_text}")
+    # Older SDKs spell the region out inline; rewrite that form too (idempotent
+    # if the INCLUDE replacement above already produced this line).
     string(REGEX REPLACE
-        "FLASH\\(rx\\)[^\n]*"
+        "FLASH\\(rx\\)[ \t]*:[^\n]*"
         "FLASH(rx) : ORIGIN = ${ORIGIN}, LENGTH = ${LENGTH}"
         _ld_text "${_ld_text}")
 

--- a/BootPartition.cmake
+++ b/BootPartition.cmake
@@ -33,9 +33,21 @@ set(FRENS_XIP_BASE        "0x10000000" CACHE STRING "RP2350 XIP flash base")
 set(FRENS_BOOTLOADER_SIZE "0x100000"   CACHE STRING "Bytes reserved for the resident bootloader (1 MB)")
 set(FRENS_FLASH_TOTAL     "0x1000000"  CACHE STRING "Total external flash on the board (Fruit Jam = 16 MB)")
 
+# Slot layout for the multi-slot ("hybrid") bootloader. The bootloader scans
+# slots 0..(FRENS_SLOT_COUNT-1) at boot when it detects a board with PSRAM +
+# >= 16 MB flash; on legacy boards it ignores the slot constants and the same
+# emulator UF2 (linked to slot 0 == FRENS_APP_BASE) doubles as the single live
+# partition. Constants here are also passed as compile defs to boot_config.h
+# so the C scanner and the linker agree.
+set(FRENS_SLOT_SIZE  "0x200000" CACHE STRING "Size of each pinned slot (2 MB)")
+set(FRENS_SLOT_COUNT "7"        CACHE STRING "Number of pinned slots (7 fit in 14 MB after 1 MB bootloader; top 1 MB reserved)")
+
 # Derived addresses.
 math(EXPR FRENS_APP_BASE "${FRENS_XIP_BASE} + ${FRENS_BOOTLOADER_SIZE}" OUTPUT_FORMAT HEXADECIMAL)
 math(EXPR FRENS_APP_SIZE  "${FRENS_FLASH_TOTAL} - ${FRENS_BOOTLOADER_SIZE}" OUTPUT_FORMAT HEXADECIMAL)
+# Slot 0's base is exactly FRENS_APP_BASE: same address as the legacy single
+# partition, so an emulator built with frens_offset_for_bootloader() (no slot
+# index) IS a valid slot-0 UF2 -- no rebuild needed.
 
 # ---------------------------------------------------------------------------
 # _frens_relink_flash(<target> <origin_hex> <length_hex>)
@@ -100,8 +112,27 @@ function(frens_link_as_bootloader TARGET)
     _frens_relink_flash(${TARGET} ${FRENS_XIP_BASE} ${FRENS_BOOTLOADER_SIZE})
 endfunction()
 
-# Link an emulator into the application partition (its UF2 will then target the
-# partition, and the bootloader writes it verbatim and jumps there).
+# Link an emulator into the application partition (legacy single-partition /
+# slot 0). Same address (FRENS_APP_BASE = 0x10100000); the bootloader writes
+# the resulting UF2 verbatim and either flashes-on-launch (legacy boards) or
+# treats it as pinned slot 0 (slot-mode boards).
 function(frens_offset_for_bootloader TARGET)
     _frens_relink_flash(${TARGET} ${FRENS_APP_BASE} ${FRENS_APP_SIZE})
+endfunction()
+
+# Link an emulator into a specific pinned slot (slot-mode boards only).
+# Slot N origin = FRENS_APP_BASE + N * FRENS_SLOT_SIZE; capped LENGTH so the
+# linker errors if the image overflows the slot rather than corrupting the
+# next one. Slot 0 alias-resolves to the legacy single-partition layout above
+# (so it is interchangeable with frens_offset_for_bootloader).
+function(frens_link_to_pinned_slot TARGET SLOT_INDEX)
+    if(SLOT_INDEX LESS 0 OR SLOT_INDEX GREATER_EQUAL ${FRENS_SLOT_COUNT})
+        message(FATAL_ERROR
+            "frens_link_to_pinned_slot: slot ${SLOT_INDEX} out of range "
+            "[0, ${FRENS_SLOT_COUNT})")
+    endif()
+    math(EXPR _origin
+        "${FRENS_XIP_BASE} + ${FRENS_BOOTLOADER_SIZE} + ${FRENS_SLOT_SIZE} * ${SLOT_INDEX}"
+        OUTPUT_FORMAT HEXADECIMAL)
+    _frens_relink_flash(${TARGET} ${_origin} ${FRENS_SLOT_SIZE})
 endfunction()

--- a/BootPartition.cmake
+++ b/BootPartition.cmake
@@ -1,0 +1,96 @@
+# BootPartition.cmake - Shared flash memory map for the emuLoader bootloader.
+#
+# The pico_emuLoader bootloader lives at the very start of flash and stays
+# resident; emulators are relinked to run from the application partition right
+# after it, so the bootloader can flash an emulator and jump to it while the
+# bootloader survives every reset / power-cycle.
+#
+# This file is the SINGLE SOURCE OF TRUTH for the map. It is included by:
+#   - the bootloader (pico_emuLoader/CMakeLists.txt) -> frens_link_as_bootloader()
+#   - every emulator built with -DBUILD_FOR_BOOTLOADER=ON -> frens_offset_for_bootloader()
+# and the same numbers are passed to the bootloader's C code (boot_config.h) as
+# compile definitions, so the linker and the loader can never disagree.
+#
+# Flash layout (Adafruit Fruit Jam, 16 MB):
+#
+#   0x10000000  +-----------------------------+  <- bootrom always boots this
+#               |   Bootloader (emuLoader)    |     image (the menu/flasher).
+#               |        1 MB                  |
+#   0x10100000  +-----------------------------+  <- FRENS_APP_BASE
+#               |   Application partition      |     emulator UF2s land here.
+#               |        15 MB                 |     the bootloader jumps here.
+#   0x11000000  +-----------------------------+
+#
+# Override on the command line for other boards, e.g.:
+#   cmake -DFRENS_FLASH_TOTAL=0x800000 ...   # 8 MB board
+
+if(DEFINED _FRENS_BOOTPARTITION_INCLUDED)
+    return()
+endif()
+set(_FRENS_BOOTPARTITION_INCLUDED 1)
+
+set(FRENS_XIP_BASE        "0x10000000" CACHE STRING "RP2350 XIP flash base")
+set(FRENS_BOOTLOADER_SIZE "0x100000"   CACHE STRING "Bytes reserved for the resident bootloader (1 MB)")
+set(FRENS_FLASH_TOTAL     "0x1000000"  CACHE STRING "Total external flash on the board (Fruit Jam = 16 MB)")
+
+# Derived addresses.
+math(EXPR FRENS_APP_BASE "${FRENS_XIP_BASE} + ${FRENS_BOOTLOADER_SIZE}" OUTPUT_FORMAT HEXADECIMAL)
+math(EXPR FRENS_APP_SIZE  "${FRENS_FLASH_TOTAL} - ${FRENS_BOOTLOADER_SIZE}" OUTPUT_FORMAT HEXADECIMAL)
+
+# ---------------------------------------------------------------------------
+# _frens_relink_flash(<target> <origin_hex> <length_hex>)
+#
+# Copy the SDK's default RP2350 memory map and rewrite only the FLASH(rx)
+# ORIGIN/LENGTH line, then point <target> at it. Adapted from the proven
+# rp2350-uf2-bootloader/cmake/patch_memmap.cmake. Keeps us compatible with SDK
+# updates (everything else in the script is untouched).
+#
+# Must be called AFTER the target exists and AFTER pico_sdk_init().
+# ---------------------------------------------------------------------------
+function(_frens_relink_flash TARGET ORIGIN LENGTH)
+    set(_candidates
+        "${PICO_SDK_PATH}/src/rp2_common/pico_crt0/rp2350/memmap_default.ld"
+        "${PICO_SDK_PATH}/src/rp2_common/pico_standard_link/memmap_default.ld"
+    )
+    set(_src_ld "")
+    foreach(_c IN LISTS _candidates)
+        if(EXISTS "${_c}")
+            set(_src_ld "${_c}")
+            break()
+        endif()
+    endforeach()
+    if(_src_ld STREQUAL "")
+        file(GLOB_RECURSE _found
+             "${PICO_SDK_PATH}/src/rp2_common/*rp2350*/memmap_default.ld")
+        if(_found)
+            list(GET _found 0 _src_ld)
+        endif()
+    endif()
+    if(_src_ld STREQUAL "")
+        message(FATAL_ERROR
+            "BootPartition: could not find an RP2350 memmap_default.ld under "
+            "${PICO_SDK_PATH}. Build for the rp2350 platform with SDK >= 2.0.0.")
+    endif()
+
+    file(READ "${_src_ld}" _ld_text)
+    string(REGEX REPLACE
+        "FLASH\\(rx\\)[^\n]*"
+        "FLASH(rx) : ORIGIN = ${ORIGIN}, LENGTH = ${LENGTH}"
+        _ld_text "${_ld_text}")
+
+    set(_out_ld "${CMAKE_CURRENT_BINARY_DIR}/${TARGET}_frens_memmap.ld")
+    file(WRITE "${_out_ld}" "${_ld_text}")
+    message(STATUS "BootPartition: ${TARGET} -> ORIGIN=${ORIGIN} LENGTH=${LENGTH} (from ${_src_ld})")
+    pico_set_linker_script(${TARGET} "${_out_ld}")
+endfunction()
+
+# Link the bootloader into the reserved boot region at the start of flash.
+function(frens_link_as_bootloader TARGET)
+    _frens_relink_flash(${TARGET} ${FRENS_XIP_BASE} ${FRENS_BOOTLOADER_SIZE})
+endfunction()
+
+# Link an emulator into the application partition (its UF2 will then target the
+# partition, and the bootloader writes it verbatim and jumps there).
+function(frens_offset_for_bootloader TARGET)
+    _frens_relink_flash(${TARGET} ${FRENS_APP_BASE} ${FRENS_APP_SIZE})
+endfunction()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,9 +41,16 @@ add_subdirectory(drivers/pico_hdmi)
 target_include_directories(pico_shared INTERFACE
         .
 )
+if (BUILD_FOR_BOOTLOADER)
+     set(BOOTLOADER_BUILD 1)
+else()
+     set(BOOTLOADER_BUILD 0)
+endif()
+
 target_compile_definitions(pico_shared INTERFACE
  NOHSTXCLOCK=1 # Do not set the hstx clock in the pico_hdmi driver, as it is already set FrensHelpers.cpp
  USE_PICO_EXTRAS_I2S=$<BOOL:${USE_PICO_EXTRAS_I2S}>
+ BOOTLOADER_BUILD=${BOOTLOADER_BUILD}
 )
 pico_generate_pio_header(${projectname} ${CMAKE_CURRENT_LIST_DIR}/ws2812.pio)
 target_link_libraries(pico_shared 

--- a/FrensHelpers.cpp
+++ b/FrensHelpers.cpp
@@ -75,6 +75,52 @@ namespace Frens
     static DWORD totalSpace = 0;
     static DWORD freeSpace = 0;
     static bool extSpeakerEnabled = false;
+
+    // pico_emuLoader bootloader handshake. Two watchdog scratch registers
+    // carry one-direction signals between the resident bootloader and the
+    // emulator app it launched. Both survive watchdog_reboot (since
+    // watchdog_reboot(0,0,0) only clobbers scratch[4]) and are cleared by a
+    // cold reset, so the "launched from bootloader" semantic resets correctly
+    // when the user power-cycles or flashes a stand-alone image via BOOTSEL.
+    //
+    //   scratch[6]: bootloader -> emulator. Set to LOADER_LAUNCH_MAGIC by
+    //               main.cpp right before app_launch_run(). Read by
+    //               isLaunchedFromBootloader().
+    //   scratch[7]: emulator -> bootloader. Set to LOADER_RETURN_MAGIC by
+    //               rebootToBootloader() right before watchdog_reboot(). The
+    //               bootloader checks and clears it in its resume path; if
+    //               present, the resume jump is skipped and the picker is
+    //               shown instead.
+    static constexpr uint32_t LOADER_LAUNCH_MAGIC = 0xB007ED01u;
+    static constexpr uint32_t LOADER_RETURN_MAGIC = 0xB007BACEu;
+    static constexpr int LOADER_LAUNCH_SCRATCH = 6;
+    static constexpr int LOADER_RETURN_SCRATCH = 7;
+
+    bool isLaunchedFromBootloader()
+    {
+        return watchdog_hw->scratch[LOADER_LAUNCH_SCRATCH] == LOADER_LAUNCH_MAGIC;
+    }
+
+    void rebootToBootloader()
+    {
+        watchdog_hw->scratch[LOADER_RETURN_SCRATCH] = LOADER_RETURN_MAGIC;
+        watchdog_reboot(0, 0, 0);
+        for (;;) tight_loop_contents();
+    }
+
+    void markLaunchedFromBootloader()
+    {
+        watchdog_hw->scratch[LOADER_LAUNCH_SCRATCH] = LOADER_LAUNCH_MAGIC;
+    }
+
+    bool consumeReturnToBootloaderRequest()
+    {
+        if (watchdog_hw->scratch[LOADER_RETURN_SCRATCH] == LOADER_RETURN_MAGIC) {
+            watchdog_hw->scratch[LOADER_RETURN_SCRATCH] = 0;
+            return true;
+        }
+        return false;
+    }
 #if !HSTX && FRAMEBUFFERISPOSSIBLE
     // uint8_t *framebuffer1; // [320 * 240];
     // uint8_t *framebuffer2; // [320 * 240];

--- a/FrensHelpers.cpp
+++ b/FrensHelpers.cpp
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <cstring>
+#include <malloc.h>
 #include "pico.h"
 #include "pico/stdlib.h"
 #include "pico/multicore.h"
@@ -902,6 +903,38 @@ namespace Frens
         return maxRomSize; // return maxRomSize as a fallback
     }
 
+    /* Snapshot both heaps (libc SRAM + lwmem PSRAM) on one line. Cheap
+     * enough to call at phase boundaries; mallinfo() walks the freelist
+     * but the lists are short on this build. */
+    void dumpHeapStats(const char *tag)
+    {
+        struct mallinfo mi = mallinfo();
+        unsigned sram_inuse  = (unsigned)mi.uordblks;
+        unsigned sram_free   = (unsigned)mi.fordblks;
+        unsigned sram_arena  = (unsigned)mi.arena;
+        unsigned sram_keep   = (unsigned)mi.keepcost; /* largest free contig */
+#if PICO_RP2350 && PSRAM_CS_PIN
+        if (isPsramEnabled())
+        {
+            PicoPlusPsram &psram_ = PicoPlusPsram::getInstance();
+            lwmem_stats_t st;
+            lwmem_get_stats_ex(nullptr, &st);
+            printf("[heap] %-14s SRAM arena=%uK in=%uK free=%uK largest=%uK | "
+                   "PSRAM total=%uK free=%uK minEver=%uK nAlloc=%u nFree=%u\n",
+                   tag,
+                   sram_arena >> 10, sram_inuse >> 10, sram_free >> 10, sram_keep >> 10,
+                   (unsigned)(st.mem_size_bytes >> 10),
+                   (unsigned)(st.mem_available_bytes >> 10),
+                   (unsigned)(st.minimum_ever_mem_available_bytes >> 10),
+                   (unsigned)st.nr_alloc, (unsigned)st.nr_free);
+            return;
+        }
+#endif
+        printf("[heap] %-14s SRAM arena=%uK in=%uK free=%uK largest=%uK | PSRAM disabled\n",
+               tag,
+               sram_arena >> 10, sram_inuse >> 10, sram_free >> 10, sram_keep >> 10);
+    }
+
     void *flashromtoPsram(char *selectdRom, bool swapbytes, uint32_t &crc, int crcOffset)
     {
 #if PICO_RP2350 && PSRAM_CS_PIN
@@ -1542,14 +1575,17 @@ namespace Frens
     bool initAll(char *selectedRom, uint32_t CPUFreqKHz, int marginTop, int marginBottom, size_t audiobufferSize, bool swapbytes, bool useFrameBuffer)
 
     {
+        dumpHeapStats("initAll/enter");
         byteSwapped = swapbytes;
         bool ok = false;
         int rc = initLed();
+        dumpHeapStats("initAll/initLed");
         if (rc != PICO_OK)
         {
             printf("Error initializing LED: %d\n", rc);
         }
        
+        dumpHeapStats("initAll/preInitPsram");
         if (initPsram() == false)
         {
             auto flashcap = storage_get_flash_capacity();
@@ -1580,10 +1616,13 @@ namespace Frens
         // printf("Total flash size: %d bytes (%d Kbytes)\n", cap,cap/ 1024);
         // reset settings to default in case SD card could not be mounted
         FrensSettings::resetsettings();
+        dumpHeapStats("initAll/preInitSD");
         if (initSDCard())
         {
             ok = true;
+            dumpHeapStats("initAll/postInitSD");
             FrensSettings::loadsettings();
+            dumpHeapStats("initAll/postLoadSettings");
             // When a game is started from the menu, the menu will reboot the device.
             // After reboot the emulator will start the selected game.
             // The watchdog timer is used to detect if the reboot was caused by the menu.
@@ -1608,26 +1647,34 @@ namespace Frens
             marginTop = marginBottom = 0; // ignore margins when using framebuffer
         }
 #endif // DVI
+        dumpHeapStats("initAll/preDVandAudio");
         initDVandAudio(marginTop, marginBottom, audiobufferSize);
+        dumpHeapStats("initAll/postDVandAudio");
         // init USB driver
         // USB driver is initalized after display driver to prevent the display driver
         // from using the PIO state machines already claimed by the USB driver.
         // This is only needed for the PIO USB driver.
 #if CFG_TUH_RPI_PIO_USB && PICO_RP2350
         printf("Using PIO USB.\n");
+        dumpHeapStats("initAll/preUSB");
         pio_usb_board_init();
+        dumpHeapStats("initAll/postPioUsbBoard");
         tusb_rhport_init_t host_init = {
             .role = TUSB_ROLE_HOST,
             .speed = TUSB_SPEED_AUTO};
         tusb_init(BOARD_TUH_RHPORT, &host_init);
+        dumpHeapStats("initAll/postTusbInit");
 
         if (board_init_after_tusb)
         {
             board_init_after_tusb();
         }
+        dumpHeapStats("initAll/postBoardAfterTusb");
 #else
         printf("Using internal USB.\n");
+        dumpHeapStats("initAll/preUSB");
         tusb_init();
+        dumpHeapStats("initAll/postTusbInit");
 #endif
 #if !HSTX
         // Add a small stack for core1

--- a/FrensHelpers.cpp
+++ b/FrensHelpers.cpp
@@ -229,16 +229,23 @@ namespace Frens
 #define STORAGE_CMD_DUMMY_BYTES 1
 #define STORAGE_CMD_DATA_BYTES 3
 #define STORAGE_CMD_TOTAL_BYTES (STORAGE_CMD_DUMMY_BYTES + STORAGE_CMD_DATA_BYTES)
-    uint storage_get_flash_capacity()
+uint __not_in_flash_func(storage_get_flash_capacity)()
+{
+    // This function needs to be called before any overclock settings are applied, 
+    // this may crash when PSRAM is also on the board.
+    static uint capacity = 0;
+    if (capacity != 0)
     {
-        uint8_t txbuf[STORAGE_CMD_TOTAL_BYTES] = {0x9f};
-        uint8_t rxbuf[STORAGE_CMD_TOTAL_BYTES] = {0};
-        auto irq = save_and_disable_interrupts();
-        flash_do_cmd(txbuf, rxbuf, STORAGE_CMD_TOTAL_BYTES);
-        restore_interrupts(irq);
-
-        return 1 << rxbuf[3];
+        return capacity;
     }
+    uint8_t txbuf[STORAGE_CMD_TOTAL_BYTES] = {0x9f};
+    uint8_t rxbuf[STORAGE_CMD_TOTAL_BYTES] = {0};
+    auto irq = save_and_disable_interrupts();
+    flash_do_cmd(txbuf, rxbuf, STORAGE_CMD_TOTAL_BYTES);
+    restore_interrupts(irq);
+    capacity = 1 << rxbuf[3];
+    return capacity;
+}
 #if !HSTX
     /// @brief Wait for vertical sync
     void setVSyncWaitTask(void (*task)(void))
@@ -1588,7 +1595,9 @@ namespace Frens
         dumpHeapStats("initAll/preInitPsram");
         if (initPsram() == false)
         {
+            printf("PSRAM not enabled, using flash for rom storage\n");
             auto flashcap = storage_get_flash_capacity();
+            printf("Flash capacity: %d bytes (%d Kbytes)\n", flashcap, flashcap / 1024);
             // Calculate the address in flash where roms will be stored
             printf("Flash binary start    : 0x%08x\n", &__flash_binary_start);
             printf("Flash binary end      : 0x%08x\n", &__flash_binary_end);
@@ -1598,8 +1607,9 @@ namespace Frens
             uint8_t *flash_end = (uint8_t *)&__flash_binary_start + flashcap - 1;
             printf("Flash end             : 0x%08x\n", flash_end);
             printf("Size program in flash :   %8d bytes (%d) Kbytes\n", &__flash_binary_end - &__flash_binary_start, (&__flash_binary_end - &__flash_binary_start) / 1024);
-            // round ROM_FILE_ADDRESS address up to 4k boundary of flash_binary_end
-            ROM_FILE_ADDR = ((uintptr_t)&__flash_binary_end + 0xFFF) & ~0xFFF;
+            // Place ROM one full flash sector above FlashParams so the sector
+            // holding FlashParams is never erased when (re)flashing a ROM.
+            ROM_FILE_ADDR = FLASHPARAM_ADDRESS + FLASH_SECTOR_SIZE;
             // ROM_FILE_ADDR =  0x1004a000;
             //  calculate max rom size
             maxRomSize = flash_end - (uint8_t *)ROM_FILE_ADDR;
@@ -1751,8 +1761,11 @@ namespace Frens
     // Set HSTX clock to 126 MHz if HSTX is used so the HSTX display driver can output at no more than 60Hz
     void setClocksAndStartStdio(uint32_t cpuFreqKHz, vreg_voltage voltage)
     {
+        // Call this function before setting the clock to a higher frequency.
+        // This will ensure that consecutive calls to   storage_get_flash_capacity();
+        // will not crash the board when the clock is set to a higher frequency than the default 125 MHz.
+        storage_get_flash_capacity();
         // Set voltage and clock frequency
-
         vreg_disable_voltage_limit();
         vreg_set_voltage(voltage);
 #if !HSTX

--- a/FrensHelpers.cpp
+++ b/FrensHelpers.cpp
@@ -1707,7 +1707,7 @@ namespace Frens
         // stay at 252 MHz for SGX (no artifacts) or accept the dots at
         // 378 MHz — the chip has no third clean PLL to use for HSTX.
         bool hstx_ok = true;
-#if SGX && CFG_TUH_RPI_PIO_USB
+#if (SGX || GENESIS_OVERCLOCK_HSTX_FIX) && CFG_TUH_RPI_PIO_USB
         const bool force_pll_usb_hstx = true;
 #else
         const bool force_pll_usb_hstx = false;

--- a/FrensHelpers.cpp
+++ b/FrensHelpers.cpp
@@ -1813,7 +1813,7 @@ uint __not_in_flash_func(storage_get_flash_capacity)()
         // stay at 252 MHz for SGX (no artifacts) or accept the dots at
         // 378 MHz — the chip has no third clean PLL to use for HSTX.
         bool hstx_ok = true;
-#if (SGX || GENESIS_OVERCLOCK_HSTX_FIX) && CFG_TUH_RPI_PIO_USB
+#if (SGX || GENESIS_OVERCLOCK_HSTX_FIX || NES_OVERCLOCK_FIX) && CFG_TUH_RPI_PIO_USB
         const bool force_pll_usb_hstx = true;
 #else
         const bool force_pll_usb_hstx = false;

--- a/FrensHelpers.h
+++ b/FrensHelpers.h
@@ -84,6 +84,9 @@ enum class ScanlineType : uint8_t
 #ifndef ENABLEDVI
 #define ENABLEDVI 0 
 #endif
+#ifndef BOOTLOADER_BUILD
+#define BOOTLOADER_BUILD 0
+#endif
 extern uintptr_t ROM_FILE_ADDR ; //0x10090000
 extern int maxRomSize;
 extern char ErrorMessage[];

--- a/FrensHelpers.h
+++ b/FrensHelpers.h
@@ -78,6 +78,12 @@ enum class ScanlineType : uint8_t
 #ifndef SGX
 #define SGX 0
 #endif
+#ifndef NES_OVERCLOCK_FIX
+#define NES_OVERCLOCK_FIX 0
+#endif
+#ifndef GENESIS_OVERCLOCK_HSTX_FIX
+#define GENESIS_OVERCLOCK_HSTX_FIX 0
+#endif
 #ifndef F_MALLOC_DEBUG
 #define F_MALLOC_DEBUG 0
 #endif

--- a/FrensHelpers.h
+++ b/FrensHelpers.h
@@ -174,6 +174,7 @@ namespace Frens
     void f_free(void *pMem);
     void *f_realloc(void *pMem, const size_t newSize);
     uint GetAvailableMemory();
+    void dumpHeapStats(const char *tag);
     int GetUnUsedDMAChan(int startChannel);
     char *get_tag_text(const char *xml, const char *tag, char *buffer, size_t bufsize);
     void waitForVSync();

--- a/FrensHelpers.h
+++ b/FrensHelpers.h
@@ -190,7 +190,29 @@ namespace Frens
 
      void pollHeadPhoneJack();
      bool isHeadPhoneJackConnected();
-   
+
+    // pico_emuLoader bootloader<->emulator handshake (see FrensHelpers.cpp).
+    // Built on watchdog scratch registers, which survive watchdog_reboot but
+    // are cleared by cold reset -- so the "launched from bootloader" semantic
+    // resets correctly on power-cycle or after a BOOTSEL flash.
+    //
+    // Emulator side:
+    //   isLaunchedFromBootloader() -- true if this image was started by the
+    //       resident bootloader (rather than flashed standalone via BOOTSEL).
+    //   rebootToBootloader() -- ask the bootloader to skip its resume path
+    //       on the next boot (so it shows the picker) and watchdog-reboot.
+    //       Does not return on success.
+    // Bootloader side:
+    //   markLaunchedFromBootloader() -- call right before app_launch_run() so
+    //       the launched image sees isLaunchedFromBootloader() == true.
+    //   consumeReturnToBootloaderRequest() -- in the resume path: returns
+    //       true and clears the request if the emulator asked to return to
+    //       the picker; the bootloader should then skip its resume jump.
+    bool isLaunchedFromBootloader();
+    void rebootToBootloader();
+    void markLaunchedFromBootloader();
+    bool consumeReturnToBootloaderRequest();
+
 } // namespace Frens
 
 

--- a/RomLister.cpp
+++ b/RomLister.cpp
@@ -118,8 +118,13 @@ namespace Frens
 		fr = f_chdir(directoryName);
 		if (fr != FR_OK)
 		{
-			printf("Error changing dir: %d\n", fr);
-			return;
+			printf("Error changing dir to %s: %d\nTrying /", directoryName, fr);
+			fr = f_chdir("/");
+			if (fr != FR_OK)
+			{
+				printf("Error changing dir to /: %d\n", fr);
+				return;
+			}
 		}
 		printf("Listing current directory, reading maximum %d entries.\n", max_entries);
 		uint availMem = Frens::GetAvailableMemory();

--- a/bld.sh
+++ b/bld.sh
@@ -13,13 +13,15 @@ APP=${PROJECT}
 function usage() {
 	echo "Build script for the ${PROJECT} project"
 	echo  ""
-	echo "Usage: $0 [-d] [-2 | -r] [-w] [-u] [-m] [-D] [-e] [-t path to toolchain] [ -p nprocessors] [-c <hwconfig>]"
+	echo "Usage: $0 [-d] [-2 | -r] [-w] [-u] [-m] [-D] [-e] [-b] [-t path to toolchain] [ -p nprocessors] [-c <hwconfig>]"
 	echo "Options:"
 	echo "  -d: build in DEBUG configuration"
 	echo "  -2: build for Pico 2 board (RP2350)"
 	echo "  -r: build for Pico 2 board (RP2350) with riscv core"
 	echo "  -u: enable PIO USB support (RP2350 only) disabled by default except for Waveshare RP2350-PiZero and Adafruit Fruit Jam."
 	echo "  -w: build for Pico_w or Pico2_w"
+	echo "  -b: build for the resident emuLoader bootloader (passes -DBUILD_FOR_BOOTLOADER=ON;"
+	echo "      relinks the image to the application partition at 0x10100000 instead of 0x10000000)."
 	echo "  -t <path to riscv toolchain>: only needed for riscv, specify the path to the riscv toolchain bin folder"
 	echo "     Default is \$PICO_SDK_PATH/toolchain/RISCV_RPI_2_0_0_2/bin"
 	echo "  -p <nprocessors>: specify the number of processors to use for the build"
@@ -89,7 +91,8 @@ CMAKEONLY=0
 USESIMPLEFILENAMES=0
 FORCEDVI=0
 USEEXTRASI2S=0
-while getopts "muwhd2rc:t:p:iDe" opt; do
+USEBOOTLOADER=0
+while getopts "muwhd2rc:t:p:iDeb" opt; do
   case $opt in
     p)
 	  BUILDPROC=$OPTARG
@@ -143,6 +146,8 @@ while getopts "muwhd2rc:t:p:iDe" opt; do
 	D) FORCEDVI=1
 	  ;;
 	e) USEEXTRASI2S=1
+	  ;;
+	b) USEBOOTLOADER=1
 	  ;;
     \?)
       #echo "Invalid option: -$OPTARG" >&2
@@ -338,18 +343,22 @@ PEI2S=
 if [ $USEEXTRASI2S -eq 1 ] ; then
 	PEI2S="_pe"
 fi
+BLSUFFIX=
+if [ $USEBOOTLOADER -eq 1 ] ; then
+	BLSUFFIX="_bl"
+fi
 # Only when SIMPLEFILENAMES=0
 if [ $USESIMPLEFILENAMES -eq 0 ] ; then
 	if [ "$PICO_PLATFORM" = "rp2350-riscv" ] ; then
-		UF2="${UF2}_${PICO_BOARD}_riscv${PIOUSB}${PEI2S}"
+		UF2="${UF2}_${PICO_BOARD}_riscv${PIOUSB}${PEI2S}${BLSUFFIX}"
 	else
-		UF2="${UF2}_${PICO_BOARD}_arm${PIOUSB}${PEI2S}"
+		UF2="${UF2}_${PICO_BOARD}_arm${PIOUSB}${PEI2S}${BLSUFFIX}"
 	fi
 else
 	if [ "$PICO_PLATFORM" = "rp2350-riscv" ] ; then
-		UF2="${UF2}_riscv${PIOUSB}${PEI2S}"
+		UF2="${UF2}_riscv${PIOUSB}${PEI2S}${BLSUFFIX}"
 	else
-		UF2="${UF2}_arm${PIOUSB}${PEI2S}"
+		UF2="${UF2}_arm${PIOUSB}${PEI2S}${BLSUFFIX}"
 	fi
 fi
 UF2="${APP}_${UF2}.uf2"
@@ -360,6 +369,9 @@ if [ $USEEXTRASI2S -eq 1 ] ; then
 	echo "Using pico-extras based I2S audio driver"
 else
 	echo "Using legacy custom I2S audio driver"
+fi
+if [ $USEBOOTLOADER -eq 1 ] ; then
+	echo "Building for the resident emuLoader bootloader (relinked to 0x10100000)"
 fi
 [ ! -z "$TOOLCHAIN_PATH" ]  && echo "Toolchain path: $TOOLCHAIN_PATH"
 echo "UF2 file: $UF2"
@@ -376,9 +388,9 @@ if [ $FORCEDVI -eq 1 ] ; then
 	FORCEDVIOPT="-DFORCE_DVI=1"
 fi
 if [ -z "$TOOLCHAIN_PATH" ] ; then
-	cmake -DCMAKE_BUILD_TYPE=$BUILD -DPICO_BOARD=$PICO_BOARD -DHW_CONFIG=$HWCONFIG -DPICO_PLATFORM=$PICO_PLATFORM -DENABLE_PIO_USB=$USEPIOUSB -DUSE_PICO_EXTRAS_I2S=$USEEXTRASI2S $FORCEDVIOPT .. || exit 1
+	cmake -DCMAKE_BUILD_TYPE=$BUILD -DPICO_BOARD=$PICO_BOARD -DHW_CONFIG=$HWCONFIG -DPICO_PLATFORM=$PICO_PLATFORM -DENABLE_PIO_USB=$USEPIOUSB -DUSE_PICO_EXTRAS_I2S=$USEEXTRASI2S -DBUILD_FOR_BOOTLOADER=$USEBOOTLOADER $FORCEDVIOPT .. || exit 1
 else
-	cmake -DCMAKE_BUILD_TYPE=$BUILD -DPICO_BOARD=$PICO_BOARD -DHW_CONFIG=$HWCONFIG -DPICO_PLATFORM=$PICO_PLATFORM -DENABLE_PIO_USB=$USEPIOUSB -DUSE_PICO_EXTRAS_I2S=$USEEXTRASI2S -DPICO_TOOLCHAIN_PATH=$TOOLCHAIN_PATH $FORCEDVIOPT .. ||  exit 1
+	cmake -DCMAKE_BUILD_TYPE=$BUILD -DPICO_BOARD=$PICO_BOARD -DHW_CONFIG=$HWCONFIG -DPICO_PLATFORM=$PICO_PLATFORM -DENABLE_PIO_USB=$USEPIOUSB -DUSE_PICO_EXTRAS_I2S=$USEEXTRASI2S -DBUILD_FOR_BOOTLOADER=$USEBOOTLOADER -DPICO_TOOLCHAIN_PATH=$TOOLCHAIN_PATH $FORCEDVIOPT .. ||  exit 1
 fi
 if [ $CMAKEONLY -eq 1 ] ; then
 	echo "CMake configuration done, exiting as requested."

--- a/bld.sh
+++ b/bld.sh
@@ -398,9 +398,9 @@ if [ $CMAKEONLY -eq 1 ] ; then
 fi
 make -j $BUILDPROC || exit 1
 cd ..
-# echo ""
-# if [ -f build/${APP}.uf2 ] ; then
-# 	cp build/${APP}.uf2 releases/${UF2} || exit 1
-# 	picotool info releases/${UF2}
-# fi
+echo ""
+if [ -f build/${APP}.uf2 ] ; then
+	cp build/${APP}.uf2 releases/${UF2} || exit 1
+#	picotool info releases/${UF2}
+fi
 

--- a/bld.sh
+++ b/bld.sh
@@ -21,7 +21,7 @@ function usage() {
 	echo "  -u: enable PIO USB support (RP2350 only) disabled by default except for Waveshare RP2350-PiZero and Adafruit Fruit Jam."
 	echo "  -w: build for Pico_w or Pico2_w"
 	echo "  -b: build for the resident emuLoader bootloader (passes -DBUILD_FOR_BOOTLOADER=ON;"
-	echo "      relinks the image to the application partition at 0x10100000 instead of 0x10000000)."
+	echo "      relinks the image to the application partition at 0x10080000 instead of 0x10000000)."
 	echo "  -t <path to riscv toolchain>: only needed for riscv, specify the path to the riscv toolchain bin folder"
 	echo "     Default is \$PICO_SDK_PATH/toolchain/RISCV_RPI_2_0_0_2/bin"
 	echo "  -p <nprocessors>: specify the number of processors to use for the build"
@@ -371,7 +371,7 @@ else
 	echo "Using legacy custom I2S audio driver"
 fi
 if [ $USEBOOTLOADER -eq 1 ] ; then
-	echo "Building for the resident emuLoader bootloader (relinked to 0x10100000)"
+	echo "Building for the resident emuLoader bootloader (relinked to 0x10080000)"
 fi
 [ ! -z "$TOOLCHAIN_PATH" ]  && echo "Toolchain path: $TOOLCHAIN_PATH"
 echo "UF2 file: $UF2"

--- a/bld.sh
+++ b/bld.sh
@@ -398,9 +398,9 @@ if [ $CMAKEONLY -eq 1 ] ; then
 fi
 make -j $BUILDPROC || exit 1
 cd ..
-echo ""
-if [ -f build/${APP}.uf2 ] ; then
-	cp build/${APP}.uf2 releases/${UF2} || exit 1
-	picotool info releases/${UF2}
-fi
+# echo ""
+# if [ -f build/${APP}.uf2 ] ; then
+# 	cp build/${APP}.uf2 releases/${UF2} || exit 1
+# 	picotool info releases/${UF2}
+# fi
 

--- a/boards/pico2b.h
+++ b/boards/pico2b.h
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+// -----------------------------------------------------
+// NOTE: THIS HEADER IS ALSO INCLUDED BY ASSEMBLER SO
+//       SHOULD ONLY CONSIST OF PREPROCESSOR DIRECTIVES
+// -----------------------------------------------------
+
+// This header may be included by other board headers as "boards/pico2b.h"
+
+#ifndef _BOARDS_PICO2B_H
+#define _BOARDS_PICO2B_H
+
+pico_board_cmake_set(PICO_PLATFORM, rp2350)
+
+// For board detection
+#define RASPBERRYPI_PICO2B
+
+// --- RP2350 VARIANT ---
+#define PICO_RP2350A 0
+
+// --- UART ---
+#ifndef PICO_DEFAULT_UART
+#define PICO_DEFAULT_UART 0
+#endif
+#ifndef PICO_DEFAULT_UART_TX_PIN
+#define PICO_DEFAULT_UART_TX_PIN 0
+#endif
+#ifndef PICO_DEFAULT_UART_RX_PIN
+#define PICO_DEFAULT_UART_RX_PIN 1
+#endif
+
+// --- LED ---
+#ifndef PICO_DEFAULT_LED_PIN
+#define PICO_DEFAULT_LED_PIN 25
+#endif
+// no PICO_DEFAULT_WS2812_PIN
+
+// --- I2C ---
+#ifndef PICO_DEFAULT_I2C
+#define PICO_DEFAULT_I2C 0
+#endif
+#ifndef PICO_DEFAULT_I2C_SDA_PIN
+#define PICO_DEFAULT_I2C_SDA_PIN 4
+#endif
+#ifndef PICO_DEFAULT_I2C_SCL_PIN
+#define PICO_DEFAULT_I2C_SCL_PIN 5
+#endif
+
+// --- SPI ---
+#ifndef PICO_DEFAULT_SPI
+#define PICO_DEFAULT_SPI 0
+#endif
+#ifndef PICO_DEFAULT_SPI_SCK_PIN
+#define PICO_DEFAULT_SPI_SCK_PIN 18
+#endif
+#ifndef PICO_DEFAULT_SPI_TX_PIN
+#define PICO_DEFAULT_SPI_TX_PIN 19
+#endif
+#ifndef PICO_DEFAULT_SPI_RX_PIN
+#define PICO_DEFAULT_SPI_RX_PIN 16
+#endif
+#ifndef PICO_DEFAULT_SPI_CSN_PIN
+#define PICO_DEFAULT_SPI_CSN_PIN 17
+#endif
+
+// --- FLASH ---
+
+#define PICO_BOOT_STAGE2_CHOOSE_W25Q080 1
+
+#ifndef PICO_FLASH_SPI_CLKDIV
+#define PICO_FLASH_SPI_CLKDIV 2
+#endif
+
+pico_board_cmake_set_default(PICO_FLASH_SIZE_BYTES, (4 * 1024 * 1024))
+#ifndef PICO_FLASH_SIZE_BYTES
+#define PICO_FLASH_SIZE_BYTES (4 * 1024 * 1024)
+#endif
+// Drive high to force power supply into PWM mode (lower ripple on 3V3 at light loads)
+#define PICO_SMPS_MODE_PIN 23
+
+// The GPIO Pin used to read VBUS to determine if the device is battery powered.
+#ifndef PICO_VBUS_PIN
+#define PICO_VBUS_PIN 24
+#endif
+
+// The GPIO Pin used to monitor VSYS. Typically you would use this with ADC.
+// There is an example in adc/read_vsys in pico-examples.
+#ifndef PICO_VSYS_PIN
+#define PICO_VSYS_PIN 29
+#endif
+
+pico_board_cmake_set_default(PICO_RP2350_A2_SUPPORTED, 1)
+#ifndef PICO_RP2350_A2_SUPPORTED
+#define PICO_RP2350_A2_SUPPORTED 1
+#endif
+
+#endif

--- a/boards/waveshare_rp2350_pizero.h
+++ b/boards/waveshare_rp2350_pizero.h
@@ -1,0 +1,102 @@
+/*
+ * Custom board header for Waveshare RP2350-PiZero
+ *  - RP2350B variant
+ *  - 16MB flash
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+// -----------------------------------------------------
+// NOTE: THIS HEADER IS ALSO INCLUDED BY ASSEMBLER SO
+//       SHOULD ONLY CONSIST OF PREPROCESSOR DIRECTIVES
+// -----------------------------------------------------
+
+// This header may be included by other board headers as "boards/waveshare_rp2350_pizero.h"
+
+#ifndef _BOARDS_WAVESHARE_RP2350_PIZERO_H
+#define _BOARDS_WAVESHARE_RP2350_PIZERO_H
+
+pico_board_cmake_set(PICO_PLATFORM, rp2350)
+
+// For board detection
+#define RASPBERRYPI_WAVESHARE_RP2350_PIZERO
+
+// --- RP2350 VARIANT ---
+#define PICO_RP2350A 0
+
+// --- UART ---
+#ifndef PICO_DEFAULT_UART
+#define PICO_DEFAULT_UART 0
+#endif
+#ifndef PICO_DEFAULT_UART_TX_PIN
+#define PICO_DEFAULT_UART_TX_PIN 0
+#endif
+#ifndef PICO_DEFAULT_UART_RX_PIN
+#define PICO_DEFAULT_UART_RX_PIN 1
+#endif
+
+// --- LED ---
+#ifndef PICO_DEFAULT_LED_PIN
+#define PICO_DEFAULT_LED_PIN 25
+#endif
+// no PICO_DEFAULT_WS2812_PIN
+
+// --- I2C ---
+#ifndef PICO_DEFAULT_I2C
+#define PICO_DEFAULT_I2C 0
+#endif
+#ifndef PICO_DEFAULT_I2C_SDA_PIN
+#define PICO_DEFAULT_I2C_SDA_PIN 4
+#endif
+#ifndef PICO_DEFAULT_I2C_SCL_PIN
+#define PICO_DEFAULT_I2C_SCL_PIN 5
+#endif
+
+// --- SPI ---
+#ifndef PICO_DEFAULT_SPI
+#define PICO_DEFAULT_SPI 0
+#endif
+#ifndef PICO_DEFAULT_SPI_SCK_PIN
+#define PICO_DEFAULT_SPI_SCK_PIN 18
+#endif
+#ifndef PICO_DEFAULT_SPI_TX_PIN
+#define PICO_DEFAULT_SPI_TX_PIN 19
+#endif
+#ifndef PICO_DEFAULT_SPI_RX_PIN
+#define PICO_DEFAULT_SPI_RX_PIN 16
+#endif
+#ifndef PICO_DEFAULT_SPI_CSN_PIN
+#define PICO_DEFAULT_SPI_CSN_PIN 17
+#endif
+
+// --- FLASH ---
+
+#define PICO_BOOT_STAGE2_CHOOSE_W25Q080 1
+
+#ifndef PICO_FLASH_SPI_CLKDIV
+#define PICO_FLASH_SPI_CLKDIV 2
+#endif
+
+pico_board_cmake_set_default(PICO_FLASH_SIZE_BYTES, (16 * 1024 * 1024))
+#ifndef PICO_FLASH_SIZE_BYTES
+#define PICO_FLASH_SIZE_BYTES (4 * 1024 * 1024)
+#endif
+// Drive high to force power supply into PWM mode (lower ripple on 3V3 at light loads)
+#define PICO_SMPS_MODE_PIN 23
+
+// The GPIO Pin used to read VBUS to determine if the device is battery powered.
+#ifndef PICO_VBUS_PIN
+#define PICO_VBUS_PIN 24
+#endif
+
+// The GPIO Pin used to monitor VSYS. Typically you would use this with ADC.
+// There is an example in adc/read_vsys in pico-examples.
+#ifndef PICO_VSYS_PIN
+#define PICO_VSYS_PIN 29
+#endif
+
+pico_board_cmake_set_default(PICO_RP2350_A2_SUPPORTED, 1)
+#ifndef PICO_RP2350_A2_SUPPORTED
+#define PICO_RP2350_A2_SUPPORTED 1
+#endif
+
+#endif

--- a/drivers/pico_fatfs/tf_card.c
+++ b/drivers/pico_fatfs/tf_card.c
@@ -62,7 +62,7 @@ static
 BYTE CardType;          /* Card type flags */
 
 /* SPI pin configurations */
-#if defined(PICO_RP2350A)
+#if PICO_RP2350A == 0
 static uint _pin_miso_conf[2][6] = {
     { 0,  4, 16, 20, 32, 36},  // SPI0_RX
     { 8, 12, 24, 28, 40, 44}   // SPI1_RX
@@ -92,15 +92,14 @@ static uint _pin_mosi_conf[2][4] = {
 
 /* SPI PIO inst (default) */
 static pio_spi_inst_t _pio_spi = {
-    .pio    = pio0,
-    .sm     = 0,
+    .pio    = SPI_PIO_DEFAULT_PIO,
+    .sm     = SPI_PIO_DEFAULT_SM,
     .cs_pin = 0
 };
-static PIO _pio = SPI_PIO_DEFAULT_PIO;
-static uint _sm = SPI_PIO_DEFAULT_SM;
 static io_rw_32* _reg_clkdiv = NULL;
-static io_rw_32  _pio_clkdiv_slow = 255 << 16;
-static io_rw_32  _pio_clkdiv_fast = 255 << 16;
+static io_rw_32  _pio_clkdiv_slow = 4096 << 16;
+static io_rw_32  _pio_clkdiv_fast =  256 << 16;
+#define PIO_CLKDIV_LIMIT (0x00018000)  // fractional div x1.5 (6 system clock syscles per 1 SCK cycle)
 
 
 static inline uint32_t _millis(void)
@@ -163,8 +162,6 @@ static void pico_fatfs_init_spi_pio(void)
     /* chip _select invalid*/
     CS_HIGH();
 
-    _pio_spi.pio    = _pio;
-    _pio_spi.sm     = _sm;
     _pio_spi.cs_pin = _config.pin_cs;
 
     uint f_clk_sys = frequency_count_khz(CLOCKS_FC0_SRC_VALUE_CLK_SYS);
@@ -172,7 +169,7 @@ static void pico_fatfs_init_spi_pio(void)
     uint offset = pio_add_program(_pio_spi.pio, &spi_cpha0_program);
     pio_spi_init(_pio_spi.pio, _pio_spi.sm, offset,
         8,       // 8 bits per SPI frame
-        (float) f_clk_sys / (_config.clk_slow / KHZ) / 4,
+        (float) f_clk_sys / (_config.clk_slow / KHZ) / 4,  // 4 PIO input clock cycles to generate one SPI clock cycle
         false,   // CPHA = 0
         false,   // CPOL = 0
         _config.pin_sck,
@@ -183,6 +180,13 @@ static void pico_fatfs_init_spi_pio(void)
     _reg_clkdiv      = &(_pio_spi.pio->sm[_pio_spi.sm].clkdiv);
     _pio_clkdiv_slow = *_reg_clkdiv;
     _pio_clkdiv_fast = (io_rw_32) ((float) _pio_clkdiv_slow * _config.clk_slow / _config.clk_fast);
+    _pio_clkdiv_fast &= 0xffffff00;
+    if (_pio_clkdiv_fast < PIO_CLKDIV_LIMIT) {
+        _pio_clkdiv_fast = PIO_CLKDIV_LIMIT;
+    }
+
+    _config.clk_fast = (uint64_t) f_clk_sys * 1000 * 256 / (_pio_clkdiv_fast / 256)  / 4;
+    _config.clk_slow = (uint64_t) f_clk_sys * 1000 * 256 / (_pio_clkdiv_slow / 256)  / 4;
 }
 
 /* Initialize SPI */
@@ -242,6 +246,11 @@ void pico_fatfs_init_spi(void)
         SPI_CPHA_0, /* cpha */
         SPI_MSB_FIRST /* order */
     );
+
+    FCLK_FAST();
+    _config.clk_fast = spi_get_baudrate(_config.spi_inst);
+    FCLK_SLOW();
+    _config.clk_slow = spi_get_baudrate(_config.spi_inst);
 }
 
 /* Exchange a byte */
@@ -741,11 +750,32 @@ bool pico_fatfs_set_config(pico_fatfs_spi_config_t* config)
 
 void pico_fatfs_config_spi_pio(PIO pio, uint sm)
 {
-    _pio = pio;
-    _sm = sm;
+    _pio_spi.pio = pio;
+    _pio_spi.sm  = sm;
 }
 
 int pico_fatfs_reboot_spi(void)
 {
+    // Send 32 cycles of CS low
+    FCLK_SLOW();
+    CS_HIGH();
+    sleep_ms(10);
+    CS_LOW();
+    for (int i = 0; i < 4; i++) {
+        xchg_spi(0xFF); /* Dummy clock (force DO enabled) */
+    }
+    CS_HIGH();
+    sleep_ms(10);
+
     return _select();
+}
+
+uint pico_fatfs_get_clk_slow_freq(void)
+{
+    return _config.clk_slow;
+}
+
+uint pico_fatfs_get_clk_fast_freq(void)
+{
+    return _config.clk_fast;
 }

--- a/drivers/pico_fatfs/tf_card.h
+++ b/drivers/pico_fatfs/tf_card.h
@@ -5,7 +5,7 @@
 #include "hardware/spi.h"
 
 #define CLK_SLOW_DEFAULT     (100 * KHZ)
-#define CLK_FAST_DEFAULT     (32 * MHZ)
+#define CLK_FAST_DEFAULT     (50 * MHZ)
 #define CLK_FAST_DEFAULT_PIO (20 * MHZ)
 // CLK_FAST: actually set to clk_peri (= 125.0 MHz) / N,
 // which is determined by spi_set_baudrate() in pico-sdk/src/rp2_common/hardware_spi/spi.c
@@ -64,8 +64,28 @@ void pico_fatfs_config_spi_pio(PIO pio, uint sm);
 
 /**
 * Reset SPI access
+*
+* @return 1: OK, 0: Timeout
 */
 int pico_fatfs_reboot_spi(void);
+
+/**
+* Get clk_slow frequency
+* If called before disk_initialize(), it returns the default setting frequency.
+* If called after disk_initialize(), it returns the actual operation frequency.
+*
+* @return frequency in Hz
+*/
+uint pico_fatfs_get_clk_slow_freq(void);
+
+/**
+* Get clk_fast frequency
+* If called before disk_initialize(), it returns the default setting frequency.
+* If called after disk_initialize(), it returns the actual operation frequency.
+*
+* @return frequency in Hz
+*/
+uint pico_fatfs_get_clk_fast_freq(void);
 
 #ifdef __cplusplus
 }

--- a/drivers/pico_hdmi/hstx.c
+++ b/drivers/pico_hdmi/hstx.c
@@ -286,7 +286,11 @@ void __not_in_flash_func(hstx_push_audio_sample)(const int left, const int right
             return;
         }
         hstx_packet_t packet;
-        g_hdmi_audio_frame_counter = hstx_packet_set_audio_samples(&packet, acc_buf, 4, g_hdmi_audio_frame_counter);
+        // _cs variant: carries IEC 60958 channel status with a valid
+        // sample-frequency code. Strict HDMI sinks mute all-zero channel
+        // status even with a correct Audio InfoFrame; lax sinks (capture
+        // cards) decode it but with glitches.
+        g_hdmi_audio_frame_counter = hstx_packet_set_audio_samples_cs(&packet, acc_buf, 4, g_hdmi_audio_frame_counter);
 
         hstx_data_island_t island;
         hstx_encode_data_island(&island, &packet, false, true);

--- a/drivers/pico_hdmi/hstx.c
+++ b/drivers/pico_hdmi/hstx.c
@@ -325,6 +325,12 @@ void hstx_init(bool dviOnly)
 // hstx_default_core1_stack() restores the boot-time stack.
 void hstx_restart_core1(uint32_t *new_stack, size_t new_stack_bytes)
 {
+    // Capture the caller-configured audio rate BEFORE teardown:
+    // video_output_init below resets it to a 48 kHz default, and the
+    // hardcoded 44100 that used to be here silently clobbered emulators
+    // running any other rate.
+    uint32_t audio_rate = pico_hdmi_get_audio_sample_rate();
+
     video_output_stop();
     multicore_reset_core1();
 
@@ -336,7 +342,7 @@ void hstx_restart_core1(uint32_t *new_stack, size_t new_stack_bytes)
     hstx_di_queue_init();
     video_output_set_vsync_callback(hstx_vsync_callbackfunc);
     video_output_init(640, 480);
-    pico_hdmi_set_audio_sample_rate(44100);
+    pico_hdmi_set_audio_sample_rate(audio_rate);
     video_output_set_scanline_callback(scanline_callbackfunc);
 
     multicore_launch_core1_with_stack(video_output_core1_run, new_stack, new_stack_bytes);

--- a/drivers/pico_hdmi/hstx_data_island_queue.c
+++ b/drivers/pico_hdmi/hstx_data_island_queue.c
@@ -7,10 +7,20 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include "pico.h"
+#include "hardware/sync.h"  // __dmb
 #ifndef DI_RING_BUFFER_SIZE
 #define DI_RING_BUFFER_SIZE 256
 #endif
-static hstx_data_island_t *di_ring_buffer = NULL; // [DI_RING_BUFFER_SIZE];
+// HSTX_DI_RING_ADDRESS lets the caller point the ring at a specific static
+// SRAM address. fruitjam-doom uses this to place the ring above the top of
+// its shortptr zone (SHORTPTR_BASE + 0x40000 = 0x20076000), reclaiming the
+// 36 KB the malloc path would otherwise steal from Doom's heap. When unset,
+// the driver falls back to its historical malloc-on-first-init behaviour.
+#ifdef HSTX_DI_RING_ADDRESS
+static hstx_data_island_t *const di_ring_buffer = (hstx_data_island_t *)(HSTX_DI_RING_ADDRESS);
+#else
+static hstx_data_island_t *di_ring_buffer = NULL; // [DI_RING_BUFFER_SIZE]
+#endif
 static volatile uint32_t di_ring_head = 0;
 static volatile uint32_t di_ring_tail = 0;
 
@@ -34,15 +44,24 @@ void hstx_di_queue_init(void)
     di_ring_head = 0;
     di_ring_tail = 0;
     audio_sample_accum = 0;
-    // Allocate memory for the ring buffer
+    // Allocate memory for the ring buffer (skipped when the address was
+    // pinned at compile time via HSTX_DI_RING_ADDRESS).
+#ifdef HSTX_DI_RING_ADDRESS
+    printf("HSTX DI ring buffer at fixed %p (%u bytes)\n",
+           (void *)di_ring_buffer,
+           (unsigned)(DI_RING_BUFFER_SIZE * sizeof(hstx_data_island_t)));
+#else
     if (di_ring_buffer == NULL) {
         printf("Allocating memory for HSTX DI ring buffer: %d bytes\n", DI_RING_BUFFER_SIZE * sizeof(hstx_data_island_t));
         di_ring_buffer = (hstx_data_island_t *)malloc(DI_RING_BUFFER_SIZE * sizeof(hstx_data_island_t));
     }
-    // Build a single silent audio packet with fixed B-frame flags.
+#endif
+    // Build a single silent audio packet. frame_count=4 (NOT 0): frame 0
+    // would set the IEC 60958 block-start B flag, so every underrun
+    // insertion would reset the sink's channel-status block sync mid-stream.
     hstx_packet_t packet;
     audio_sample_t samples[4] = {0};
-    (void)hstx_packet_set_audio_samples(&packet, samples, 4, 0);
+    (void)hstx_packet_set_audio_samples(&packet, samples, 4, 4);
     hstx_encode_data_island(&silence_packet, &packet, false, true);
 }
 
@@ -64,6 +83,9 @@ bool __not_in_flash_func(hstx_di_queue_push)(const hstx_data_island_t *island)
     const uint32_t *src = island->words;
     for (size_t i = 0; i < count_of(island->words); i++)
         dst[i] = src[i];
+    // Publish payload before head: the consumer (DMA IRQ on the other core)
+    // must never observe the head advance ahead of the payload words.
+    __dmb();
     di_ring_head = next_head;
     return true;
 }

--- a/drivers/pico_hdmi/hstx_data_island_queue.c
+++ b/drivers/pico_hdmi/hstx_data_island_queue.c
@@ -17,14 +17,17 @@ static volatile uint32_t di_ring_tail = 0;
 // Single pre-encoded silent audio packet (fixed B-frame flags).
 static hstx_data_island_t silence_packet;
 
-// Audio timing state (default 48kHz)
-static uint32_t audio_sample_accum = 0; // Fixed-point accumulator
-#define DEFAULT_SAMPLES_PER_FRAME (48000 / 60)
-static uint32_t samples_per_line_fp = (DEFAULT_SAMPLES_PER_FRAME << 16) / MODE_V_TOTAL_LINES;
-
-// Limit accumulator to avoid overflow if we run dry.
-// Clamping to 1 packet (plus a tiny margin is implicit) ensures we don't burst.
-#define MAX_AUDIO_ACCUM (4 << 16)
+// Audio packet scheduler — exact rational arithmetic, zero long-term
+// drift. Accumulate `sample_rate` per scanline; a 4-sample packet is due
+// each time the accumulator reaches 4 x line_rate. The previous
+// fixed-point form truncated sample_rate/60 to whole samples per frame
+// (32000/60 -> 533, i.e. 31980 samples/s), a -20 sample/s deficit
+// against the ACR-derived sink clock that drained the sink's audio FIFO
+// roughly every 6 s — an audible dropout while the receiver re-locked.
+// Line rate follows from the 25.2 MHz pixel clock both video modes use.
+#define DI_LINE_RATE_HZ (25200000u / MODE_H_TOTAL_PIXELS)
+static uint32_t audio_sample_accum = 0;      // unit: samples x line-rate
+static uint32_t audio_samples_per_sec = 48000;
 extern void * frens_f_malloc(size_t size);
 void hstx_di_queue_init(void)
 {
@@ -45,8 +48,8 @@ void hstx_di_queue_init(void)
 
 void hstx_di_queue_set_sample_rate(uint32_t sample_rate)
 {
-    uint32_t samples_per_frame = sample_rate / 60;
-    samples_per_line_fp = (samples_per_frame << 16) / MODE_V_TOTAL_LINES;
+    audio_samples_per_sec = sample_rate;
+    audio_sample_accum = 0;
 }
 
 bool __not_in_flash_func(hstx_di_queue_push)(const hstx_data_island_t *island)
@@ -76,21 +79,33 @@ uint32_t __not_in_flash_func(hstx_di_queue_get_level)(void)
 
 void __not_in_flash_func(hstx_di_queue_tick)(void)
 {
-    audio_sample_accum += samples_per_line_fp;
+    audio_sample_accum += audio_samples_per_sec;
 }
+
+// Counts silence-packet fallbacks (queue empty when a packet was due).
+// Diagnostic: lets producers distinguish real queue underruns from
+// silence that was genuinely mixed into the stream.
+static volatile uint32_t di_underrun_count = 0;
 
 const uint32_t *__not_in_flash_func(hstx_di_queue_get_audio_packet)(void)
 {
-    // Check if it's time to send a 4-sample audio packet (every ~2.6 lines)
-    if (audio_sample_accum >= (4 << 16)) {
-        audio_sample_accum -= (4 << 16);
+    // Check if it's time to send a 4-sample audio packet (every ~3.9 lines
+    // at 32 kHz / 31.5 kHz line rate)
+    if (audio_sample_accum >= 4u * DI_LINE_RATE_HZ) {
+        audio_sample_accum -= 4u * DI_LINE_RATE_HZ;
         if (di_ring_tail != di_ring_head) {
             const uint32_t *words = di_ring_buffer[di_ring_tail].words;
             di_ring_tail = (di_ring_tail + 1) % DI_RING_BUFFER_SIZE;
             return words;
         }
         // Queue is empty: return a pre-encoded silent packet to keep HDMI audio active.
+        di_underrun_count++;
         return silence_packet.words;
     }
     return NULL;
+}
+
+uint32_t hstx_di_queue_get_underrun_count(void)
+{
+    return di_underrun_count;
 }

--- a/drivers/pico_hdmi/hstx_data_island_queue.h
+++ b/drivers/pico_hdmi/hstx_data_island_queue.h
@@ -41,4 +41,10 @@ void hstx_di_queue_tick(void);
  */
 const uint32_t *hstx_di_queue_get_audio_packet(void);
 
+/**
+ * Number of silence-packet fallbacks since boot (a packet was due but the
+ * queue was empty). Monotonic; diff between reads to detect underruns.
+ */
+uint32_t hstx_di_queue_get_underrun_count(void);
+
 #endif // HSTX_DATA_ISLAND_QUEUE_H

--- a/drivers/pico_hdmi/hstx_packet.c
+++ b/drivers/pico_hdmi/hstx_packet.c
@@ -204,6 +204,80 @@ void hstx_packet_set_avi_infoframe(hstx_packet_t *packet, uint8_t vic, uint8_t p
     compute_all_parity(packet);
 }
 
+// IEC 60958-3 channel status bytes, one bit per audio frame across the
+// 192-frame block: byte 0 = 0x04 (consumer, L-PCM, copy permitted), byte 3 =
+// sample-frequency code (bits 24-27). Bytes 5..23 are zero, which IEC 60958
+// treats as valid consumer defaults, so only the first 5 bytes are stored.
+// Mutable so hstx_packet_set_cs_sample_rate can retarget the rate code; lives
+// in .data (RAM), safe to read from the not-in-flash encode path.
+static uint8_t cs_bytes[5] = {0x04, 0x00, 0x00, 0x02 /* 48 kHz */, 0x00};
+
+void hstx_packet_set_cs_sample_rate(uint32_t sample_rate)
+{
+    // Sample-frequency code, IEC 60958-3 bits 24-27 (LSB-first in byte 3):
+    // 44.1 kHz = 0000, 48 kHz = 0100, 32 kHz = 1100.
+    switch (sample_rate) {
+        case 44100: cs_bytes[3] = 0x00; break;
+        case 32000: cs_bytes[3] = 0x03; break;
+        case 48000:
+        default:    cs_bytes[3] = 0x02; break;
+    }
+}
+
+static inline int channel_status_bit(int frame)
+{
+    return frame < 40 ? (cs_bytes[frame >> 3] >> (frame & 7)) & 1 : 0;
+}
+
+int __not_in_flash_func(hstx_packet_set_audio_samples_cs)(hstx_packet_t *packet,
+                                                          const audio_sample_t *samples,
+                                                          int num_samples,
+                                                          int frame_count)
+{
+    hstx_packet_init(packet);
+    if (num_samples < 1) num_samples = 1;
+    if (num_samples > 4) num_samples = 4;
+
+    uint8_t sample_present = (1 << num_samples) - 1;
+    uint8_t b_flags = 0;
+    int temp_frame_count = frame_count;
+    for (int i = 0; i < num_samples; i++) {
+        if (temp_frame_count == 0) b_flags |= (1 << i);
+        temp_frame_count = (temp_frame_count + 1) % 192;
+    }
+
+    packet->header[0] = 0x02;
+    packet->header[1] = sample_present;
+    packet->header[2] = b_flags << 4;
+    compute_header_parity(packet);
+
+    int fc = frame_count;
+    for (int i = 0; i < num_samples; i++) {
+        uint8_t *d = packet->subpacket[i];
+        int16_t left = samples[i].left;
+        int16_t right = samples[i].right;
+        int c = channel_status_bit(fc);
+        fc = (fc + 1) % 192;
+
+        d[0] = 0x00;
+        d[1] = left & 0xFF;
+        d[2] = (left >> 8) & 0xFF;
+        d[3] = 0x00;
+        d[4] = right & 0xFF;
+        d[5] = (right >> 8) & 0xFF;
+
+        // Parity covers the 24-bit sample plus V, U, C bits (V=U=0 here).
+        int p_left = (int)compute_parity3(d[1], d[2], 0) ^ c;
+        int p_right = (int)compute_parity3(d[4], d[5], 0) ^ c;
+
+        // Byte 6 layout: VL UL CL PL VR UR CR PR (bits 0..7).
+        d[6] = (uint8_t)((c << 2) | (p_left << 3) | (c << 6) | (p_right << 7));
+        compute_subpacket_parity(packet, i);
+    }
+
+    return temp_frame_count;
+}
+
 int __not_in_flash_func(hstx_packet_set_audio_samples)(hstx_packet_t *packet, const audio_sample_t *samples, int num_samples,
                                   int frame_count)
 {

--- a/drivers/pico_hdmi/hstx_packet.h
+++ b/drivers/pico_hdmi/hstx_packet.h
@@ -41,6 +41,21 @@ void hstx_packet_set_audio_infoframe(hstx_packet_t *packet, uint32_t sample_rate
 void hstx_packet_set_avi_infoframe(hstx_packet_t *packet, uint8_t vic, uint8_t pixel_repetition);
 int hstx_packet_set_audio_samples(hstx_packet_t *packet, const audio_sample_t *samples, int num_samples,
                                   int frame_count);
+// Same as hstx_packet_set_audio_samples but also writes IEC 60958 channel
+// status bits ("consumer LPCM, copy permitted" + the sample-frequency code
+// set via hstx_packet_set_cs_sample_rate) into the L/R VUCP bytes across the
+// 192-frame block. Strict HDMI receivers (many monitors/TVs) mute streams
+// whose channel status is all-zero — "sample rate not indicated" — even when
+// the Audio InfoFrame is present; lax sinks decode them with glitches.
+// Found the hard way in fruitjam-doom (2026-07); ported from the standalone
+// pico_hdmi upstream, with the sample-frequency code made configurable.
+int hstx_packet_set_audio_samples_cs(hstx_packet_t *packet, const audio_sample_t *samples, int num_samples,
+                                     int frame_count);
+// Set the IEC 60958 channel-status sample-frequency code used by
+// hstx_packet_set_audio_samples_cs. Supported: 32000, 44100, 48000 Hz
+// (anything else falls back to the 48 kHz code). Called automatically by
+// pico_hdmi_set_audio_sample_rate via configure_audio_packets.
+void hstx_packet_set_cs_sample_rate(uint32_t sample_rate);
 void hstx_packet_set_null(hstx_packet_t *packet);
 
 // ============================================================================

--- a/drivers/pico_hdmi/video_output.c
+++ b/drivers/pico_hdmi/video_output.c
@@ -504,6 +504,10 @@ static void configure_audio_packets(uint32_t sample_rate)
 {
     configured_audio_sample_rate = sample_rate;
     hstx_di_queue_set_sample_rate(sample_rate);
+    // Keep the IEC 60958 channel-status sample-frequency code in lockstep
+    // with ACR and the Audio InfoFrame — strict sinks require all three to
+    // agree with the actual stream rate.
+    hstx_packet_set_cs_sample_rate(sample_rate);
 
     hstx_packet_t packet;
     hstx_data_island_t island;
@@ -823,14 +827,16 @@ void __not_in_flash_func(video_output_core1_run)(void)
             uint32_t d_us = now - rate_last_us;
             uint32_t d_frames = current_count - rate_last_frames;
             uint32_t d_irqs = irq_count - rate_last_irqs;
-            printf("video rate: %lu frames/s, %lu irqs/s (dvi=%d) clk_sys=%lu clk_hstx=%lu csr=%08lx resync=%d\n",
+            printf("video rate: %lu frames/s, %lu irqs/s (dvi=%d) clk_sys=%lu clk_hstx=%lu csr=%08lx resync=%d di_lvl=%lu underrun=%lu\n",
                    (unsigned long)((uint64_t)d_frames * 1000000u / d_us),
                    (unsigned long)((uint64_t)d_irqs * 1000000u / d_us),
                    dvi_mode ? 1 : 0,
                    (unsigned long)clock_get_hz(clk_sys),
                    (unsigned long)clock_get_hz(clk_hstx),
                    (unsigned long)hstx_ctrl_hw->csr,
-                   resync_count);
+                   resync_count,
+                   (unsigned long)hstx_di_queue_get_level(),
+                   (unsigned long)hstx_di_queue_get_underrun_count());
             printf("  hstx_div=%08lx exp_sh=%08lx exp_tmds=%08lx ping_ctrl=%08lx pong_ctrl=%08lx\n",
                    (unsigned long)clocks_hw->clk[clk_hstx].div,
                    (unsigned long)hstx_ctrl_hw->expand_shift,

--- a/drivers/pico_hdmi/video_output.c
+++ b/drivers/pico_hdmi/video_output.c
@@ -628,7 +628,18 @@ void video_output_set_vsync_callback(video_output_vsync_cb_t cb)
     vsync_callback = cb;
 }
 
-void video_output_core1_run(void)
+// __not_in_flash_func: this function's while(1) loop runs on core1 forever.
+// When core0 calls flash_range_erase / flash_range_program, XIP is briefly
+// disabled and any core1 instruction fetch from flash stalls or returns
+// garbage. Keeping the whole function (including the one-time hardware-init
+// prologue) in SRAM costs ~700 bytes but lets the bootloader's progress bar
+// keep updating on screen while flashing a new emulator. All callees from
+// the steady-state loop (time_us_32 inline, hstx_resync, dma_irq_handler,
+// scanline_callback, etc.) are themselves __not_in_flash_func; the only
+// flash-resident calls left here (printf, irq_set_enabled) sit inside the
+// rare resync path, which is not expected to fire during a normal flash
+// write -- and would be the same risk as before this attribute was added.
+void __not_in_flash_func(video_output_core1_run)(void)
 {
 #if 0
     // HSTX Hardware Setup

--- a/drivers/pico_hdmi/video_output.c
+++ b/drivers/pico_hdmi/video_output.c
@@ -490,8 +490,19 @@ static void get_acr_params(uint32_t sample_rate, uint32_t *n, uint32_t *cts)
     }
 }
 
+// Last rate handed to configure_audio_packets. Lets hstx_restart_core1
+// restore the caller-configured rate instead of resetting to 44.1 kHz
+// (pico_snesPlus runs 32 kHz).
+static uint32_t configured_audio_sample_rate = 48000;
+
+uint32_t pico_hdmi_get_audio_sample_rate(void)
+{
+    return configured_audio_sample_rate;
+}
+
 static void configure_audio_packets(uint32_t sample_rate)
 {
+    configured_audio_sample_rate = sample_rate;
     hstx_di_queue_set_sample_rate(sample_rate);
 
     hstx_packet_t packet;

--- a/drivers/pico_hdmi/video_output.h
+++ b/drivers/pico_hdmi/video_output.h
@@ -143,6 +143,9 @@ void video_output_core1_run(void);
  */
 void pico_hdmi_set_audio_sample_rate(uint32_t sample_rate);
 
+/// Last rate passed to pico_hdmi_set_audio_sample_rate (default 48000).
+uint32_t pico_hdmi_get_audio_sample_rate(void);
+
 /**
  * Request a full HSTX + DMA resync. The request is latched and serviced by
  * the core-1 main loop, so this is safe to call from core 0 at any time.

--- a/gamepad.cpp
+++ b/gamepad.cpp
@@ -13,6 +13,7 @@ namespace io
     {
         GamePadState currentGamePad_[2];
         KeyboardState currentKeyboard_ = {};
+        MouseState currentMouse_;
     }
 
     GamePadState &getCurrentGamePadState(int i)
@@ -23,6 +24,11 @@ namespace io
     const KeyboardState &getCurrentKeyboardState()
     {
         return currentKeyboard_;
+    }
+
+    MouseState &getCurrentMouseState()
+    {
+        return currentMouse_;
     }
 
     void

--- a/gamepad.h
+++ b/gamepad.h
@@ -70,6 +70,21 @@ namespace io
         uint8_t keycode[6];
     };
     const KeyboardState &getCurrentKeyboardState();
+
+    // USB HID mouse state. Populated by hid_app.cpp from boot-protocol mouse
+    // reports (and generic desktop-mouse reports). Movement and wheel are
+    // accumulated deltas: the consumer should read them and reset dx/dy/wheel
+    // to zero after processing (single-consumer model). buttons matches
+    // MOUSE_BUTTON_* from TinyUSB (bit 0 left, bit 1 right, bit 2 middle).
+    struct MouseState
+    {
+        bool connected{false};
+        uint8_t buttons{0};
+        int32_t dx{0};
+        int32_t dy{0};
+        int32_t wheel{0};
+    };
+    MouseState &getCurrentMouseState();
 }
 
 #endif /* _510036F3_0134_6411_4376_A918ACA8AC4C */

--- a/hid_app.cpp
+++ b/hid_app.cpp
@@ -35,6 +35,25 @@ extern "C"
         static constexpr int MAX_USB_PLAYERS = 2;
         static uint8_t playerDevAddr[MAX_USB_PLAYERS] = {0, 0};
 
+        // Boot-protocol mouse tracking. A mouse does not occupy a player
+        // slot, so a keyboard + mouse + gamepad can all be connected at once.
+        static bool mouseMounted = false;
+        static uint8_t mouseDevAddr = 0;
+        static uint8_t mouseInstance = 0;
+
+        static void processMouseReport(hid_mouse_report_t const *r, uint16_t len)
+        {
+            auto &m = io::getCurrentMouseState();
+            m.connected = true;
+            m.buttons = r->buttons;
+            m.dx += r->x;
+            m.dy += r->y;
+            if (len >= 4) // wheel-less mice send 3-byte reports
+            {
+                m.wheel += r->wheel;
+            }
+        }
+
         static int assignPlayer(uint8_t dev_addr)
         {
             for (int i = 0; i < MAX_USB_PLAYERS; i++)
@@ -370,6 +389,21 @@ extern "C"
     {
         uint16_t vid, pid;
         tuh_vid_pid_get(dev_addr, &vid, &pid);
+        // Mice are handled separately and do not claim a player slot.
+        if (tuh_hid_interface_protocol(dev_addr, instance) == HID_ITF_PROTOCOL_MOUSE)
+        {
+            printf("Mouse detected - device address = %d, instance = %d is mounted - VID = %04x, PID = %04x\n",
+                   dev_addr, instance, vid, pid);
+            mouseMounted = true;
+            mouseDevAddr = dev_addr;
+            mouseInstance = instance;
+            io::getCurrentMouseState().connected = true;
+            if (!tuh_hid_receive_report(dev_addr, instance))
+            {
+                printf("Error: cannot request to receive report\r\n");
+            }
+            return;
+        }
         int player = assignPlayer(dev_addr);
         if (player < 0)
         {
@@ -451,6 +485,15 @@ extern "C"
 
     void tuh_hid_umount_cb(uint8_t dev_addr, uint8_t instance)
     {
+        if (mouseMounted && dev_addr == mouseDevAddr && instance == mouseInstance)
+        {
+            printf("Mouse device address = %d, instance = %d is unmounted\n", dev_addr, instance);
+            mouseMounted = false;
+            auto &m = io::getCurrentMouseState();
+            m.connected = false;
+            m.buttons = 0;
+            return;
+        }
         int player = getPlayerIndex(dev_addr);
         if (player >= 0)
         {
@@ -470,6 +513,20 @@ extern "C"
     void tuh_hid_report_received_cb(uint8_t dev_addr,
                                     uint8_t instance, uint8_t const *report, uint16_t len)
     {
+        if (mouseMounted && dev_addr == mouseDevAddr && instance == mouseInstance)
+        {
+            // Boot-protocol mouse report (TinyUSB host defaults interfaces to
+            // boot protocol): buttons, x, y, wheel.
+            if (len >= 3)
+            {
+                processMouseReport(reinterpret_cast<hid_mouse_report_t const *>(report), len);
+            }
+            if (!tuh_hid_receive_report(dev_addr, instance))
+            {
+                printf("Error: cannot request to receive report\r\n");
+            }
+            return;
+        }
         int player = getPlayerIndex(dev_addr);
         if (player < 0)
         {
@@ -515,6 +572,8 @@ extern "C"
                 gp.buttons = gp.buttons |
                              (r->buttons1 & DS4Report::Button1::TRIANGLE ? io::GamePadState::Button::X : 0) |
                              (r->buttons1 & DS4Report::Button1::SQUARE ? io::GamePadState::Button::Y : 0) |
+                             (r->buttons2 & DS4Report::Button2::L1 ? io::GamePadState::Button::L : 0) |
+                             (r->buttons2 & DS4Report::Button2::R1 ? io::GamePadState::Button::R : 0) |
                              (r->buttons2 & DS4Report::Button2::SHARE ? io::GamePadState::Button::SELECT : 0) |
                              (r->tpad ? io::GamePadState::Button::SELECT : 0) |
                              (r->buttons2 & DS4Report::Button2::OPTIONS ? io::GamePadState::Button::START : 0);
@@ -561,6 +620,8 @@ extern "C"
                     gp.buttons |
                     (buttons & DS5Report::Button::TRIANGLE ? io::GamePadState::Button::X : 0) |
                     (buttons & DS5Report::Button::SQUARE ? io::GamePadState::Button::Y : 0) |
+                    (buttons & DS5Report::Button::L1 ? io::GamePadState::Button::L : 0) |
+                    (buttons & DS5Report::Button::R1 ? io::GamePadState::Button::R : 0) |
                     (buttons & (DS5Report::Button::SHARE | DS5Report::Button::TPAD) ? io::GamePadState::Button::SELECT : 0) |
                     (buttons & DS5Report::Button::OPTIONS ? io::GamePadState::Button::START : 0);
                 gp.hat = static_cast<io::GamePadState::Hat>(r->getHat());
@@ -606,6 +667,9 @@ extern "C"
                         ((isManta[player] == 1 && r->byte6 & MantaPadReport::Button::NESB) ? io::GamePadState::Button::B : 0) |
                         ((isManta[player] == 2 && r->byte6 & MantaPadReport::Button::B) ? io::GamePadState::Button::B : 0) |
                         ((isManta[player] == 2 && r->byte6 & MantaPadReport::Button::X) ? io::GamePadState::Button::X : 0) |
+                        ((isManta[player] == 2 && r->byte6 & MantaPadReport::Button::Y) ? io::GamePadState::Button::Y : 0) |
+                        (r->byte7 & MantaPadReport::Button::SHOULDERLEFT ? io::GamePadState::Button::L : 0) |
+                        (r->byte7 & MantaPadReport::Button::SHOULDERRIGHT ? io::GamePadState::Button::R : 0) |
                         (r->byte7 & MantaPadReport::Button::START ? io::GamePadState::Button::START : 0) |
                         (r->byte7 & MantaPadReport::Button::SELECT ? io::GamePadState::Button::SELECT : 0) |
                         (udb == MantaPadReport::Button::UP ? io::GamePadState::Button::UP : 0) |
@@ -620,6 +684,9 @@ extern "C"
                         ((isManta[player] == 1 && r->byte6 & MantaPadReport::Button::NESB) ? io::GamePadState::Button::A : 0) |
                         ((isManta[player] == 2 && r->byte6 & MantaPadReport::Button::B) ? io::GamePadState::Button::A : 0) |
                         ((isManta[player] == 2 && r->byte6 & MantaPadReport::Button::X) ? io::GamePadState::Button::X : 0) |
+                        ((isManta[player] == 2 && r->byte6 & MantaPadReport::Button::Y) ? io::GamePadState::Button::Y : 0) |
+                        (r->byte7 & MantaPadReport::Button::SHOULDERLEFT ? io::GamePadState::Button::L : 0) |
+                        (r->byte7 & MantaPadReport::Button::SHOULDERRIGHT ? io::GamePadState::Button::R : 0) |
                         (r->byte7 & MantaPadReport::Button::START ? io::GamePadState::Button::START : 0) |
                         (r->byte7 & MantaPadReport::Button::SELECT ? io::GamePadState::Button::SELECT : 0) |
                         (udb == MantaPadReport::Button::UP ? io::GamePadState::Button::UP : 0) |
@@ -871,8 +938,12 @@ extern "C"
 
                 case HID_USAGE_DESKTOP_MOUSE:
                     TU_LOG1("HID receive mouse report\n");
-                    // Assume mouse follow boot report layout
-                    //                process_mouse_report((hid_mouse_report_t const *)report);
+                    // Assume mouse follows boot report layout (report ID, if
+                    // any, has already been stripped above).
+                    if (len >= 3)
+                    {
+                        processMouseReport(reinterpret_cast<hid_mouse_report_t const *>(report), len);
+                    }
                     break;
 
                 case HID_USAGE_DESKTOP_JOYSTICK:
@@ -989,6 +1060,12 @@ extern "C"
                     gp.buttons |= (abSwapped ? io::GamePadState::Button::A : io::GamePadState::Button::B);
                 if (p->wButtons & XINPUT_GAMEPAD_Y)
                     gp.buttons |= io::GamePadState::Button::X;
+                if (p->wButtons & XINPUT_GAMEPAD_X)
+                    gp.buttons |= io::GamePadState::Button::Y;
+                if (p->wButtons & XINPUT_GAMEPAD_LEFT_SHOULDER)
+                    gp.buttons |= io::GamePadState::Button::L;
+                if (p->wButtons & XINPUT_GAMEPAD_RIGHT_SHOULDER)
+                    gp.buttons |= io::GamePadState::Button::R;
                 if (p->wButtons & XINPUT_GAMEPAD_DPAD_UP)
                     gp.buttons |= io::GamePadState::Button::UP;
                 if (p->wButtons & XINPUT_GAMEPAD_DPAD_DOWN)
@@ -1003,6 +1080,15 @@ extern "C"
                     gp.buttons |= io::GamePadState::Button::SELECT;
                 if (p->wButtons & XINPUT_GAMEPAD_GUIDE)
                     gp.buttons |= (io::GamePadState::Button::START | io::GamePadState::Button::SELECT);
+                // Left thumbstick doubles as the dpad (sThumbLY is positive up).
+                if (p->sThumbLX < -16384)
+                    gp.buttons |= io::GamePadState::Button::LEFT;
+                else if (p->sThumbLX > 16384)
+                    gp.buttons |= io::GamePadState::Button::RIGHT;
+                if (p->sThumbLY > 16384)
+                    gp.buttons |= io::GamePadState::Button::UP;
+                else if (p->sThumbLY < -16384)
+                    gp.buttons |= io::GamePadState::Button::DOWN;
                 gp.flagConnected(true);
             }
         }

--- a/menu.cpp
+++ b/menu.cpp
@@ -3251,6 +3251,7 @@ int showSettingsMenu(bool calledFromGame)
         // If the overclock toggle disagrees with the live clock, rewrite
         // FlashParams and reboot. writeFlashParamsToFlash arms the watchdog
         // and never returns.
+#if HW_CONFIG != 7
         uint32_t liveKHz   = clock_get_hz(clk_sys) / 1000;
         uint32_t targetKHz = (settings.flags.overclock || settings.flags.useFM) ? FLASHPARAM_MAX_FREQ_KHZ : FLASHPARAM_MIN_FREQ_KHZ;
         vreg_voltage targetV = (settings.flags.overclock || settings.flags.useFM) ? FLASHPARAM_MAX_VOLTAGE : FLASHPARAM_MIN_VOLTAGE;
@@ -3259,6 +3260,7 @@ int showSettingsMenu(bool calledFromGame)
             showLoadingScreen((settings.flags.overclock || settings.flags.useFM) ? "Enabling overclock" : "Disabling overclock", 60);
             Frens::writeFlashParamsToFlash(targetKHz, targetV);
         }
+#endif
     }
     Frens::f_free(workingDyn);
     // restore contents of swap file back to altScreenbuffer when not nullptr

--- a/menu.cpp
+++ b/menu.cpp
@@ -2402,9 +2402,15 @@ int showSettingsMenu(bool calledFromGame)
             }
              case MenuSettingsIndex::MOPT_ENTER_BOOTSEL_MODE:
             {
-                
-                
+
+
                 label = "Enter BOOTSEL Mode";
+                value = "";
+                break;
+            }
+            case MenuSettingsIndex::MOPT_REBOOT_TO_LOADER:
+            {
+                label = "Return to emuLoader";
                 value = "";
                 break;
             }
@@ -2666,7 +2672,7 @@ int showSettingsMenu(bool calledFromGame)
                 value = "";
                 break;
             }
-            snprintf(line, sizeof(line), "%s%s%s", label, (optIndex == MOPT_EXIT_GAME || optIndex == MOPT_SAVE_RESTORE_STATE || optIndex == MOPT_ENTER_BOOTSEL_MODE || optIndex == MOPT_RESET_GAME) ? "" : ": ", value);
+            snprintf(line, sizeof(line), "%s%s%s", label, (optIndex == MOPT_EXIT_GAME || optIndex == MOPT_SAVE_RESTORE_STATE || optIndex == MOPT_ENTER_BOOTSEL_MODE || optIndex == MOPT_REBOOT_TO_LOADER || optIndex == MOPT_RESET_GAME) ? "" : ": ", value);
             putText(0, row++, line, CBLACK, CWHITE);
         }
         // Down-scroll indicator (centered): shown when there are options below the window
@@ -2735,6 +2741,7 @@ int showSettingsMenu(bool calledFromGame)
             if (curOpt == MOPT_EXIT_GAME ||
                 curOpt == MOPT_SAVE_RESTORE_STATE ||
                 curOpt == MOPT_ENTER_BOOTSEL_MODE ||
+                curOpt == MOPT_REBOOT_TO_LOADER ||
                 curOpt == MOPT_RESET_GAME)
             {
                 snprintf(line, sizeof(line), "UP/DOWN: Move, %s: select", buttonLabel1);
@@ -2917,7 +2924,7 @@ int showSettingsMenu(bool calledFromGame)
                         firstVisibleOption = selectedOptionIndex - optionWindowSize + 1; // scroll down
                 }
             }
-            else if (pad & LEFT || pad & RIGHT || ((pad & A) && (optIndex == MOPT_EXIT_GAME || optIndex == MOPT_SAVE_RESTORE_STATE || optIndex == MOPT_ENTER_BOOTSEL_MODE || optIndex == MOPT_RESET_GAME || optIndex == MOPT_FDS_DISK_SWAP)))
+            else if (pad & LEFT || pad & RIGHT || ((pad & A) && (optIndex == MOPT_EXIT_GAME || optIndex == MOPT_SAVE_RESTORE_STATE || optIndex == MOPT_ENTER_BOOTSEL_MODE || optIndex == MOPT_REBOOT_TO_LOADER || optIndex == MOPT_RESET_GAME || optIndex == MOPT_FDS_DISK_SWAP)))
             {
                 // LEFT/RIGHT on the action row cycles sub-selection
                 if (onActionRow && (pad & (LEFT | RIGHT)))
@@ -2929,9 +2936,13 @@ int showSettingsMenu(bool calledFromGame)
                 }
                 else if (optIndex != -1)
                 {
-                     if (optIndex == MOPT_ENTER_BOOTSEL_MODE && pad & A) 
+                     if (optIndex == MOPT_ENTER_BOOTSEL_MODE && pad & A)
                     {
                        reset_usb_boot(0, 0);
+                    }
+                    if (optIndex == MOPT_REBOOT_TO_LOADER && pad & A)
+                    {
+                       Frens::rebootToBootloader(); // does not return
                     }
                     bool right = pad & RIGHT;
                     switch (optIndex)

--- a/menu.cpp
+++ b/menu.cpp
@@ -3350,8 +3350,12 @@ void menu(const char *title, char *errorMessage, bool isFatal, bool showSplash, 
     if (showSplash && !watchdog_enable_caused_reboot())
     {
         showSplash = false;
+#if !BOOTLOADER_BUILD
         printf("Showing splash screen\n");
         showSplashScreen();
+#else
+        printf("Bootloader build, skipping splash screen\n");
+#endif
     }
     srand(get_rand_32()); // Seed the random number generator for screensaver
     romlister.list(settings.currentDir);

--- a/menu.cpp
+++ b/menu.cpp
@@ -2534,6 +2534,12 @@ int showSettingsMenu(bool calledFromGame)
                 value = working.flags.overclock ? "ON" : "OFF";
                 break;
             }
+            case MenuSettingsIndex::MOPT_FM_AUDIO:
+            {
+                label = "YM2413 FM";
+                value = working.flags.useFM ? "ON" : "OFF";
+                break;
+            }
             // case MenuSettingsIndex::MOPT_FRUITJAM_INTERNAL_SPEAKER:
             // {
             //     label = "Fruit Jam Internal Speaker";
@@ -3070,6 +3076,9 @@ int showSettingsMenu(bool calledFromGame)
                         break;
                     case MOPT_OVERCLOCK:
                         working.flags.overclock = !working.flags.overclock;
+                        break;
+                    case MOPT_FM_AUDIO:
+                        working.flags.useFM = !working.flags.useFM;
                         break;
                     case MOPT_DMG_PALETTE:
                     {

--- a/menu.cpp
+++ b/menu.cpp
@@ -3626,9 +3626,44 @@ void menu(const char *title, char *errorMessage, bool isFatal, bool showSplash, 
 
                     if (strcmp(settings.currentDir, "/") != 0)
                     {
+                        // Capture the directory we're leaving so we can
+                        // re-highlight it in the parent listing.
+                        char childName[ROMLISTER_MAXPATH] = {0};
+                        const char *slash = strrchr(settings.currentDir, '/');
+                        if (slash && *(slash + 1) != '\0')
+                        {
+                            strncpy(childName, slash + 1, sizeof(childName) - 1);
+                        }
+
                         romlister.list("..");
-                        settings.firstVisibleRowINDEX = 0;
-                        settings.selectedRow = STARTROW;
+
+                        int foundIndex = -1;
+                        if (childName[0] != '\0')
+                        {
+                            auto *parentEntries = romlister.GetEntries();
+                            for (size_t i = 0; i < romlister.Count(); ++i)
+                            {
+                                if (parentEntries[i].IsDirectory &&
+                                    strcasecmp(parentEntries[i].Path, childName) == 0)
+                                {
+                                    foundIndex = (int)i;
+                                    break;
+                                }
+                            }
+                        }
+
+                        if (foundIndex >= 0)
+                        {
+                            settings.firstVisibleRowINDEX =
+                                (foundIndex / PAGESIZE) * PAGESIZE;
+                            settings.selectedRow =
+                                STARTROW + (foundIndex - settings.firstVisibleRowINDEX);
+                        }
+                        else
+                        {
+                            settings.firstVisibleRowINDEX = 0;
+                            settings.selectedRow = STARTROW;
+                        }
                         displayRoms(romlister, settings.firstVisibleRowINDEX);
                         fr = f_getcwd(settings.currentDir, FF_MAX_LFN); // f_getcwd(settings.currentDir, FF_MAX_LFN);
                         if (fr == FR_OK)

--- a/menu.cpp
+++ b/menu.cpp
@@ -3252,11 +3252,11 @@ int showSettingsMenu(bool calledFromGame)
         // FlashParams and reboot. writeFlashParamsToFlash arms the watchdog
         // and never returns.
         uint32_t liveKHz   = clock_get_hz(clk_sys) / 1000;
-        uint32_t targetKHz = settings.flags.overclock ? FLASHPARAM_MAX_FREQ_KHZ : FLASHPARAM_MIN_FREQ_KHZ;
-        vreg_voltage targetV = settings.flags.overclock ? FLASHPARAM_MAX_VOLTAGE : FLASHPARAM_MIN_VOLTAGE;
+        uint32_t targetKHz = (settings.flags.overclock || settings.flags.useFM) ? FLASHPARAM_MAX_FREQ_KHZ : FLASHPARAM_MIN_FREQ_KHZ;
+        vreg_voltage targetV = (settings.flags.overclock || settings.flags.useFM) ? FLASHPARAM_MAX_VOLTAGE : FLASHPARAM_MIN_VOLTAGE;
         if (liveKHz != targetKHz)
         {
-            showLoadingScreen(settings.flags.overclock ? "Enabling overclock" : "Disabling overclock", 60);
+            showLoadingScreen((settings.flags.overclock || settings.flags.useFM) ? "Enabling overclock" : "Disabling overclock", 60);
             Frens::writeFlashParamsToFlash(targetKHz, targetV);
         }
     }

--- a/menu.cpp
+++ b/menu.cpp
@@ -147,7 +147,7 @@ void resetColors(int prevfgColor, int prevbgColor)
     }
 }
 
-static void getButtonLabels(char *buttonLabel1, char *buttonLabel2)
+void getButtonLabels(char *buttonLabel1, char *buttonLabel2)
 {
     auto &gp = io::getCurrentGamePadState(0);
     if (strcmp(gp.GamePadName, "Dual Shock 4") == 0 || strcmp(gp.GamePadName, "Dual Sense") == 0 || strcmp(gp.GamePadName, "PSClassic") == 0)

--- a/menu.cpp
+++ b/menu.cpp
@@ -2410,7 +2410,7 @@ int showSettingsMenu(bool calledFromGame)
             }
             case MenuSettingsIndex::MOPT_REBOOT_TO_LOADER:
             {
-                label = "Return to emuLoader";
+                label = "Return to emulator selection";
                 value = "";
                 break;
             }

--- a/menu.h
+++ b/menu.h
@@ -60,6 +60,7 @@ void menuSetFdsHooks(const MenuFdsHooks *hooks);
 
 void menuPumpBlankFrames(int count);
 bool showSaveStateMenu(int (*savestatefunc)(const char *path), int (*loadstatefunc)(const char *path), const char *extraMessage, SaveStateTypes quickSave);
+void getButtonLabels(char *buttonLabel1, char *buttonLabel2);
 void getQuickSavePath(char *path, size_t pathsize);
 void getSaveStatePath(char *path, size_t pathsize, int slot);
 void getAutoSaveStatePath(char *path, size_t pathsize);

--- a/menu_settings.h
+++ b/menu_settings.h
@@ -29,7 +29,8 @@ enum MenuSettingsIndex {
     MOPT_AUTO_SWAP_FDS_DISK, // New menu option for automatically swapping FDS disk sides when loading a .fds file
     MOPT_FDS_DISK_SWAP,
     MOPT_OVERCLOCK,
-    MOPT_ENTER_BOOTSEL_MODE, // Keep last so BOOTSEL is the final entry in the settings list
+    MOPT_ENTER_BOOTSEL_MODE,
+    MOPT_REBOOT_TO_LOADER,   // Only shown when Frens::isLaunchedFromBootloader(): reboots to the emuLoader picker
     MOPT_COUNT
 };
 // Create and initialize an array which explains each option in a short description of max 40 characters
@@ -58,7 +59,8 @@ const char* const g_settings_descriptions[MOPT_COUNT] = {
     "Auto swap disk side when game asks",
     "Eject / insert FDS disk side",
     "Run CPU at high clock (reboots to apply)",
-    "Reboot to BOOTSEL mode for flashing"
+    "Reboot to BOOTSEL mode for flashing",
+    "Return to emuLoader picker menu"
 };
 
 extern const int8_t *g_settings_visibility; // Visibility configuration for options menu

--- a/menu_settings.h
+++ b/menu_settings.h
@@ -7,6 +7,7 @@
 enum MenuSettingsIndex {
     MOPT_EXIT_GAME = 0,
     MOPT_RESET_GAME,
+    MOPT_REBOOT_TO_LOADER,   // Only shown when Frens::isLaunchedFromBootloader(): reboots to the emuLoader picker
     MOPT_SAVE_RESTORE_STATE,
     MOPT_SCREENMODE,
     MOPT_SCANLINES,
@@ -30,7 +31,6 @@ enum MenuSettingsIndex {
     MOPT_FDS_DISK_SWAP,
     MOPT_OVERCLOCK,
     MOPT_ENTER_BOOTSEL_MODE,
-    MOPT_REBOOT_TO_LOADER,   // Only shown when Frens::isLaunchedFromBootloader(): reboots to the emuLoader picker
     MOPT_COUNT
 };
 // Create and initialize an array which explains each option in a short description of max 40 characters

--- a/menu_settings.h
+++ b/menu_settings.h
@@ -30,6 +30,7 @@ enum MenuSettingsIndex {
     MOPT_AUTO_SWAP_FDS_DISK, // New menu option for automatically swapping FDS disk sides when loading a .fds file
     MOPT_FDS_DISK_SWAP,
     MOPT_OVERCLOCK,
+    MOPT_FM_AUDIO,
     MOPT_ENTER_BOOTSEL_MODE,
     MOPT_COUNT
 };
@@ -61,6 +62,7 @@ const char* const g_settings_descriptions[MOPT_COUNT] = {
     [MOPT_AUTO_SWAP_FDS_DISK]        = "Auto swap disk side when game asks",
     [MOPT_FDS_DISK_SWAP]             = "Eject / insert FDS disk side",
     [MOPT_OVERCLOCK]                 = "Run CPU at high clock (reboots to apply)",
+    [MOPT_FM_AUDIO]                  = "YM2413 FM sound (SMS, RP2350 only)",
     [MOPT_ENTER_BOOTSEL_MODE]        = "Reboot to BOOTSEL mode for flashing",
 };
 

--- a/menu_settings.h
+++ b/menu_settings.h
@@ -33,34 +33,35 @@ enum MenuSettingsIndex {
     MOPT_ENTER_BOOTSEL_MODE,
     MOPT_COUNT
 };
-// Create and initialize an array which explains each option in a short description of max 40 characters
+// Short description (max 40 chars) for each option. Use designated initializers
+// so descriptions stay bound to their enum tag — reordering or inserting new
+// MOPT_* values cannot silently shift the descriptions out of alignment.
 const char* const g_settings_descriptions[MOPT_COUNT] = {
-    "Exit game and return to main menu",
-    "Reset the currently running game",
-    "Save or load emulator state",
-    "Screen scaling & scanline mode",
-    "Toggle scanlines effect",
-    "Scanline type (CRT/LCD style)",
-    "Show FPS (frame rate)",
-    "Toggle game audio",
-    "Skip frames for speed",
-    "HDMI or DVI",
-    "Play audio over audio line out jack",
-    "Menu text color (0-63)",
-    "Menu background color (0-63)",
-    "RGB LEDs show audio level (VU)",
-   // "Enable Fruit Jam internal speaker",
-    "Fruit Jam change volume (-63 to +23 dB)",
-    "Color Palette for mono / DMG games",
-    "Select border artwork",
-    "Enable rapid fire for this button",
-    "Enable rapid fire for this button",
-    "Insert disk at boot or stay in BIOS",
-    "Auto swap disk side when game asks",
-    "Eject / insert FDS disk side",
-    "Run CPU at high clock (reboots to apply)",
-    "Reboot to BOOTSEL mode for flashing",
-    "Return to emuLoader picker menu"
+    [MOPT_EXIT_GAME]                = "Exit game and return to main menu",
+    [MOPT_RESET_GAME]                = "Reset the currently running game",
+    [MOPT_REBOOT_TO_LOADER]          = "Return to emulator selection menu",
+    [MOPT_SAVE_RESTORE_STATE]        = "Save or load emulator state",
+    [MOPT_SCREENMODE]                = "Screen scaling & scanline mode",
+    [MOPT_SCANLINES]                 = "Toggle scanlines effect",
+    [MOPT_SCANLINE_TYPE]             = "Scanline type (CRT/LCD style)",
+    [MOPT_FPS_OVERLAY]               = "Show FPS (frame rate)",
+    [MOPT_AUDIO_ENABLE]              = "Toggle game audio",
+    [MOPT_FRAMESKIP]                 = "Skip frames for speed",
+    [MOPT_DISPLAY_MODE]              = "HDMI or DVI",
+    [MOPT_EXTERNAL_AUDIO]            = "Play audio over audio line out jack",
+    [MOPT_FONT_COLOR]                = "Menu text color (0-63)",
+    [MOPT_FONT_BACK_COLOR]           = "Menu background color (0-63)",
+    [MOPT_FRUITJAM_VUMETER]          = "RGB LEDs show audio level (VU)",
+    [MOPT_FRUITJAM_VOLUME_CONTROL]   = "Fruit Jam change volume (-63 to +23 dB)",
+    [MOPT_DMG_PALETTE]               = "Color Palette for mono / DMG games",
+    [MOPT_BORDER_MODE]               = "Select border artwork",
+    [MOPT_RAPID_FIRE_ON_A]           = "Enable rapid fire for this button",
+    [MOPT_RAPID_FIRE_ON_B]           = "Enable rapid fire for this button",
+    [MOPT_AUTO_INSERT_FDS_DISK_A]    = "Insert disk at boot or stay in BIOS",
+    [MOPT_AUTO_SWAP_FDS_DISK]        = "Auto swap disk side when game asks",
+    [MOPT_FDS_DISK_SWAP]             = "Eject / insert FDS disk side",
+    [MOPT_OVERCLOCK]                 = "Run CPU at high clock (reboots to apply)",
+    [MOPT_ENTER_BOOTSEL_MODE]        = "Reboot to BOOTSEL mode for flashing",
 };
 
 extern const int8_t *g_settings_visibility; // Visibility configuration for options menu

--- a/settings.cpp
+++ b/settings.cpp
@@ -103,6 +103,7 @@ namespace FrensSettings
         printf("autoSwapFDS: %d\n", settings.flags.autoSwapFDS);
         printf("autoInsertDiskA: %d\n", settings.flags.autoInsertDiskA);
         printf("overclock: %d\n", settings.flags.overclock);
+        printf("useFM: %d\n", settings.flags.useFM);
         printf("\n");
     }
     void resetsettings(struct settings *settingsPtr)
@@ -133,6 +134,7 @@ namespace FrensSettings
         settings.flags.autoSwapFDS = 0;
         settings.flags.autoInsertDiskA = 1; // default: disk side A pre-inserted at boot
         settings.flags.overclock = 0; // default: run at FLASHPARAM_MIN_FREQ_KHZ
+        settings.flags.useFM = 0; // default: disable FM audio
         settings.flags.reserved = 0;  // clear spare bits
         snprintf(settings.currentDir, sizeof(settings.currentDir), "/roms/%s", emulatorstrings[static_cast<int>(emulatorType)]);
     }

--- a/settings.cpp
+++ b/settings.cpp
@@ -128,7 +128,7 @@ namespace FrensSettings
         settings.flags.autoInsertDiskA = 1; // default: disk side A pre-inserted at boot
         settings.flags.overclock = 0; // default: run at FLASHPARAM_MIN_FREQ_KHZ
         settings.flags.reserved = 0;  // clear spare bits
-        strcpy(settings.currentDir, "/");
+        snprintf(settings.currentDir, sizeof(settings.currentDir), "/roms/%s", emulatorstrings[static_cast<int>(emulatorType)]);
     }
 
     void savesettings()

--- a/settings.cpp
+++ b/settings.cpp
@@ -127,6 +127,7 @@ namespace FrensSettings
         settings.flags.autoSwapFDS = 0;
         settings.flags.autoInsertDiskA = 1; // default: disk side A pre-inserted at boot
         settings.flags.overclock = 0; // default: run at FLASHPARAM_MIN_FREQ_KHZ
+        settings.flags.reserved = 0;  // clear spare bits
         strcpy(settings.currentDir, "/");
     }
 

--- a/settings.cpp
+++ b/settings.cpp
@@ -7,7 +7,7 @@ struct settings settings;
 namespace FrensSettings
 {
     #define SETTINGSFILE "/settings_%s.dat" // File to store settings
-    static const char *emulatorstrings[7] = { "NES", "SMS", "GB", "MD", "MUL", "PCE", "O2E" };
+    static const char *emulatorstrings[8] = { "NES", "SMS", "GB", "MD", "MUL", "PCE", "O2E", "SNES" };
     static char settingsFileName[21] = {};
     static emulators emulatorTypeForSettings = emulators::MULTI;
     char *getSettingsFileName()
@@ -55,10 +55,16 @@ namespace FrensSettings
         }
         else if (strcasecmp(fileextension, ".gen") == 0 || strcasecmp(fileextension, ".md") == 0|| strcasecmp(fileextension, ".bin") == 0)
         {
-           
+
             if ( emulatorType == emulators::GENESIS ) return;
             emulatorType = emulators::GENESIS;
             g_settings_visibility = g_settings_visibility_md;
+        }
+        else if (strcasecmp(fileextension, ".smc") == 0 || strcasecmp(fileextension, ".sfc") == 0)
+        {
+            if ( emulatorType == emulators::SNES ) return;
+            emulatorType = emulators::SNES;
+            g_settings_visibility = g_settings_visibility_snes;
         }
         else
         {

--- a/settings.h
+++ b/settings.h
@@ -64,7 +64,8 @@ namespace FrensSettings
         GENESIS = 3,
         MULTI = 4,
         PCE = 5,
-        O2EM = 6
+        O2EM = 6,
+        SNES = 7
     } emulators;
     static emulators emulatorType = NES;
     void initSettings(emulators emu) ;
@@ -86,5 +87,6 @@ extern const int8_t g_settings_visibility_sms[];
 extern const int8_t g_settings_visibility_md[];
 extern const int8_t g_settings_visibility_pce[];
 extern const int8_t g_settings_visibility_o2em[];
+extern int8_t g_settings_visibility_snes[];
 extern const int8_t g_settings_visibility_main[];
 #endif

--- a/settings.h
+++ b/settings.h
@@ -43,8 +43,9 @@ struct settings
         uint32_t autoSwapFDS : 1;      // 1 = automatically swap FDS disk sides when loading a .fds file, 0 = do not auto swap (user must manually select "FDS Disk Swap" in settings menu to swap sides). Default to on, because it's less confusing for users if the correct disk side is automatically loaded.
         uint32_t autoInsertDiskA : 1;  // 1 = disk side A is pre-inserted at boot, 0 = disk starts ejected (user presses A to insert, allowing BIOS Mario/Luigi animation to play)
         uint32_t overclock : 1;        // 1 = boot/run at FLASHPARAM_MAX_FREQ_KHZ, 0 = FLASHPARAM_MIN_FREQ_KHZ
-        uint32_t reserved : 16;        // spare bits for future flags; reset to 0
-    } flags; // 16 bits used + 16 reserved = full 32-bit container
+        uint32_t useFM : 1;            // SMS-only: 1 = YM2413 FM sound on (RP2350 only); 0 = PSG only
+        uint32_t reserved : 15;        // spare bits for future flags; reset to 0
+    } flags; // 17 bits used + 15 reserved = full 32-bit container
 
 };
 namespace FrensSettings

--- a/settings.h
+++ b/settings.h
@@ -6,12 +6,12 @@
 
 
 extern struct settings settings;
-#define SETTINGS_VERSION 113
+#define SETTINGS_VERSION 114
 
 struct settings
 {
     unsigned short version = SETTINGS_VERSION; // version of settings structure
-   
+
     ScreenMode screenMode;
     short firstVisibleRowINDEX;
     short selectedRow;
@@ -22,25 +22,30 @@ struct settings
     char currentDir[FF_MAX_LFN];
     int8_t fruitjamVolumeLevel; // Volume level for Fruit Jam internal speaker in db
     uint8_t scanlineType;
+    // 32-bit bitfield container: keeps the bits packed into a single storage
+    // unit so adding new flags doesn't change layout per-bit. 16 bits used,
+    // 16 spare. Bumping SETTINGS_VERSION above invalidates older saved files
+    // whose layout used the 16-bit container.
     struct
     {
-        unsigned short useExtAudio : 1;      // 0 = use DVIAudio, 1 = use external Audio
-        unsigned short enableVUMeter : 1;    // 0 = disable VU meter, 1 = enable VU meter
-        unsigned short borderMode : 2;       // BorderMode enum (2 bits)
-        unsigned short dmgLCDPalette : 2;    // DMG LCD Palette (2 bits) 0=Green 1=Color 2=B&W
-        unsigned short audioEnabled : 1;     // 1 = audio on, 0 = audio muted
-        unsigned short displayFrameRate : 1; // 1 = show FPS overlay, 0 = do not show
-        unsigned short frameSkip : 1;        // 1 = enable frame skipping, 0 = disable frame skipping
-        unsigned short scanlineOn : 1;        // 1 = scanlines on, 0 = scanlines off
-       // unsigned short fruitJamEnableInternalSpeaker : 1; // 1 = enable Fruit Jam internal speaker, 0 = disable
-        unsigned short rapidFireOnA : 1;      // 1 = rapid fire on A button, 0 = off
-        unsigned short rapidFireOnB : 1;      // 1 = rapid fire on B button, 0 = off
-        unsigned short useDVIModeForHDMI : 1;      // 1 = use DVI mode for HDMI output (lower latency, but no audio), 0 = use HDMI mode (required for audio, but slightly higher latency)
-        unsigned short autoSwapFDS : 1;      // 1 = automatically swap FDS disk sides when loading a .fds file, 0 = do not auto swap (user must manually select "FDS Disk Swap" in settings menu to swap sides). Default to on, because it's less confusing for users if the correct disk side is automatically loaded.
-        unsigned short autoInsertDiskA : 1;  // 1 = disk side A is pre-inserted at boot, 0 = disk starts ejected (user presses A to insert, allowing BIOS Mario/Luigi animation to play)
-        unsigned short overclock : 1;        // 1 = boot/run at FLASHPARAM_MAX_FREQ_KHZ, 0 = FLASHPARAM_MIN_FREQ_KHZ
-    } flags; // Total 16 bits
-   
+        uint32_t useExtAudio : 1;      // 0 = use DVIAudio, 1 = use external Audio
+        uint32_t enableVUMeter : 1;    // 0 = disable VU meter, 1 = enable VU meter
+        uint32_t borderMode : 2;       // BorderMode enum (2 bits)
+        uint32_t dmgLCDPalette : 2;    // DMG LCD Palette (2 bits) 0=Green 1=Color 2=B&W
+        uint32_t audioEnabled : 1;     // 1 = audio on, 0 = audio muted
+        uint32_t displayFrameRate : 1; // 1 = show FPS overlay, 0 = do not show
+        uint32_t frameSkip : 1;        // 1 = enable frame skipping, 0 = disable frame skipping
+        uint32_t scanlineOn : 1;       // 1 = scanlines on, 0 = scanlines off
+       // uint32_t fruitJamEnableInternalSpeaker : 1; // 1 = enable Fruit Jam internal speaker, 0 = disable
+        uint32_t rapidFireOnA : 1;     // 1 = rapid fire on A button, 0 = off
+        uint32_t rapidFireOnB : 1;     // 1 = rapid fire on B button, 0 = off
+        uint32_t useDVIModeForHDMI : 1; // 1 = use DVI mode for HDMI output (lower latency, but no audio), 0 = use HDMI mode (required for audio, but slightly higher latency)
+        uint32_t autoSwapFDS : 1;      // 1 = automatically swap FDS disk sides when loading a .fds file, 0 = do not auto swap (user must manually select "FDS Disk Swap" in settings menu to swap sides). Default to on, because it's less confusing for users if the correct disk side is automatically loaded.
+        uint32_t autoInsertDiskA : 1;  // 1 = disk side A is pre-inserted at boot, 0 = disk starts ejected (user presses A to insert, allowing BIOS Mario/Luigi animation to play)
+        uint32_t overclock : 1;        // 1 = boot/run at FLASHPARAM_MAX_FREQ_KHZ, 0 = FLASHPARAM_MIN_FREQ_KHZ
+        uint32_t reserved : 16;        // spare bits for future flags; reset to 0
+    } flags; // 16 bits used + 16 reserved = full 32-bit container
+
 };
 namespace FrensSettings
 {

--- a/vumeter.cpp
+++ b/vumeter.cpp
@@ -100,8 +100,12 @@ void initializeNeoPixelStrip()
     // We use pio_claim_free_sm_and_add_program_for_gpio_range (for_gpio_range variant)
     // so we will get a PIO instance suitable for addressing gpios >= 32 if needed and supported by the hardware
     bool success = pio_claim_free_sm_and_add_program_for_gpio_range(&ws2812_program, &pio, &sm, &offset, LED_PIN, 1, true);
-    hard_assert(success);
-
+    //hard_assert(success);
+    if (! success)
+    {
+        printf("Failed to claim PIO and state machine for WS2812 program\n");
+        return;
+    }
     ws2812_program_init(pio, sm, offset, LED_PIN, 800000, IS_RGBW);
 
 #if (VU_METER_TOGGLE_PIN >= 0)


### PR DESCRIPTION
This pull request introduces several significant updates to support a new bootloader architecture, improve memory diagnostics, and enhance hardware compatibility for the RP2350-based boards. The changes include a new shared flash memory map, bootloader-emulator handshake mechanisms, extensive heap usage diagnostics, and various configuration improvements.

**Bootloader support and memory map:**
- Added a new `BootPartition.cmake` file which defines the shared flash memory layout for the resident bootloader and emulator application partitions. This ensures the bootloader and emulators are always linked to non-overlapping flash regions, preventing corruption and simplifying slot-based multi-emulator support.

**Bootloader-emulator communication:**
- Implemented handshake mechanisms between the bootloader and emulator using RP2040 watchdog scratch registers. This allows the emulator to detect if it was launched by the bootloader and to request a return to the bootloader, supporting robust menu and slot management.

**Memory diagnostics and heap management:**
- Introduced the `dumpHeapStats` function to log detailed SRAM and PSRAM heap usage at various initialization stages, aiding debugging and performance tuning. This function is now called throughout the emulator's initialization process to provide granular memory usage snapshots. [[1]](diffhunk://#diff-47e62d520f7eae50d3519dbc612bbebcb49fef07fc4079a79b177921ac064db8R913-R944) [[2]](diffhunk://#diff-47e62d520f7eae50d3519dbc612bbebcb49fef07fc4079a79b177921ac064db8R1585-R1600) [[3]](diffhunk://#diff-47e62d520f7eae50d3519dbc612bbebcb49fef07fc4079a79b177921ac064db8R1629-R1635) [[4]](diffhunk://#diff-47e62d520f7eae50d3519dbc612bbebcb49fef07fc4079a79b177921ac064db8R1660-R1687)

**Flash/ROM access and safety:**
- Updated the ROM file address calculation to always place the ROM one sector above the FlashParams, ensuring FlashParams are never erased when flashing a new ROM. Also, improved `storage_get_flash_capacity` to cache its result and marked it `__not_in_flash_func` for safety. [[1]](diffhunk://#diff-47e62d520f7eae50d3519dbc612bbebcb49fef07fc4079a79b177921ac064db8L185-R247) [[2]](diffhunk://#diff-47e62d520f7eae50d3519dbc612bbebcb49fef07fc4079a79b177921ac064db8L1519-R1612)

**Configuration and build system improvements:**
- Added new CMake and preprocessor definitions for bootloader builds (`BOOTLOADER_BUILD`), overclocking fixes, and board-specific settings, improving flexibility and hardware compatibility. Also, appended the shared board header directory and set the correct board type for the WaveShare RP2350-PiZero. [[1]](diffhunk://#diff-b3c802778928e7d76bb0858fff28c9239e6c7283515aaaa66f928405b3589326R43) [[2]](diffhunk://#diff-b3c802778928e7d76bb0858fff28c9239e6c7283515aaaa66f928405b3589326R271) [[3]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR44-R53) [[4]](diffhunk://#diff-5f5975e512c19f502d53f7be6bdadfa01cafa61f5514a26e7a13870fd871080bR81-R95)

**Most important changes:**

**Bootloader and Flash Layout**
- Added `BootPartition.cmake` to define and enforce a safe, shared flash memory map for the bootloader and emulator slots, with supporting CMake functions for correct linker script generation.

**Bootloader-Emulator Handshake**
- Implemented handshake functions in `FrensHelpers.cpp` using watchdog scratch registers to manage bootloader launch detection and return requests.

**Heap and Memory Diagnostics**
- Introduced `dumpHeapStats` and integrated it throughout `initAll` and other initialization routines to print detailed SRAM/PSRAM usage at key stages. [[1]](diffhunk://#diff-47e62d520f7eae50d3519dbc612bbebcb49fef07fc4079a79b177921ac064db8R913-R944) [[2]](diffhunk://#diff-47e62d520f7eae50d3519dbc612bbebcb49fef07fc4079a79b177921ac064db8R1585-R1600) [[3]](diffhunk://#diff-47e62d520f7eae50d3519dbc612bbebcb49fef07fc4079a79b177921ac064db8R1629-R1635) [[4]](diffhunk://#diff-47e62d520f7eae50d3519dbc612bbebcb49fef07fc4079a79b177921ac064db8R1660-R1687)

**ROM and Flash Management**
- Changed ROM file placement to always be above FlashParams, protecting configuration data from accidental erasure. Improved flash capacity detection logic for safety and performance. [[1]](diffhunk://#diff-47e62d520f7eae50d3519dbc612bbebcb49fef07fc4079a79b177921ac064db8L185-R247) [[2]](diffhunk://#diff-47e62d520f7eae50d3519dbc612bbebcb49fef07fc4079a79b177921ac064db8L1519-R1612)

**Build System and Configurations**
- Enhanced CMake and preprocessor configuration for board support, bootloader builds, and overclocking fixes, including new defines and board header path management. [[1]](diffhunk://#diff-b3c802778928e7d76bb0858fff28c9239e6c7283515aaaa66f928405b3589326R43) [[2]](diffhunk://#diff-b3c802778928e7d76bb0858fff28c9239e6c7283515aaaa66f928405b3589326R271) [[3]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR44-R53) [[4]](diffhunk://#diff-5f5975e512c19f502d53f7be6bdadfa01cafa61f5514a26e7a13870fd871080bR81-R95)

These changes collectively improve reliability, maintainability, and debugging capabilities for emulator and bootloader development on RP2350-based platforms.