### PR TITLE
Scale XIP flash divisor with clk_sys and improve overclock management

### DIFF
--- a/FlashParams.cpp
+++ b/FlashParams.cpp
@@ -1,9 +1,44 @@
 #include "FlashParams.h"
 #include <cstring>
 
+#define FLASHPARAM_MIN_FREQ_KHZ 252000 // NES, GB, SMS
+#define FLASHPARAM_MIN_VOLTAGE vreg_voltage::VREG_VOLTAGE_1_20
+
+// Genesis max settings
+#if !HSTX
+#define FLASHPARAM_MAX_FREQ_KHZ 324000 
+// Because of high overclock, RP2450-Pizero needs high voltage for stable image. 
+// THIS MAY OVERHEAT AND DAMAGE THE CPU, USE HEATSINK!!!
+#if HW_CONFIG == 7   
+// 1_90 2_00 : Unstable image during gameplay
+// 2_35 : Stable image during gameplay, but random reboots.
+#define FLASHPARAM_MAX_VOLTAGE vreg_voltage::VREG_VOLTAGE_2_50
+#else
+#define FLASHPARAM_MAX_VOLTAGE vreg_voltage::VREG_VOLTAGE_1_30
+#endif
+#else
+#define FLASHPARAM_MAX_FREQ_KHZ 378000 // May cause artifacts on some screens, 336000 seems stable 
+                                       // https://github.com/fhoedemakers/retroJam/issues/7
+#define FLASHPARAM_MAX_VOLTAGE vreg_voltage::VREG_VOLTAGE_1_60
+#endif
 // Helper functions to manage FlashParams in flash memory.
 namespace Frens
 {
+    static vreg_voltage _minVoltage = FLASHPARAM_MIN_VOLTAGE;
+    static vreg_voltage _maxVoltage = FLASHPARAM_MAX_VOLTAGE;
+    static uint32_t _minFreq = FLASHPARAM_MIN_FREQ_KHZ;
+    static uint32_t _maxFreq = FLASHPARAM_MAX_FREQ_KHZ;
+    
+    void setOverclockLimits(uint32_t minFreqKHz, uint32_t maxFreqKHz, vreg_voltage minVoltage, vreg_voltage maxVoltage)
+    {
+        _minFreq = minFreqKHz;
+        _maxFreq = maxFreqKHz;
+        _minVoltage = minVoltage;
+        _maxVoltage = maxVoltage;
+    }
+
+    uint32_t getMinFreqKHz() { return _minFreq; }
+    uint32_t getMaxFreqKHz() { return _maxFreq; }
 
     /// @brief Validate the given FlashParams structure.
     /// @param params
@@ -18,12 +53,12 @@ namespace Frens
         }
 
         // Check CPU frequency & voltage
-        if (params.cpuFreqKHz == FLASHPARAM_MIN_FREQ_KHZ && params.voltage == FLASHPARAM_MIN_VOLTAGE)
+        if (params.cpuFreqKHz == _minFreq && params.voltage == _minVoltage)
         {
             // printf("Valid FlashParams: min freq/voltage\n");
             return true;
         }
-        if (params.cpuFreqKHz == FLASHPARAM_MAX_FREQ_KHZ && params.voltage == FLASHPARAM_MAX_VOLTAGE)
+        if (params.cpuFreqKHz == _maxFreq && params.voltage == _maxVoltage)
         {
             // printf("Valid FlashParams: max freq/voltage\n");
             return true;
@@ -43,7 +78,7 @@ namespace Frens
     /// @param cpuFreqKHz The CPU frequency in KHz.
     /// @param voltage The voltage setting.
     /// @return true on success, false when invalid params are provided.
-    bool writeFlashParamsToFlash(uint32_t cpuFreqKHz, vreg_voltage voltage)
+    bool __not_in_flash_func(writeFlashParamsToFlash)(uint32_t cpuFreqKHz, vreg_voltage voltage)
     {
         FlashParams params;
         params.cpuFreqKHz = cpuFreqKHz;
@@ -82,4 +117,13 @@ namespace Frens
         return true;
     }
 
+    bool WriteMaxValuesToFlash()
+    {
+        return writeFlashParamsToFlash(_maxFreq, _maxVoltage);
+    }
+
+    bool WriteMinValuesToFlash()
+    {
+        return writeFlashParamsToFlash(_minFreq, _minVoltage);
+    }
 } // namespace Frens

