### PR TITLE
BootPartition: pass --platform rp2350 to picotool for relinked images

### DIFF
--- a/BootPartition.cmake
+++ b/BootPartition.cmake
@@ -102,6 +102,23 @@ function(_frens_relink_flash TARGET ORIGIN LENGTH)
     # 16 MB partition). FRENS_FLASH_TOTAL is the single source of truth here.
     target_compile_definitions(${TARGET} PRIVATE
         PICO_FLASH_SIZE_BYTES=${FRENS_FLASH_TOTAL})
+    # picotool >= 2.2.0 re-detects the chip from the ELF instead of trusting
+    # --family, and assumes RP2040 for images that don't start at 0x10000000.
+    # Our relinked images do, so tell it explicitly. Option doesn't exist
+    # before 2.2.0, so version-guard it.
+    if(PICO_PLATFORM MATCHES "rp2350")
+        find_program(_frens_picotool picotool)
+        if(_frens_picotool)
+            execute_process(COMMAND ${_frens_picotool} version --semantic
+                            OUTPUT_VARIABLE _frens_pt_ver
+                            OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
+            if(_frens_pt_ver VERSION_GREATER_EQUAL 2.2.0)
+                set_target_properties(${TARGET} PROPERTIES
+                    PICOTOOL_EXTRA_UF2_ARGS "--platform;rp2350")
+            endif()
+        endif()
+    endif()
+
 endfunction()
 
 # Link the bootloader into the reserved boot region at the start of flash.


### PR DESCRIPTION
picotool 2.2.0 changed how elf2uf2 picks the valid address ranges. Up to 2.1.1 they were derived from the --family value the SDK passes on the command line; from 2.2.0 they come from a chip model that picotool auto-detects from the ELF itself (get_access_model). When it finds no PICOBIN IMAGE_DEF block and the image does not start at 0x10000000, it falls back to assuming RP2040, whose SRAM ends at 0x20042000.

Images relinked by _frens_relink_flash() start at the app partition base, so they hit exactly that fallback. The RP2350 SCRATCH_X segment at 0x20080000 is then rejected and the build fails at link time with:

    ERROR: Memory segment 20080000->20080c00 is outside of valid address
    range for device

Set PICOTOOL_EXTRA_UF2_ARGS on the target so the SDK adds --platform rp2350 to "picotool uf2 convert", which overrides the guess. The SDK still appends --abs-block itself when PICO_RP2350_A2_SUPPORTED is set, and the resulting UF2 is unchanged - the check is validation only.

The option does not exist before picotool 2.2.0, so it is version-guarded to keep builds against 2.1.1 working.