--- a/FlashParams.cpp
+++ b/FlashParams.cpp
@@ -39,6 +39,8 @@ namespace Frens
 
     uint32_t getMinFreqKHz() { return _minFreq; }
     uint32_t getMaxFreqKHz() { return _maxFreq; }
+    vreg_voltage getMinVoltage() { return _minVoltage; }
+    vreg_voltage getMaxVoltage() { return _maxVoltage; }
 
     /// @brief Validate the given FlashParams structure.
     /// @param params

--- a/FlashParams.h
+++ b/FlashParams.h
@@ -3,29 +3,14 @@
 #include "hardware/flash.h"
 #include "hardware/watchdog.h"
 #include "pico/multicore.h"
-#define FLASHPARAM_ADDRESS (((uintptr_t)&__flash_binary_end + 0xFFF) & ~0xFFF)
-#define FLASHPARAM_MAGIC "FRENS01"
-#define FLASHPARAM_MIN_FREQ_KHZ 252000 // NES, GB, SMS
-#define FLASHPARAM_MIN_VOLTAGE vreg_voltage::VREG_VOLTAGE_1_20
 
-// Genesis max settings
-#if !HSTX
-#define FLASHPARAM_MAX_FREQ_KHZ 324000 
-// Because of high overclock, RP2450-Pizero needs high voltage for stable image. 
-// THIS MAY OVERHEAT AND DAMAGE THE CPU, USE HEATSINK!!!
-#if HW_CONFIG == 7   
-// 1_90 2_00 : Unstable image during gameplay
-// 2_35 : Stable image during gameplay, but random reboots.
-#define FLASHPARAM_MAX_VOLTAGE vreg_voltage::VREG_VOLTAGE_2_50
-#else
-#define FLASHPARAM_MAX_VOLTAGE vreg_voltage::VREG_VOLTAGE_1_30
-#endif
-#else
-#define FLASHPARAM_MAX_FREQ_KHZ 378000 // May cause artifacts on some screens, 336000 seems stable 
-                                       // https://github.com/fhoedemakers/retroJam/issues/7
-#define FLASHPARAM_MAX_VOLTAGE vreg_voltage::VREG_VOLTAGE_1_60
-#endif
+#define FLASHPARAM_MAGIC "FRENS01"
+#define FLASHPARAM_ADDRESS (((uintptr_t)&__flash_binary_end + 0xFFF) & ~0xFFF)
+
+
+
 namespace Frens {
+    
     
     typedef struct 
     {
@@ -37,5 +22,11 @@ namespace Frens {
     } FlashParams;
 
     bool validateFlashParams(const FlashParams &params);
-    bool writeFlashParamsToFlash(uint32_t cpuFreqKHz, vreg_voltage voltage);
-}
+    //bool writeFlashParamsToFlash(uint32_t cpuFreqKHz, vreg_voltage voltage);
+
+    void setOverclockLimits(uint32_t minFreqKHz, uint32_t maxFreqKHz, vreg_voltage minVoltage, vreg_voltage maxVoltage);
+    bool WriteMaxValuesToFlash();
+    bool WriteMinValuesToFlash();
+    uint32_t getMinFreqKHz() ;
+    uint32_t getMaxFreqKHz() ;
+} // namespace Frens

--- a/FlashParams.h
+++ b/FlashParams.h
@@ -29,4 +29,6 @@ namespace Frens {
     bool WriteMinValuesToFlash();
     uint32_t getMinFreqKHz() ;
     uint32_t getMaxFreqKHz() ;
+    vreg_voltage getMinVoltage() ;
+    vreg_voltage getMaxVoltage() ;
 } // namespace Frens

--- a/FrensHelpers.cpp
+++ b/FrensHelpers.cpp
@@ -1810,7 +1810,34 @@ uint __not_in_flash_func(storage_get_flash_capacity)()
              * system clock does not overdrive the flash. Without this, random faults or hard
              * crashes can occur when fetching code/data from XIP at these frequencies.
              */
-            qmi_hw->m[0].timing = 0x60007304; // 4x FLASH divisor
+            /*
+             * Frequency-aware divisor. The old fixed 0x60007304 hard-coded
+             * CLKDIV=4, so the flash clock tracked clk_sys: fine at 378 MHz
+             * (94.5 MHz flash) but 432/480/504 gave 108/120/126 MHz, past
+             * what the QSPI part will sample reliably — and XIP traffic
+             * peaks under emulator load, so that shows up as a hard fault
+             * seconds in rather than at boot.
+             *
+             * Pick the smallest divisor that keeps flash <= 94.5 MHz (the
+             * rate proven at 378 MHz), and scale RXDELAY so the read sample
+             * point stays at roughly the same absolute delay in ns (3 sys
+             * cycles @ 378 MHz = 7.9 ns). At 378 this reproduces the old
+             * constant exactly (div 4, rxdelay 3 -> 0x60007304), so nothing
+             * changes for existing builds; at 504 it gives div 6 (84 MHz
+             * flash) and rxdelay 4.
+             *
+             * Field layout (RP2350 QMI M0_TIMING): COOLDOWN[31:30]=1,
+             * PAGEBREAK[29:28]=2 (1024), MAX_SELECT[21:16]=0,
+             * MIN_DESELECT[15:11]=14, RXDELAY[10:8], CLKDIV[7:0].
+             */
+            const uint32_t max_flash_khz = 94500;
+            uint32_t flash_div = (cpuFreqKHz + max_flash_khz - 1) / max_flash_khz;
+            if (flash_div < 4)
+                flash_div = 4;
+            uint32_t rxdelay = (3 * cpuFreqKHz + 189000) / 378000; // 3 @378, 4 @504
+            if (rxdelay > 7)
+                rxdelay = 7; // RXDELAY is 3 bits
+            qmi_hw->m[0].timing = 0x60000000u | (14u << 11) | (rxdelay << 8) | flash_div;
         }
 
         sleep_ms(100);

--- a/menu.cpp
+++ b/menu.cpp
@@ -3512,12 +3512,25 @@ int showSettingsMenu(bool calledFromGame)
         // and never returns.
 #if HW_CONFIG != 7
         uint32_t liveKHz   = clock_get_hz(clk_sys) / 1000;
-        uint32_t targetKHz = (settings.flags.overclock || settings.flags.useFM) ? FLASHPARAM_MAX_FREQ_KHZ : FLASHPARAM_MIN_FREQ_KHZ;
-        vreg_voltage targetV = (settings.flags.overclock || settings.flags.useFM) ? FLASHPARAM_MAX_VOLTAGE : FLASHPARAM_MIN_VOLTAGE;
-        if (liveKHz != targetKHz && FrensSettings::getEmulatorType() != FrensSettings::emulators::SNES)
+        uint32_t targetKHz = (settings.flags.overclock || settings.flags.useFM) ? Frens::getMaxFreqKHz() : Frens::getMinFreqKHz();
+        //vreg_voltage targetV = (settings.flags.overclock || settings.flags.useFM) ? Frens::getMaxVoltage() : Frens::getMinVoltage();
+        if (liveKHz != targetKHz ) //&& FrensSettings::getEmulatorType() != FrensSettings::emulators::SNES)
         {
             showLoadingScreen((settings.flags.overclock || settings.flags.useFM) ? "Enabling overclock" : "Disabling overclock", 60);
-            Frens::writeFlashParamsToFlash(targetKHz, targetV);
+            if (liveKHz < targetKHz)
+            {
+                if (Frens::WriteMaxValuesToFlash() == false)
+                {
+                    printf("Failed to write max values to flash\n");
+                }
+            }
+            else
+            {
+                if (Frens::WriteMinValuesToFlash() == false)
+                {
+                    printf("Failed to write min values to flash\n");
+                }
+            }
         }
 #endif
     }
@@ -3669,7 +3682,7 @@ void menu(const char *title, char *errorMessage, bool isFatal, bool showSplash, 
 // clk_hstx from clk_sys at 378 MHz — running there would produce visible TMDS
 // artifacts. Skip the auto-switch in that case; the .sgx ROM still loads and
 // runs at the build's default 252 MHz (slower on the heavier titles but clean).
-#if (HSTX && SGX && CFG_TUH_RPI_PIO_USB)
+#if (HSTX && SGX && CFG_TUH_RPI_PIO_USB) 
         // Skip per-ROM auto-switch when user explicitly locked overclock on:
         // the system stays at FLASHPARAM_MAX_FREQ_KHZ for every ROM.
         if (!settings.flags.overclock && selectedRomOrFolder && entries[index].IsDirectory == false && oldIndex != index)
@@ -3677,25 +3690,25 @@ void menu(const char *title, char *errorMessage, bool isFatal, bool showSplash, 
             oldIndex = index;
             if ( strncasecmp(fileExt, ".sgx", 4) == 0)
             {
-                if (clockFreq != FLASHPARAM_MAX_FREQ_KHZ)
+                if (clockFreq != Frens::getMaxFreqKHz())
                 {
                     char message[40];
-                    snprintf(message, sizeof(message), "Setting clock to  %dMHZ for SGX", FLASHPARAM_MAX_FREQ_KHZ /1000);
+                    snprintf(message, sizeof(message), "Setting clock to  %dMHZ for SGX", Frens::getMaxFreqKHz() /1000);
                     showLoadingScreen(message, 60);
                     FrensSettings::savesettings(); // save current settings before changing clock
-                    if (Frens::writeFlashParamsToFlash(FLASHPARAM_MAX_FREQ_KHZ, FLASHPARAM_MAX_VOLTAGE) == false)
+                    if (Frens::WriteMaxValuesToFlash() == false)
                     {
                         printf("Failed to write flash params for high clock\n");
                     }
                 }
             } else {
-                if (clockFreq != FLASHPARAM_MIN_FREQ_KHZ)
+                if (clockFreq != Frens::getMinFreqKHz())
                 {
                     char message[40];
-                    snprintf(message, sizeof(message), "Setting clock to  %dMHZ", FLASHPARAM_MIN_FREQ_KHZ /1000);
+                    snprintf(message, sizeof(message), "Setting clock to  %dMHZ", Frens::getMinFreqKHz() /1000);
                     showLoadingScreen(message, 60);
                     FrensSettings::savesettings(); // save current settings before changing clock
-                    if (Frens::writeFlashParamsToFlash(FLASHPARAM_MIN_FREQ_KHZ, FLASHPARAM_MIN_VOLTAGE) == false)
+                    if (Frens::WriteMinValuesToFlash() == false)
                     {
                         printf("Failed to write flash params for low clock\n");
                     }
@@ -3720,13 +3733,13 @@ void menu(const char *title, char *errorMessage, bool isFatal, bool showSplash, 
             if (FrensSettings::getEmulatorType() == FrensSettings::emulators::GENESIS && !isWav)
             {
                 // Skip clock switch when user locked overclock on (stay at MAX).
-                if (!settings.flags.overclock && clockFreq != FLASHPARAM_MAX_FREQ_KHZ)
+                if (!settings.flags.overclock && clockFreq != Frens::getMaxFreqKHz())
                 {
                     char message[40];
-                    snprintf(message, sizeof(message), "Setting clock to  %dMHZ", FLASHPARAM_MAX_FREQ_KHZ /1000);
+                    snprintf(message, sizeof(message), "Setting clock to  %dMHZ", Frens::getMaxFreqKHz() /1000);
                     showLoadingScreen(message, 60);
                     FrensSettings::savesettings(); // save current settings before changing clock
-                    if (Frens::writeFlashParamsToFlash(FLASHPARAM_MAX_FREQ_KHZ, FLASHPARAM_MAX_VOLTAGE) == false)
+                    if (Frens::WriteMaxValuesToFlash() == false)
                     {
                         printf("Failed to write flash params for high clock\n");
                     }
@@ -3735,13 +3748,13 @@ void menu(const char *title, char *errorMessage, bool isFatal, bool showSplash, 
             else
             {
                 // Skip clock switch when user locked overclock on (stay at MAX).
-                if (!settings.flags.overclock && clockFreq != FLASHPARAM_MIN_FREQ_KHZ)
+                if (!settings.flags.overclock && clockFreq != Frens::getMinFreqKHz())
                 {
                     char message[40];
-                    snprintf(message, sizeof(message), "Setting clock to  %dMHZ", FLASHPARAM_MIN_FREQ_KHZ /1000);
+                    snprintf(message, sizeof(message), "Setting clock to  %dMHZ", Frens::getMinFreqKHz() /1000);
                     showLoadingScreen(message, 60);
                     FrensSettings::savesettings(); // save current settings before changing clock
-                    if (Frens::writeFlashParamsToFlash(FLASHPARAM_MIN_FREQ_KHZ, FLASHPARAM_MIN_VOLTAGE) == false)
+                    if (Frens::WriteMinValuesToFlash() == false)
                     {
                         printf("Failed to write flash params for low clock\n");
                     }
@@ -3762,14 +3775,14 @@ void menu(const char *title, char *errorMessage, bool isFatal, bool showSplash, 
 #if !HSTX
             if ((PAD1_Latch)&UP && (PAD1_Latch & SELECT))
             {
-                if (clockFreq == FLASHPARAM_MAX_FREQ_KHZ)
+                if (clockFreq == Frens::getMaxFreqKHz())
                 {
                     printf("Emergency reset to low clock speed requested\n");
                     // Emergency reset to default settings and clock speed
                     // This can be used to in case there is no display or unstable display because of high clock speed settings
                     FrensSettings::resetsettings();
                     FrensSettings::savesettings();
-                    Frens::writeFlashParamsToFlash(FLASHPARAM_MIN_FREQ_KHZ, FLASHPARAM_MIN_VOLTAGE);
+                    Frens::WriteMinValuesToFlash();
                 } else {
                     printf("Emergency reset requested, but already at low clock speed\n");
                 }

--- a/menu.cpp
+++ b/menu.cpp
@@ -952,6 +952,110 @@ static bool showDialogYesNo(const char *message)
         }
     }
 }
+
+// Warn before committing an overclock whose target clock exceeds this (kHz).
+static constexpr uint32_t OVERCLOCK_WARN_KHZ = 378000;
+
+// Format a vreg_voltage enum as "X.XX V". The enum values are contiguous from
+// VREG_VOLTAGE_0_85 upward, so index a millivolt table by the offset.
+static void formatVregVoltage(vreg_voltage v, char *buf, size_t n)
+{
+    static const uint16_t mv[] = {
+        850, 900, 950, 1000, 1050, 1100, 1150, 1200, 1250, 1300,   // 0.85 .. 1.30
+        1350, 1400, 1500, 1600, 1650, 1700, 1800, 1900, 2000,      // 1.35 .. 2.00
+        2350, 2500, 2650, 2800, 3000, 3150, 3300};                 // 2.35 .. 3.30
+    int idx = (int)v - (int)VREG_VOLTAGE_0_85;
+    if (idx >= 0 && idx < (int)(sizeof(mv) / sizeof(mv[0])))
+    {
+        unsigned m = mv[idx];
+        snprintf(buf, n, "%u.%02u V", m / 1000, (m % 1000) / 10);
+    }
+    else
+    {
+        snprintf(buf, n, "?.?? V");
+    }
+}
+
+// Fill a rectangular block of the character grid with a solid color (spaces).
+static void fillRect(int x, int y, int w, int h, int color)
+{
+    for (int r = 0; r < h; r++)
+    {
+        for (int c = 0; c < w; c++)
+        {
+            int col = x + c;
+            int rowIdx = y + r;
+            if (col < 0 || col >= SCREEN_COLS || rowIdx < 0 || rowIdx >= SCREEN_ROWS)
+                continue;
+            int idx = rowIdx * SCREEN_COLS + col;
+            screenBuffer[idx].charvalue = ' ';
+            screenBuffer[idx].fgcolor = color;
+            screenBuffer[idx].bgcolor = color;
+        }
+    }
+}
+
+// Full-screen warning shown before enabling an overclock that boots the CPU
+// above the safe default clock. The message sits inside a red box and shows the
+// target clock and voltage. Returns true if the user confirms (A: Continue),
+// false to back out (B: Undo). Modeled on showDialogYesNo.
+static bool showOverclockWarning(uint32_t targetMHz, vreg_voltage targetVoltage)
+{
+    char msg[SCREEN_COLS + 1];
+    char voltStr[10];
+    formatVregVoltage(targetVoltage, voltStr, sizeof(voltStr));
+
+    ClearScreen(settings.bgcolor);
+
+    // Red alert box with white text.
+    const int boxW = 33;
+    const int boxH = 9;
+    const int boxX = centerColClamped(boxW);
+    const int boxY = SCREEN_ROWS / 2 - boxH / 2 - 2;
+    fillRect(boxX, boxY, boxW, boxH, CRED);
+
+    int row = boxY + 1;
+    const char *title = "!! OVERCLOCK WARNING !!";
+    putText(centerColClamped(strlen(title)), row, title, CWHITE, CRED);
+    row += 2;
+    snprintf(msg, sizeof(msg), "Runs at %u MHz / %s.", (unsigned)targetMHz, voltStr);
+    putText(centerColClamped(strlen(msg)), row, msg, CWHITE, CRED);
+    row += 1;
+    const char *l2 = "This can cause serious wear";
+    putText(centerColClamped(strlen(l2)), row, l2, CWHITE, CRED);
+    row += 1;
+    const char *l3 = "and overheating of the board.";
+    putText(centerColClamped(strlen(l3)), row, l3, CWHITE, CRED);
+    row += 2;
+    const char *l4 = "Enable it at your own risk.";
+    putText(centerColClamped(strlen(l4)), row, l4, CWHITE, CRED);
+
+    // Button prompts below the box, in the normal menu colors.
+    getButtonLabels(buttonLabel1, buttonLabel2);
+    row = boxY + boxH + 1;
+    snprintf(msg, sizeof(msg), "%s:Continue", buttonLabel1);
+    putText(centerColClamped(strlen(msg)), row, msg, settings.fgcolor, settings.bgcolor);
+    row += 1;
+    snprintf(msg, sizeof(msg), "%s:Undo", buttonLabel2);
+    putText(centerColClamped(strlen(msg)), row, msg, settings.fgcolor, settings.bgcolor);
+
+    waitForNoButtonPress();
+    DWORD waitPad;
+    while (true)
+    {
+        drawAllLines(-1);
+        RomSelect_PadState(&waitPad);
+        Menu_LoadFrame();
+        if (waitPad & A)
+        {
+            return true;
+        }
+        else if (waitPad & B)
+        {
+            return false;
+        }
+    }
+}
 // --- Controller Test screen (Settings > Controller Test) -------------------
 // Shows a SNES-pad graphic that follows whichever input source was last
 // active, plus a status list of all sources. Reads the raw per-source globals
@@ -3497,6 +3601,19 @@ int showSettingsMenu(bool calledFromGame)
     }
     if (applySettings && (rval == 0 || rval == 5))
     {
+#if HW_CONFIG != 7
+        // Enabling overclock (OFF->ON) boots into a higher clock. If that target
+        // exceeds the safe default, warn first and let the user back out. Checked
+        // before the commit below, while settings still holds the old value.
+        if (working.flags.overclock && !settings.flags.overclock &&
+            Frens::getMaxFreqKHz() > OVERCLOCK_WARN_KHZ)
+        {
+            if (!showOverclockWarning(Frens::getMaxFreqKHz() / 1000, Frens::getMaxVoltage()))
+            {
+                working.flags.overclock = 0; // Undo: keep overclock OFF, no reboot
+            }
+        }
+#endif
         // Copy working settings into global settings and persist.
         // Preserve directory navigation fields that user did not edit here.
         working.firstVisibleRowINDEX = settings.firstVisibleRowINDEX;


### PR DESCRIPTION
This pull request refactors how CPU frequency and voltage limits are managed and applied throughout the codebase, improving flexibility and maintainability. It introduces getter and setter functions for overclock parameters, replaces hardcoded constants with these functions, and adds user warnings for potentially unsafe overclocking. The most important changes are grouped below:

**Refactoring Overclock Parameter Management:**

* Introduced static variables and getter/setter functions (`setOverclockLimits`, `getMinFreqKHz`, `getMaxFreqKHz`, `getMinVoltage`, `getMaxVoltage`) in `FlashParams.cpp` and updated `FlashParams.h` accordingly, replacing hardcoded frequency and voltage constants with function calls throughout the code. [[1]](diffhunk://#diff-071279e9b44cd0422a50c062ef77cd2abc81a48ac6ba7c0b9660084c9ed6af0aR4-R43) [[2]](diffhunk://#diff-adc27b57977415aa95902c9c166a301fdc2595da3accfe9cc3c82559e2c4aea6L6-R14) [[3]](diffhunk://#diff-adc27b57977415aa95902c9c166a301fdc2595da3accfe9cc3c82559e2c4aea6L40-R34)
* Added `WriteMaxValuesToFlash` and `WriteMinValuesToFlash` functions to encapsulate writing overclock parameters to flash, and updated all relevant call sites to use these instead of the previous direct function. [[1]](diffhunk://#diff-071279e9b44cd0422a50c062ef77cd2abc81a48ac6ba7c0b9660084c9ed6af0aR122-R130) [[2]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L3515-R3650) [[3]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L3680-R3828) [[4]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L3738-R3874) [[5]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L3765-R3902) [[6]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L3723-R3859)

**User Interface and Safety Improvements:**

* Added a full-screen warning dialog (`showOverclockWarning`) that appears before enabling an overclock above a safe threshold, informing users of potential risks and allowing them to cancel. [[1]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79R955-R1058) [[2]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79R3604-R3616)
* Updated the settings menu logic to show this warning when the user enables overclocking and the target clock exceeds the safe default.

**Validation and Consistency Updates:**

* Updated validation logic and menu code to use the new getter functions for frequency and voltage, ensuring consistent parameter usage across the codebase. [[1]](diffhunk://#diff-071279e9b44cd0422a50c062ef77cd2abc81a48ac6ba7c0b9660084c9ed6af0aL21-R63) [[2]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L3680-R3828) [[3]](diffhunk://#diff-09598131d2a95ea6e2d59325d4a32c79605b76ddf9601e464c10bdaf2b026a79L3738-R3874)

**Other Technical Improvements:**

* Updated the flash timing divisor logic in `FrensHelpers.cpp` to be frequency-aware, improving reliability at high clock speeds.
* Marked the `writeFlashParamsToFlash` function with `__not_in_flash_func` for correct placement in memory.

These changes make overclocking safer and the codebase more maintainable by centralizing parameter management and improving user feedback.